### PR TITLE
DR-2937 Run swimlanes and featured images test 10 times in parallel during load test

### DIFF
--- a/.github/workflows/swimlanes_test.yml
+++ b/.github/workflows/swimlanes_test.yml
@@ -2,12 +2,14 @@ name: Run Swimlanes Test
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/2 * * * *'
 
 jobs:
-  run_swimlanes_test:
+  run_swimlanes_test_parallel:
+    strategy:
+      matrix:
+        index: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added legacy homepage image loading test script (DR-2921)
 
+### Updated
+
+- Run homepage images tests 10x in parallel (DR-2937)
+
 ## [0.1.4] 2024-04-11
 
 ### Added


### PR DESCRIPTION
## Ticket:

- JIRA ticket [Run swimlanes and featured images test 10 times in parallel during load test](https://jira.nypl.org/browse/DR-2937)

## This PR does the following:
- Makes the featured and swimlanes images scripts run every 2 minutes instead of every 10 minutes
- Makes the same scripts run 10x in parallel for each execution


## How has this been tested?

- Tests not possible until merging to main
- We should:
  - Merge during "off hours" and monitor the workflow behavior
  - Disable the workflow afterwards
  - Rework the workflow if the behavior isn't as described in the ticket. 
  - Enable the workflow shortly before the load test
  - Disable the workflow shortly after the load test

## Accessibility concerns or updates

- N/A

### Checklist:

- [ ] I have added relevant accessibility documentation for this pull request.
- [ x ] All new and existing tests passed.
