### PR TITLE
DR-2814: Adding api route caching and client side fetch call caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added feedback button and logic for form to submit to google spreadsheet (DR-2595)
 - Added newrelic agent (DR-2772)
 - Added canonical link (DR-2784)
+- Added caching to API routes for `/api/featuredItem ` and `/api/homepage` as well as from the client side (DR-2785)
 
 ## [0.1.0] 2024-01-08
 

--- a/src/components/hero/campaignHero.tsx
+++ b/src/components/hero/campaignHero.tsx
@@ -10,9 +10,7 @@ const CampaignHero = ({ imageID }) => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const response = await fetch(`/api/featuredItem?imageID=${imageID}`, {
-        cache: "force-cache",
-      });
+      const response = await fetch(`/api/featuredItem?imageID=${imageID}`);
       const responseData = await response.json();
       setData(responseData);
     };

--- a/src/components/hero/campaignHero.tsx
+++ b/src/components/hero/campaignHero.tsx
@@ -1,15 +1,18 @@
-import { Hero, Link as DSLink } from "@nypl/design-system-react-components";
+import { Hero } from "@nypl/design-system-react-components";
+import { useEffect, useState } from "react";
+
 import CampaignHeroSubText from "./campaignHeroSubText";
 import CampaignHeroHeading from "./campaignHeroHeading";
 import CampaignHeroLoading from "./campaignHeroLoading";
-import { useEffect, useState } from "react";
 
 const CampaignHero = ({ imageID }) => {
   const [data, setData] = useState<any>({});
 
   useEffect(() => {
     const fetchData = async () => {
-      const response = await fetch(`/api/featuredItem?imageID=${imageID}`);
+      const response = await fetch(`/api/featuredItem?imageID=${imageID}`, {
+        cache: "force-cache",
+      });
       const responseData = await response.json();
       setData(responseData);
     };

--- a/src/components/homePageMainContent/homePageMainContent.tsx
+++ b/src/components/homePageMainContent/homePageMainContent.tsx
@@ -1,7 +1,8 @@
 import React from "react";
+import { useEffect, useState } from "react";
+
 import FeaturedContentComponent from "../featuredContent/featuredContent";
 import SwimLanes from "../swimlanes/swimLanes";
-import { useEffect, useState } from "react";
 import SwimLanesLoading from "../swimlanes/swimLanesLoading";
 
 const HomePageMainContent = () => {
@@ -9,13 +10,14 @@ const HomePageMainContent = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const response = await fetch("/api/homepage");
+      const response = await fetch("/api/homepage", { cache: "force-cache" });
       const responseData = await response.json();
       setData(responseData);
     };
 
     fetchData();
   }, []);
+
   return data?.lanesWithNumItems ? (
     <>
       <SwimLanes lanesWithNumItems={[data.lanesWithNumItems[0]]} />

--- a/src/components/homePageMainContent/homePageMainContent.tsx
+++ b/src/components/homePageMainContent/homePageMainContent.tsx
@@ -10,7 +10,7 @@ const HomePageMainContent = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const response = await fetch("/api/homepage", { cache: "force-cache" });
+      const response = await fetch("/api/homepage");
       const responseData = await response.json();
       setData(responseData);
     };

--- a/src/pages/api/featuredItem.ts
+++ b/src/pages/api/featuredItem.ts
@@ -33,11 +33,15 @@ const featuredItemDataHandler = async (
       }`,
     };
 
+    // 24 hour cache
+    response.setHeader("Cache-Control", "s-maxage=86400");
+
     return response.status(200).json({
       featuredItem: featuredItemObject,
       numberOfDigitizedItems: numDigitizedItems,
     });
   }
 };
+
 export default featuredItemDataHandler;
 // http://localhost:3000/api/featuredItem

--- a/src/pages/api/homepage.ts
+++ b/src/pages/api/homepage.ts
@@ -31,12 +31,15 @@ const homepageHandler = async (
     });
     const randomNumber = Math.floor(Math.random() * 2);
 
+    // 24 hour cache
+    response.setHeader("Cache-Control", "s-maxage=86400");
+
     return response.status(200).json({
       randomNumber,
       lanesWithNumItems: updatedLanes,
     });
   }
 };
-export default homepageHandler;
 
+export default homepageHandler;
 // http://localhost:3000/api/homepage

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -122,6 +122,8 @@ export const apiCall = async (apiUrl: string) => {
   try {
     const startTime = new Date().getTime();
     const response = await fetch(apiUrl, {
+      // aggressively cache Repo API?
+      // cache: "force-cache",
       headers: {
         Authorization: `Token token=${apiKey}`,
       },


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-2814](https://jira.nypl.org/browse/DR-2814)

## This PR does the following:

- This adds caching for 24hours to the Next.js internal API routes for `/api/featuredItem` and `/api/homepage`.
- These two endpoints are hit by the client through fetch calls. I'm using the `{ cache: "force-cache" }` option which will always use the cache if available unless a hard refresh is made. This is based on the docs but I'm wondering if it is too aggresive. https://developer.mozilla.org/en-US/docs/Web/API/Request/cache
- The [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) is a browser API but node also supports it. I don't think it's right to aggressively cache the fetch call to Repo API but would it make sense to do so?

## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
