### PR TITLE
DR-2937 Run swimlanes and featured images test 10 times in parallel during load test v2

### DIFF
--- a/.github/workflows/swimlanes_test.yml
+++ b/.github/workflows/swimlanes_test.yml
@@ -1,8 +1,9 @@
 name: Run Swimlanes Test
 
 on:
+  workflow_dispatch:
   schedule:
-    - cron: '*/2 * * * *'
+    - cron: '*/5 * * * *'
 
 jobs:
   run_swimlanes_test_parallel:


### PR DESCRIPTION
## Ticket:

- JIRA ticket [Run swimlanes and featured images test 10 times in parallel during load test](https://jira.nypl.org/browse/DR-2937)

## This PR does the following:
- Makes the featured and swimlanes images scripts run every 5 minutes instead of every 2 minutes (5 minutes is the minimum allowed interval since 2019)
- Add the ability to trigger the workflow manually via the GitHub API


## How has this been tested?

- Tests not possible until merging to main
- We should:
  - Merge during "off hours" and monitor the workflow behavior
  - Disable the workflow afterwards
  - Rework the workflow if the behavior isn't as described in the ticket. 
  - Enable the workflow shortly before the load test
  - Disable the workflow shortly after the load test

## Accessibility concerns or updates

- N/A

### Checklist:

- [ ] I have added relevant accessibility documentation for this pull request.
- [ x ] All new and existing tests passed.
