### PR TITLE
DR 2921 Add a test for legacy dc homepage images

### DIFF
--- a/.github/workflows/legacy_swimlanes_test.yml
+++ b/.github/workflows/legacy_swimlanes_test.yml
@@ -1,0 +1,19 @@
+name: Run Legacy Swimlanes Test
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+
+jobs:
+  run_legacy_swimlanes_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Puppeteer script for legacy swimlanes images
+        run: npm run legacyHomepageImageLoadingTestProd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - temporarily remove feedback button (DR-2918)
 
+### Added
+
+- Added legacy homepage image loading test script (DR-2921)
+
 ## [0.1.4] 2024-04-11
 
 ### Added
@@ -21,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Next documentation to DCF readme (DR-2868)
 - Reenable underline hover state on 'Explore further' card titles (DR-2834)
 - Enable GitHub Actions to run homepage swimlanes test automatically (DR-2912)
-- Added selenium script (DR-2872)
 - Added homepage images loading test script (DR-2872)
 
 ### Updated

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "homepageImageLoadingTestQa": "node test/homepageImageLoadingTest.js",
     "homepageImageLoadingTestProd": "node test/homepageImageLoadingTest.js --prod",
     "homepageFeaturedImageLoadingTestQa": "node test/homepageFeaturedImageLoadingTest.js",
