### PR TITLE
DR-2824: Repo API endpoint for uuids to item count response

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Repo api
-API_URL= https://api.repo.nypl.org
+API_URL=https://api.repo.nypl.org
 IIIF_URL=https://qa-iiif.nypl.org
 AUTH_TOKEN= # Get credentials from a teammate!
 API_DEBUG= # Controls verbosity of api related log output

--- a/src/components/hero/hero.test.tsx
+++ b/src/components/hero/hero.test.tsx
@@ -11,7 +11,7 @@ describe("Campaign Hero", () => {
       })
     ) as jest.Mock;
 
-    const { container } = render(<CampaignHero imageID="5273165" />);
+    render(<CampaignHero imageID="5273165" />);
 
     expect(screen.getByTestId("hero-skeleton-loader")).toBeTruthy();
   });

--- a/src/components/homePageMainContent/homePageMainContent.test.tsx
+++ b/src/components/homePageMainContent/homePageMainContent.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import HomePageMainContent from "./homePageMainContent";
+import { props as homepageData } from "../../../__tests__/data/homepageProps";
 
 describe("homePageMainContent", () => {
   it("renders the SkeletonLoader", () => {
@@ -10,11 +11,39 @@ describe("homePageMainContent", () => {
       })
     ) as jest.Mock;
 
-    const { container } = render(<HomePageMainContent />);
+    render(<HomePageMainContent />);
 
     expect(screen.getByTestId("swimlane-skeleton-loader-1")).toBeTruthy();
     expect(screen.getByTestId("swimlane-skeleton-loader-2")).toBeTruthy();
     expect(screen.getByTestId("swimlane-skeleton-loader-3")).toBeTruthy();
     expect(screen.getByTestId("swimlane-skeleton-loader-4")).toBeTruthy();
+  });
+
+  it("renders the Campaign Hero", async () => {
+    (global as any).fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            randomNumber: 1,
+            lanesWithNumItems: homepageData.lanesWithNumItems,
+          }),
+      })
+    ) as jest.Mock;
+
+    render(<HomePageMainContent />);
+    await waitFor(() => {
+      const firstrow = screen.getByTestId("test-collections-1");
+      expect(
+        within(firstrow).getByText("Posada Collection")
+      ).toBeInTheDocument();
+      expect(within(firstrow).getByText("34 items")).toBeInTheDocument();
+
+      const secondrow = screen.getByTestId("test-collections-2");
+      expect(
+        within(secondrow).getByText("Friedman-Abeles photographs")
+      ).toBeInTheDocument();
+      expect(within(secondrow).getByText("35 items")).toBeInTheDocument();
+    });
   });
 });

--- a/src/utils/utils.test.tsx
+++ b/src/utils/utils.test.tsx
@@ -1,11 +1,13 @@
-import { getAPIUri, apiCall } from "@/utils/utils";
-
-describe.skip("getAPIUri()", () => {
-  it("should not be undefined", async () => {
-    const apiUriData = await getAPIUri("local_image_id", "105180");
-    expect(apiUriData.apiUri).toBeDefined();
-  });
-});
+import {
+  adobeAnalyticsRouteToPageName,
+  apiCall,
+  apiPOSTCall,
+  getItemsCountFromUUIDs,
+} from "../utils/utils";
+import {
+  ADOBE_ANALYTICS_DC_PREFIX,
+  ADOBE_ANALYTICS_PAGE_NAMES,
+} from "../config/constants";
 
 describe.skip("apiCall()", () => {
   it("should not return undefined", async () => {
@@ -19,6 +21,30 @@ describe.skip("apiCall()", () => {
         "http://api.repo.nypl.org/api/v2/mods/6265a5c0-c5ef-012f-687c-58d385a7bc34"
       )
     ).toBeDefined();
+  });
+});
+
+describe.skip("apiPOSTCall()", () => {
+  it("should not return undefined", async () => {
+    expect(
+      await apiPOSTCall(
+        "https://api.repo.nypl.org/api/v2/items/local_image_id/105180",
+        { uuid: ["uuid1", "uuid2"] }
+      )
+    ).toBeDefined();
+    expect(
+      await apiPOSTCall(
+        "http://api.repo.nypl.org/api/v2/mods/6265a5c0-c5ef-012f-687c-58d385a7bc34",
+        { uuid: ["uuid1", "uuid2"] }
+      )
+    ).toBeDefined();
+  });
+});
+
+describe.skip("getItemsCountFromUUIDs()", () => {
+  it("should not return undefined", async () => {
+    const data = ["uuid1", "uuid2"];
+    expect(await getItemsCountFromUUIDs(data)).toBeDefined();
   });
 });
 
