### PR TITLE
add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.env
+.git
+.next
+node_modules
+npm-debug.log
+README.md


### PR DESCRIPTION
This shortens the time it takes to build a docker image by reducing the lengthy "transfering context" step. In particular, the node_modules directory gets large and is not needed for the docker build.