### PR TITLE
DR-2833: Remove extra link space

### DIFF
--- a/src/components/hero/campaignHeroSubText.tsx
+++ b/src/components/hero/campaignHeroSubText.tsx
@@ -37,7 +37,7 @@ const CampaignHeroSubText = ({ featuredItem }: any) => {
       <HorizontalRule />
       <Box>
         <Text color="ui.typography.body" mb="0px" noOfLines={2}>
-          Featured Image:
+          Featured Image:{" "}
           <DSLink
             color="var(--nypl-colors-ui-link-primary) !important"
             __css={{
@@ -51,7 +51,6 @@ const CampaignHeroSubText = ({ featuredItem }: any) => {
             }}
             href={featuredItem.href}
           >
-            {" "}
             {featuredItem.title}{" "}
           </DSLink>
         </Text>


### PR DESCRIPTION
## Ticket:

Resolves JIRA ticket [DR-2833](https://jira.nypl.org/browse/DR-2833)

## This PR does the following:
- Removes the extra space in the hero's image link

## How has this been tested?

Locally

## Accessibility concerns or updates


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
