### PR TITLE
DR-2928 add cluster names to readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Updated
+- Add cluster names to readme (DR-2928)
 
 ## [0.1.6] 2024-04-30
 

--- a/README.md
+++ b/README.md
@@ -439,11 +439,11 @@ All pushes to this repo will be checked with `npm test` and `npm lint`.
 
 Our branches (in order of stability are):
 
-| Branch     | Environment | AWS Account    | Link To Application                                                                        |
-| :--------- | :---------- | :------------- | :----------------------------------------------------------------------------------------- |
-| main       | development |                | [localhost:3000](http://localhost:3000)                                                    |
-| qa         | qa          | nypl-dams-dev  | [https://qa-new-digitalcollections.nypl.org/](https://qa-new-digitalcollections.nypl.org/) |
-| production | production  | nypl-dams-prod | [https://new-digitalcollections.nypl.org/](https://new-digitalcollections.nypl.org/)       |
+| Branch     | Environment | AWS Account    | Cluster                   | Link To Application                                                                        |
+| :--------- | :---------- | :------------- | :------------------------ | :----------------------------------------------------------------------------------------- |
+| main       | development |                |                           | [localhost:3000](http://localhost:3000)                                                    |
+| qa         | qa          | nypl-dams-dev  | dc-frontend-qa            | [https://qa-new-digitalcollections.nypl.org/](https://qa-new-digitalcollections.nypl.org/) |
+| production | production  | nypl-dams-prod | new-digitalcollections    | [https://new-digitalcollections.nypl.org/](https://new-digitalcollections.nypl.org/)       |
 
 ## Contributing
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-2928](https://jira.nypl.org/browse/DR-2928))

## This PR does the following:

- Adds cluster names to the readme