@@ -60,12 +86,6 @@ describe.skip("apiCall()", () => {
 //// Example usage:
 // let numberWithCommas = addCommas(1234567);
 // console.log(numberWithCommas); // Output: "1,234,567"
-
-import { adobeAnalyticsRouteToPageName } from "../utils/utils";
-import {
-  ADOBE_ANALYTICS_DC_PREFIX,
-  ADOBE_ANALYTICS_PAGE_NAMES,
-} from "../config/constants";
 
 describe("appUtils", () => {
   describe("adobeAnalyticsRouteToPageName", () => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -36,16 +36,31 @@ export const getNumDigitizedItems = async () => {
 };
 
 /**
- * Returns the total number of items in the collection.
- * @param {string} uuid - the collection ID
+ * Returns a map of uuids to its item count.
  */
+export const getItemsCountFromUUIDs = async (uuids: string[]) => {
+  const apiUrl = `${process.env.API_URL}/api/v2/items/counts`;
+  const { counts } = await apiPOSTCall(apiUrl, { uuids });
 
-export const getNumItems = async (uuid: string) => {
-  const apiUrl = `${process.env.API_URL}/api/v2/collections/${uuid}/items`;
-  // console.log(`getNumItems: About to fetch ${apiUrl}`);
-  // console.log(`getNumItems calls apiCall function internally`);
-  const res = await apiCall(apiUrl);
-  return res.numItems || 0;
+  if (!counts?.count?.length) {
+    return {};
+  }
+
+  // The response is an array of objects:
+  // [
+  //   { uuid: { $: 'uuid1' }, count_value: { $: 'count1' }}
+  // ]
+  // We want to convert it to an object:
+  // {
+  //   uuid1: count1
+  //
+  const uuidCounts = counts?.count || [];
+  const cleanCounts = uuidCounts.reduce((acc, count) => {
+    acc[count.uuid["$"]] = count.count_value["$"];
+    return acc;
+  }, {});
+
+  return cleanCounts ? cleanCounts : {};
 };
 
 /**
@@ -96,6 +111,33 @@ export const apiCall = async (
       // console.log(`apiCall: called ${apiUrl}`);
       // console.log(`Response time: ${new Date().getTime() - startTime}`);
       return data.nyplAPI.response;
+    } else {
+      return undefined;
+    }
+  } catch (error) {
+    return undefined;
+  }
+};
+
+/**
+ * Makes a POST request to Repo API.
+ */
+export const apiPOSTCall = async (apiUrl: string, postData: any) => {
+  const apiKey = process.env.AUTH_TOKEN;
+
+  try {
+    const response = await fetch(apiUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Token token=${apiKey}`,
+      },
+      body: JSON.stringify(postData),
+    });
+
+    if (response.status === 200) {
+      const data = await response.json();
+      return data?.nyplAPI?.response;
     } else {
       return undefined;
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -40,11 +40,13 @@ export const getNumDigitizedItems = async () => {
  */
 export const getItemsCountFromUUIDs = async (uuids: string[]) => {
   const apiUrl = `${process.env.API_URL}/api/v2/items/counts`;
-  const { counts } = await apiPOSTCall(apiUrl, { uuids });
+  const response = await apiPOSTCall(apiUrl, { uuids });
 
-  if (!counts?.count?.length) {
+  if (!response?.counts?.count?.length) {
     return {};
   }
+
+  const counts = response.counts;
 
   // The response is an array of objects:
   // [


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-2824](https://jira.nypl.org/browse/DR-2824)

## This PR does the following:

- This removes the code that queued up 28 API calls to Repo API for the item number count for each collection.
- The current behavior is to make an array of all the uuids and hit the new `/items/counts` Repo API endpoint to get all the item number count in one request.
- The relevant code has been updated.

## How has this been tested?

Locally with both QA and prod Repo API.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
