### PR TITLE
Hotfix/dr 2944 remove cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.6] 2024-04-30
+
+### Removed
+
+- removed caching for the featured item (DR-2944)
+
 ## [0.1.5] 2024-04-29
 
 ### Added
@@ -20,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Run homepage images tests 10x in parallel (DR-2937)
+- Updated Travis file to point to new AWS clusters (DR-2943)
 
 ## [0.1.4] 2024-04-11
 

--- a/src/pages/api/featuredItem.ts
+++ b/src/pages/api/featuredItem.ts
@@ -39,9 +39,6 @@ const featuredItemDataHandler = async (
       }`,
     };
 
-    // 24 hour cache
-    response.setHeader("Cache-Control", "s-maxage=86400");
-
     return response.status(200).json({
       featuredItem: featuredItemObject,
       numberOfDigitizedItems: numDigitizedItems,


### PR DESCRIPTION
## Ticket:

- JIRA ticket https://jira.nypl.org/browse/DR-2944

## This PR does the following:

- removes code that caches of the v2/items/featured?random=true repo api response and thus breaks the featured item in prod 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
