### PR TITLE
DR 2915 puppeteer script for facelift homepage featured image

### DIFF
--- a/.github/workflows/swimlanes_test.yml
+++ b/.github/workflows/swimlanes_test.yml
@@ -15,6 +15,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Run Puppeteer script
+      - name: Run Puppeteer script for swimlanes images
         run: npm run homepageImageLoadingTestProd
 
+      - name: Run Puppeteer script for the featured image
+        run: npm run homepageFeaturedImageLoadingTestProd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added NewRelic client-side monitoring (DR-2893)
+- Added homepage featured image loading test script (DR-2915)
 
 ## [0.1.3] 2024-03-28
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "test:ci": "jest --ci --config=jest.config.ts",
     "prepare": "husky install",
     "homepageImageLoadingTestQa": "node test/homepageImageLoadingTest.js",
-    "homepageImageLoadingTestProd": "node test/homepageImageLoadingTest.js --prod"
+    "homepageImageLoadingTestProd": "node test/homepageImageLoadingTest.js --prod",
+    "homepageFeaturedImageLoadingTestQa": "node test/homepageFeaturedImageLoadingTest.js",
+    "homepageFeaturedImageLoadingTestProd": "node test/homepageFeaturedImageLoadingTest.js --prod"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/test/homepageFeaturedImageLoadingTest.js
+++ b/test/homepageFeaturedImageLoadingTest.js
@@ -1,0 +1,73 @@
+const puppeteer = require("puppeteer");
+
+function parseArgs(args) {
+  const parsedArgs = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith("--")) {
+      const keyValue = arg.split("=");
+      const key = keyValue[0].slice(2);
+      const value = keyValue.length > 1 ? keyValue[1] : true;
+      parsedArgs[key] = value;
+    }
+  }
+  return parsedArgs;
+}
+
+(async () => {
+  const args = process.argv.slice(2);
+  const parsedArgs = parseArgs(args);
+
+  const browser = await puppeteer.launch({ headless: true });
+  const page = await browser.newPage();
+
+  await page.setRequestInterception(true);
+
+  const loadedImageUrls = [];
+
+  // Intercept network requests
+  page.on("request", (request) => {
+    if (request.resourceType() === "image") {
+      console.log("Image request:", request.url());
+      loadedImageUrls.push(request.url());
+    }
+    request.continue();
+  });
+
+  let homepage = "https://qa-new-digitalcollections.nypl.org";
+
+  if (parsedArgs["prod"] === true) {
+    console.log("Condition is true");
+    homepage = "https://new-digitalcollections.nypl.org";
+  }
+
+  await page.goto(homepage);
+
+  const startTime = new Date();
+
+  const desiredImageUrls = loadedImageUrls.filter((url) =>
+    url.includes("900,900")
+  );
+
+  await page.waitForFunction(
+    (desiredImageUrls) => {
+      const images = document.querySelectorAll("img");
+      const loadedImageUrls = Array.from(images).map((img) => img.src);
+
+      return desiredImageUrls.every((url) => loadedImageUrls.includes(url));
+    },
+    {},
+    desiredImageUrls
+  );
+
+  const loadTime = new Date() - startTime;
+  console.log(
+    "Time taken for all desired images to appear:",
+    loadTime,
+    "milliseconds"
+  );
+
+  console.log("Loaded image URLs:", loadedImageUrls);
+
+  await browser.close();
+})();


### PR DESCRIPTION
## Ticket:

- JIRA ticket [Create featured image test and have it run with the swimlanes test](https://jira.nypl.org/browse/DR-2915)

## This PR does the following:

- Adds a test script to assert that the featured image loads on the homepage

## How has this been tested?

- Do `npm install`
- Make sure you are accessinated and can reach the facelift qa environment
- Run the test against qa with `npm run homepageFeaturedImageLoadingTestQa`. If it does not time out, that means it succeeded. It should print all images loaded and the time taken, and it should succeed as long as the featured image loads and can be found in the DOM. This simulates a single user loading the homepage one time.
- Run the test against production with `npm run homepageFeaturedImageLoadingTestProd`. The above still applies.

## Accessibility concerns or updates

- None

### Checklist:

- [ x ] All new and existing tests passed.
