### PR TITLE
DR-2936: Point hero and header links to About page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added legacy homepage image loading test script (DR-2921)
+- Links updated to point to new About page (DR-2936)
 
 ## [0.1.4] 2024-04-11
 

--- a/src/components/hero/campaignHeroSubText.tsx
+++ b/src/components/hero/campaignHeroSubText.tsx
@@ -27,7 +27,7 @@ const CampaignHeroSubText = ({ featuredItem }: any) => {
               color: "var(--nypl-colors-ui-link-tertiary) !important",
             },
           }}
-          href="https://digitalcollections.nypl.org/about#nypl_harmful_content_statement"
+          href="/about#nypl_harmful_content_statement"
           aria-label="Learn more about harmful content"
           target="_blank"
         >

--- a/src/components/hero/campaignHeroSubText.tsx
+++ b/src/components/hero/campaignHeroSubText.tsx
@@ -29,7 +29,6 @@ const CampaignHeroSubText = ({ featuredItem }: any) => {
           }}
           href="/about#nypl_harmful_content_statement"
           aria-label="Learn more about harmful content"
-          target="_blank"
         >
           Learn more
         </DSLink>

--- a/src/components/publicDomainFilter/publicDomainFilter.tsx
+++ b/src/components/publicDomainFilter/publicDomainFilter.tsx
@@ -8,9 +8,7 @@ const PublicDomainFilter = ({ onCheckChange }: PublicDomainFilterProps) => {
   const text = (
     <>
       Search only public domain.{" "}
-      <Link href="https://digitalcollections.nypl.org/about">
-        What is public domain?
-      </Link>
+      <Link href="/about#public_domain">What is public domain?</Link>
     </>
   );
 

--- a/src/data/aboutPageElements.tsx
+++ b/src/data/aboutPageElements.tsx
@@ -119,6 +119,7 @@ const aboutData = [
       <Heading
         level="h2"
         size="heading4"
+        id="public_domain"
         text="Public Domain / no known U.S. copyright restrictions"
       />
     ),


### PR DESCRIPTION
## Ticket:

Resolves JIRA ticket [DR-2936](https://jira.nypl.org/browse/DR-2936)

## This PR does the following:

- Points "Learn more" link in hero to the harmful content section of About page
- Points "What is public domain?" link in header to the public domain/copyright section of About page

## How has this been tested?

Locally

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Anchor links point to the correct place on the page, but often the text they're pointing to is covered by the sticky header. This is expected and will be addressed in [this ticket](https://jira.nypl.org/browse/DR-2911), it is not considered a blocker to launch by Clare

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