-    "homepageFeaturedImageLoadingTestProd": "node test/homepageFeaturedImageLoadingTest.js --prod"
+    "homepageFeaturedImageLoadingTestProd": "node test/homepageFeaturedImageLoadingTest.js --prod",
+    "legacyHomepageImageLoadingTestProd": "node test/legacyHomepageImageLoadingTest.js --prod"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/test/legacyHomepageImageLoadingTest.js
+++ b/test/legacyHomepageImageLoadingTest.js
@@ -47,24 +47,6 @@ function parseArgs(args) {
 
   const startTime = new Date();
 
-  // Scroll down the page to trigger image loading
-  //  await page.evaluate(async () => {
-  //    await new Promise((resolve, reject) => {
-  //      let totalHeight = 0;
-  //      const distance = 100;
-  //      const scrollInterval = setInterval(() => {
-  //        const scrollHeight = document.body.scrollHeight;
-  //        window.scrollBy(0, distance);
-  //        totalHeight += distance;
-  //
-  //        if (totalHeight >= scrollHeight) {
-  //          clearInterval(scrollInterval);
-  //          resolve();
-  //        }
-  //      }, 100);
-  //    });
-  //  });
-
   // Wait for all desired images to be present in the DOM
   await page.waitForFunction(() => {
     const desiredImageUrls = [

--- a/test/legacyHomepageImageLoadingTest.js
+++ b/test/legacyHomepageImageLoadingTest.js
@@ -1,0 +1,118 @@
+const puppeteer = require("puppeteer");
+
+function parseArgs(args) {
+  const parsedArgs = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith("--")) {
+      const keyValue = arg.split("=");
+      const key = keyValue[0].slice(2);
+      const value = keyValue.length > 1 ? keyValue[1] : true;
+      parsedArgs[key] = value;
+    }
+  }
+  return parsedArgs;
+}
+
+(async () => {
+  const args = process.argv.slice(2);
+  const parsedArgs = parseArgs(args);
+  //console.log('Parsed command line arguments:', parsedArgs);
+
+  const browser = await puppeteer.launch({ headless: true });
+  const page = await browser.newPage();
+
+  await page.setRequestInterception(true);
+
+  const loadedImageUrls = [];
+
+  // Intercept network requests
+  page.on("request", (request) => {
+    if (request.resourceType() === "image") {
+      // Log the URL of the image being requested
+      console.log("Image request:", request.url());
+      loadedImageUrls.push(request.url());
+    }
+    request.continue();
+  });
+
+  let homepage = "https://qa-digitalcollections.nypl.org";
+
+  if (parsedArgs["prod"] === true) {
+    console.log("Condition is true");
+    homepage = "https://digitalcollections.nypl.org";
+  }
+
+  await page.goto(homepage);
+
+  const startTime = new Date();
+
+  // Scroll down the page to trigger image loading
+  //  await page.evaluate(async () => {
+  //    await new Promise((resolve, reject) => {
+  //      let totalHeight = 0;
+  //      const distance = 100;
+  //      const scrollInterval = setInterval(() => {
+  //        const scrollHeight = document.body.scrollHeight;
+  //        window.scrollBy(0, distance);
+  //        totalHeight += distance;
+  //
+  //        if (totalHeight >= scrollHeight) {
+  //          clearInterval(scrollInterval);
+  //          resolve();
+  //        }
+  //      }, 100);
+  //    });
+  //  });
+
+  // Wait for all desired images to be present in the DOM
+  await page.waitForFunction(() => {
+    const desiredImageUrls = [
+      // Photography Collections
+      "https://images.nypl.org/index.php?id=5032198&t=r",
+      "https://images.nypl.org/index.php?id=5209999&t=r",
+      "https://images.nypl.org/index.php?id=5226203&t=r",
+      "https://images.nypl.org/index.php?id=1709433&t=r",
+      // Early American Manuscripts Project
+      "https://images.nypl.org/index.php?id=5234356&t=r",
+      "https://images.nypl.org/index.php?id=5246763&t=r",
+      "https://images.nypl.org/index.php?id=5221338&t=r",
+      "https://images.nypl.org/index.php?id=5247898&t=r",
+      // Public Domain Picks
+      "https://images.nypl.org/index.php?id=4001447&t=r",
+      "https://iiif-prod.nypl.org/index.php?id=5207703&t=r",
+      "https://images.nypl.org/index.php?id=58449605&t=r",
+      "https://images.nypl.org/index.php?id=5104173&t=r",
+      // Collections About New York City
+      "https://images.nypl.org/index.php?id=5652518&t=r",
+      "https://images.nypl.org/index.php?id=700001F&t=r",
+      "https://images.nypl.org/index.php?id=1509403&t=r",
+      "https://iiif-prod.nypl.org/index.php?id=57045713&t=r",
+      // Fashion Collections
+      "https://images.nypl.org/index.php?id=1948588&t=r",
+      "https://images.nypl.org/index.php?id=5231730&t=r",
+      "https://images.nypl.org/index.php?id=105956&t=r",
+      "https://images.nypl.org/index.php?id=1159593&t=r",
+      // Collections for Designers
+      "https://images.nypl.org/index.php?id=101739&t=r",
+      "https://images.nypl.org/index.php?id=96534&t=r",
+      "https://images.nypl.org/index.php?id=487624&t=r",
+      "https://images.nypl.org/index.php?id=1585122&t=r",
+    ];
+
+    const images = document.querySelectorAll("img");
+    const loadedImageUrls = Array.from(images).map((img) => img.src);
+    return desiredImageUrls.every((url) => loadedImageUrls.includes(url));
+  });
+
+  const loadTime = new Date() - startTime;
+  console.log(
+    "Time taken for all desired images to appear:",
+    loadTime,
+    "milliseconds"
+  );
+
+  console.log("Loaded image URLs:", loadedImageUrls);
+
+  await browser.close();
+})();


### PR DESCRIPTION
## Ticket:

- JIRA ticket [Run puppeteer script on legacy Digital Collections for images.nypl.org](https://jira.nypl.org/browse/DR-2921)

## This PR does the following:
- Added a puppeteer script to test the loading of the swimlanes images on the legacy digital collections homepage.
- Added a new GitHub Actions workflow to also make this script run every 10 minutes

## How has this been tested?

- Do `npm install`
- Do `npm run npm run legacyHomepageImageLoadingTestProd`
- The test should run and should (probably) succeed once the 24 images we expect to load have loaded.
- NB: We'll need to wait until the qa homepage is fixed to do anything with the qa site. That can come in a subsequent PR.

## Accessibility concerns or updates

- N/A

### Checklist:

- [ ] I have added relevant accessibility documentation for this pull request.
- [ x ] All new and existing tests passed.
