### PR TITLE
Read IIIF_URL setting from app config file instead of .env

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import featuredItemsData from "../data/featureditems.json";
+import appConfig from "../../appConfig";
 let featuredItemArray = [];
 
 /**
@@ -205,7 +206,6 @@ import {
   ADOBE_ANALYTICS_DC_PREFIX,
   BASE_URL,
 } from "../config/constants";
-import appConfig from "../../appConfig";
 
 /**
  * adobeAnalyticsParam

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -67,7 +67,9 @@ export const imageURL = (
   size = "!1600,1600",
   rotation = "0"
 ) => {
-  return `${process.env.IIIF_URL}/iiif/2/${imageId}/${region}/${size}/${rotation}/default.jpg`;
+  return `${
+    appConfig.IIIF_URL[appConfig.environment]
+  }/iiif/2/${imageId}/${region}/${size}/${rotation}/default.jpg`;
 };
 
 /**
@@ -203,6 +205,7 @@ import {
   ADOBE_ANALYTICS_DC_PREFIX,
   BASE_URL,
 } from "../config/constants";
+import appConfig from "../../appConfig";
 
 /**
  * adobeAnalyticsParam


### PR DESCRIPTION
## Ticket:

- None

## This PR does the following:

- Updates the `imageURL` of the utils file to grab the `IIIF_URL` setting from app config instead of `.env`, thus making use of the changes added in #85:
   <img width="1324" alt="Screenshot 2024-03-08 at 2 48 43 PM" src="https://github.com/NYPL/digital-collections/assets/4614468/d23d5d02-800c-4f02-b341-9efff0332361">

## How has this been tested?

- Vercel app now successfully displays images (whereas they were previously showing blank values):
   - **Before:**
      <img width="1175" alt="Screenshot 2024-03-08 at 2 24 39 PM" src="https://github.com/NYPL/digital-collections/assets/4614468/bad79668-d874-474e-bad7-9340b984a84e">
   - **After:** 
      <img width="1324" alt="Screenshot 2024-03-08 at 2 47 26 PM" src="https://github.com/NYPL/digital-collections/assets/4614468/02ff61fe-6725-4323-92e0-9ad7fc9d8c88">

## Accessibility concerns or updates
- None

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
