### PR TITLE
DR-2741: Add meta and OG tags to head

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -28,6 +28,22 @@ export default function App({ Component, pageProps }: AppProps) {
         />
         <meta property="og:type" content="website" />
         <meta property="og:site_name" content="NYPL Digital Collections" />
+        <meta
+          name="twitter:url"
+          content="https://digitalcollections.nypl.org/"
+        />
+        <meta name="twitter:title" content="NYPL Digital Collections" />
+        <meta
+          name="twitter:description"
+          content="Explore hundreds of thousands of digital items from The New York Public Library."
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:image"
+          content="https://digitalcollections.nypl.org/featured_items/ps_mss_831.jpg"
+        />
+        <meta name="twitter:site" content="@nypl" />
+        <meta name="twitter:creator" content="@nypl" />
       </Head>
       <DSProvider>
         <Component {...pageProps} />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,6 +8,26 @@ export default function App({ Component, pageProps }: AppProps) {
     <>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>NYPL Digital Collections</title>
+        <meta
+          name="description"
+          content="NYPL's Digital Collections is a living database featuring prints, photographs, maps, manuscripts, video, and more unique research materials."
+        />
+        <meta
+          property="og:image"
+          content="https://digitalcollections.nypl.org/featured_items/ps_mss_831.jpg"
+        />
+        <meta property="og:title" content="NYPL Digital Collections" />
+        <meta
+          property="og:description"
+          content="Explore hundreds of thousands of digital items from The New York Public Library."
+        />
+        <meta
+          property="og:url"
+          content="https://digitalcollections.nypl.org/"
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="NYPL Digital Collections" />
       </Head>
       <DSProvider>
         <Component {...pageProps} />


### PR DESCRIPTION
## Ticket:

Fixes JIRA ticket [DR-2741](https://jira.nypl.org/browse/DR-2741).

## This PR does the following:

- Adds meta title and description tags
- Adds OG tags for sharing
- Adds Twitter tags for sharing

## How has this been tested?

Locally, [Vercel Open Graph preview](https://vercel.com/nypl/digital-collections/Cyb6K88Zbjg9sLwJRifAjyEsr6V9/og)

## Accessibility concerns or updates

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
