### PR TITLE
remove volumes from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,3 @@ services:
       dockerfile: Dockerfile
     ports:
       - 3000:3000
-    volumes:
-      - ./pages:/app/pages
-      - ./styles:/app/styles


### PR DESCRIPTION
## This PR does the following:

- removes volumes from the docker-compose.yml file (reason being because running `docker-compose build` moves the /pages and /styles directory to the root, which would be fine if they didn't already exist in the /src directory)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- running `docker-compose build` and `docker-compose up` locally and hitting localhost:3000 works
- running `docker-compose build` and `docker-compose up` locally does not create a /pages or /styles directory at the root level

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
