### PR TITLE
DR-2543/campaign hero number of digitized items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Created a campaign hero component and other child components for the featured item data. (DR-2464)
 
 ### Update
+
 - Update version of NYPL Reservoir to 2.0.1
 - Updated image in Hero Component to change on reload. (DR-2565)
+- Updated number in Hero Component to use a live number in Repo API. (DR-2543)
 
 ### Added
+
 - Added spider block script (DR-2518)
 - Created Dockerfile and docker-compose.yml files. (DR-2446)
 - Created Next.js 13 app using NYPL Reservoir and TS 4.9.5. (DR-2444)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-opti
 
 ## Tests
 
+To run tests, run
+
+```
+npm run test
+```
+
 ## Getting Started With Docker
 
 First, install ["Docker"](https://www.docker.com/) on your local machine.

--- a/src/components/hero/campaignHero.tsx
+++ b/src/components/hero/campaignHero.tsx
@@ -3,13 +3,15 @@ import { imageURL } from "../../utils/utils";
 import CampaignHeroSubText from "./campaignHeroSubText";
 import CampaignHeroHeading from "./campaignHeroHeading";
 
-const CampaignHero = ({ featuredItem }: any) => {
+const CampaignHero = ({ featuredItem, numberOfDigitizedItems }: any) => {
   return (
     <Hero
       backgroundImageSrc={imageURL(featuredItem.imageID)}
       backgroundColor="ui.bg.default"
       heroType="campaign"
-      heading={<CampaignHeroHeading />}
+      heading={
+        <CampaignHeroHeading numberOfDigitizedItems={numberOfDigitizedItems} />
+      }
       imageProps={{
         alt: featuredItem.title,
         src: imageURL(featuredItem.imageID),

--- a/src/components/hero/campaignHeroHeading.tsx
+++ b/src/components/hero/campaignHeroHeading.tsx
@@ -1,6 +1,7 @@
 import { Heading } from "@nypl/design-system-react-components";
 
-const CampaignHeroHeading = () => {
+const CampaignHeroHeading = ({ numberOfDigitizedItems }: any) => {
+  console.log("numberOfDigitizedItems", numberOfDigitizedItems);
   return (
     <Heading
       color="ui.typography.heading"
@@ -9,11 +10,13 @@ const CampaignHeroHeading = () => {
       size="heading2"
     >
       <>
-        Explore 863,848 items digitized from The New York Public Library&apos;s
-        collections.
+        Explore {numberOfDigitizedItems} items digitized from The New York
+        Public Library&apos;s collections.
       </>
     </Heading>
   );
 };
 
 export default CampaignHeroHeading;
+
+//863,848

--- a/src/components/hero/campaignHeroSubText.tsx
+++ b/src/components/hero/campaignHeroSubText.tsx
@@ -6,7 +6,7 @@ import {
 } from "@nypl/design-system-react-components";
 
 const CampaignHeroSubText = ({ featuredItem }: any) => {
-  console.log("featuredItem in CampaignHeroSubText is: ", featuredItem);
+  // console.log("featuredItem in CampaignHeroSubText is: ", featuredItem);
   return (
     <>
       {/* To Do: make the link color blue: */}

--- a/src/components/hero/campaignHeroSubText.tsx
+++ b/src/components/hero/campaignHeroSubText.tsx
@@ -35,7 +35,7 @@ const CampaignHeroSubText = ({ featuredItem }: any) => {
         </DSLink>
       </Text>
       <HorizontalRule />
-      <Text color="ui.typography.body" mb="0px" noOfLines={2}>
+      <Text color="ui.typography.body" mb="0px">
         Featured Image:{" "}
         <DSLink
           color="var(--nypl-colors-ui-link-primary) !important"

--- a/src/components/hero/campaignHeroSubText.tsx
+++ b/src/components/hero/campaignHeroSubText.tsx
@@ -35,7 +35,7 @@ const CampaignHeroSubText = ({ featuredItem }: any) => {
         </DSLink>
       </Text>
       <HorizontalRule />
-      <Text color="ui.typography.body" mb="0px">
+      <Text color="ui.typography.body" mb="0px" noOfLines={2}>
         Featured Image:{" "}
         <DSLink
           color="var(--nypl-colors-ui-link-primary) !important"

--- a/src/components/hero/campaignHeroSubText.tsx
+++ b/src/components/hero/campaignHeroSubText.tsx
@@ -3,6 +3,8 @@ import {
   HorizontalRule,
   Text,
   Spacer,
+  Box,
+  Tooltip,
 } from "@nypl/design-system-react-components";
 
 const CampaignHeroSubText = ({ featuredItem }: any) => {
@@ -35,25 +37,29 @@ const CampaignHeroSubText = ({ featuredItem }: any) => {
         </DSLink>
       </Text>
       <HorizontalRule />
-      <Text color="ui.typography.body" mb="0px" noOfLines={2}>
-        Featured Image:{" "}
-        <DSLink
-          color="var(--nypl-colors-ui-link-primary) !important"
-          __css={{
-            display: "inline !important",
-            _hover: {
-              color: "var(--nypl-colors-ui-link-secondary) !important",
-            },
-            _visited: {
-              color: "var(--nypl-colors-ui-link-tertiary) !important",
-            },
-          }}
-          href={featuredItem.href}
-        >
-          {" "}
-          {featuredItem.title}{" "}
-        </DSLink>
-      </Text>
+      <Tooltip content={featuredItem.title}>
+        <Box>
+          <Text color="ui.typography.body" mb="0px" noOfLines={2}>
+            Featured Image:{" "}
+            <DSLink
+              color="var(--nypl-colors-ui-link-primary) !important"
+              __css={{
+                display: "inline !important",
+                _hover: {
+                  color: "var(--nypl-colors-ui-link-secondary) !important",
+                },
+                _visited: {
+                  color: "var(--nypl-colors-ui-link-tertiary) !important",
+                },
+              }}
+              href={featuredItem.href}
+            >
+              {" "}
+              {featuredItem.title}{" "}
+            </DSLink>
+          </Text>
+        </Box>
+      </Tooltip>
     </>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
 import data from "@/data/lanes";
 import {
   getNumItems,
+  getNumDigitizedItems,
   featuredImageID,
   getAPIUri,
   apiCall,
@@ -17,7 +18,12 @@ export default function Home(props: any) {
       /**
        * @TODO: Correct spacing below hero/above swimlanes
        */
-      breakout={<CampaignHero featuredItem={props.featuredItem} />}
+      breakout={
+        <CampaignHero
+          featuredItem={props.featuredItem}
+          numberOfDigitizedItems={props.numberOfDigitizedItems}
+        />
+      }
       contentPrimary={<SwimLanes lanesWithNumItems={props.lanesWithNumItems} />}
       renderSkipNavigation={true}
     />
@@ -50,6 +56,8 @@ export async function getServerSideProps() {
   const imageID = featuredImageID();
   const apiUri = await getAPIUri("local_image_id", imageID);
   const dataFromUri = await apiCall(apiUri.apiUri);
+  const numDigitizedItems = await getNumDigitizedItems();
+  console.log("numDigitizedItems", numDigitizedItems);
   const featuredItemObject = {
     imageID: imageID,
     uuid: apiUri.uuid,
@@ -60,6 +68,7 @@ export async function getServerSideProps() {
     props: {
       lanesWithNumItems: updatedLanes,
       featuredItem: featuredItemObject,
+      numberOfDigitizedItems: numDigitizedItems,
     },
   };
 }

--- a/src/utils/utils.test.tsx
+++ b/src/utils/utils.test.tsx
@@ -152,3 +152,7 @@ describe.skip("apiCall()", () => {
 // if rotation is not a string
 // if rotation is not supplied
 // if rotation is a string & not default
+
+//// Example usage:
+// let numberWithCommas = addCommas(1234567);
+// console.log(numberWithCommas); // Output: "1,234,567"

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -30,6 +30,17 @@ export const imageURL = (
 };
 
 /**
+ * Returns the number of digitized items in repo api.
+ */
+
+export const getNumDigitizedItems = async () => {
+  const apiUrl = `${process.env.API_URL}/api/v2/items/total`;
+  const res = await apiCall(apiUrl);
+  return addCommas(res.count.$) || 0;
+  // return apiCall(apiUrl);
+};
+
+/**
  * Returns the total number of items in the collection.
  * @param {string} uuid - the collection ID
  */
@@ -78,6 +89,9 @@ export const apiCall = async (apiUrl: string) => {
     if (response.status === 200) {
       const data = await response.json();
       const responseData = data.nyplAPI.response;
+      // if (apiUrl.includes('api/v2/items/total')) {
+      //   console.log("responseData for api/v2/items/total", responseData)
+      // }
       return responseData;
     } else {
       return 0;
@@ -86,3 +100,18 @@ export const apiCall = async (apiUrl: string) => {
     return 0;
   }
 };
+
+function addCommas(number) {
+  // Convert the number to a string
+  let numberString = number.toString();
+
+  // Use a regular expression to add commas to the string
+  numberString = numberString.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+
+  // Return the formatted number
+  return numberString;
+}
+
+// Example usage:
+let numberWithCommas = addCommas(1234567);
+console.log(numberWithCommas); // Output: "1,234,567"

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -74,8 +74,9 @@ export const imageURL = (
 export const getNumDigitizedItems = async () => {
   const apiUrl = `${process.env.API_URL}/api/v2/items/total`;
   const res = await apiCall(apiUrl);
-  return addCommas(res.count.$) || 0;
-  // return apiCall(apiUrl);
+  const fallbackCount = 863848;
+  const totalItems = res.count.$ || fallbackCount;
+  return addCommas(totalItems);
 };
 
 /**
@@ -139,12 +140,6 @@ export const getItemDataFromImageID = async (imageID: string) => {
 };
 
 function addCommas(number) {
-  // Convert the number to a string
-  let numberString = number.toString();
-
-  // Use a regular expression to add commas to the string
-  numberString = numberString.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-
   // Return the formatted number
-  return numberString;
+  return Number(number).toLocaleString("en-US");
 }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-2543](https://jira.nypl.org/browse/DR-2543)

## This PR does the following:

- Display the total number of available digitized items on DC
- Should display within the hero title
- Use the same typography as the rest of the title
- Updates on a regular schedule (dev can suggest the best cadence and update this)

### To verify:
- Should include location restricted materials as well as the ones available anywhere

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
