### PR TITLE
DR-2937 remove cron from swim lanes test

### DIFF
--- a/.github/workflows/swimlanes_test.yml
+++ b/.github/workflows/swimlanes_test.yml
@@ -2,8 +2,6 @@ name: Run Swimlanes Test
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '*/5 * * * *'
 
 jobs:
   run_swimlanes_test_parallel:


### PR DESCRIPTION
## Ticket:

- JIRA ticket [Run swimlanes and featured images test 10 times in parallel during load test](https://jira.nypl.org/browse/DR-2937)

## This PR does the following:
- Removes the cron schedule from the swim lanes test workflow to allow for manual triggering only in preparation for tomorrow's load test (we already got a lot of good 10x data from today).

## How has this been tested?

- Tests not possible until merging to main

## Accessibility concerns or updates

- N/A

### Checklist:

- [ ] I have added relevant accessibility documentation for this pull request.
- [ x ] All new and existing tests passed.
