### PR TITLE
DR-2834: Explore further link hover

### DIFF
--- a/src/components/exploreFurther/exploreFurther.tsx
+++ b/src/components/exploreFurther/exploreFurther.tsx
@@ -74,6 +74,7 @@ const ExploreFurther = () => {
                 rel="noreferrer noopener"
                 sx={{
                   textDecoration: "none !important",
+                  _hover: { textDecoration: "underline 1px dotted !important" },
                 }}
               >
                 {item.title}


### PR DESCRIPTION
## Ticket:

Resolves JIRA ticket [DR-2834](https://jira.nypl.org/browse/DR-2834).

## This PR does the following:

- Adds hover underline to Explore further links
- **This requires some overriding of the Link styles (instead of just using the default card heading behavior, as seen in the swim lanes) because the links need to open in a new tab

## How has this been tested?

Locally

## Accessibility concerns or updates


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
