### PR TITLE
DR-2910: Link new About page to home page

### DIFF
--- a/src/components/navMenu/navMenu.test.tsx
+++ b/src/components/navMenu/navMenu.test.tsx
@@ -28,6 +28,6 @@ describe("Nav menu component", () => {
       "href",
       appConfig.DC_URL[appConfig.environment] + `/collections`
     );
-    //expect(getByLabelText("About")).toHaveAttribute("href", `/about`);
+    expect(getByLabelText("About")).toHaveAttribute("href", "/about");
   });
 });

--- a/src/data/dcNavLinks.ts
+++ b/src/data/dcNavLinks.ts
@@ -13,9 +13,8 @@ export const dcNavLinks = [
     href: `${DC_URL}/divisions`,
     text: "Divisions",
   },
-  // TO DO: make this link self-referential
   {
-    href: `${DC_URL}/about`,
+    href: "/about",
     text: "About",
   },
 ];


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-2910](https://jira.nypl.org/browse/DR-2910)

## This PR does the following:

- Points "About" link in nav menu to new About page

## How has this been tested?


## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
