### PR TITLE
No ref/bug fixes

### DIFF
--- a/src/components/exploreFurther/exploreFurther.tsx
+++ b/src/components/exploreFurther/exploreFurther.tsx
@@ -73,6 +73,10 @@ const ExploreFurther = () => {
                 target="_blank"
                 rel="noreferrer noopener"
                 hasVisitedState
+                __css={{
+                  textDecoration: "none !important",
+                  _hover: { textDecoration: "underline 1px dotted !important" },
+                }}
               >
                 {item.title}
               </Link>

--- a/src/components/exploreFurther/exploreFurther.tsx
+++ b/src/components/exploreFurther/exploreFurther.tsx
@@ -72,7 +72,7 @@ const ExploreFurther = () => {
                 href={item.url}
                 target="_blank"
                 rel="noreferrer noopener"
-                hasVisitedState={true}
+                hasVisitedState
               >
                 {item.title}
               </Link>

--- a/src/components/exploreFurther/exploreFurther.tsx
+++ b/src/components/exploreFurther/exploreFurther.tsx
@@ -72,10 +72,7 @@ const ExploreFurther = () => {
                 href={item.url}
                 target="_blank"
                 rel="noreferrer noopener"
-                sx={{
-                  textDecoration: "none !important",
-                  _hover: { textDecoration: "underline 1px dotted !important" },
-                }}
+                hasVisitedState={true}
               >
                 {item.title}
               </Link>

--- a/src/components/featuredContent/featuredContent.test.tsx
+++ b/src/components/featuredContent/featuredContent.test.tsx
@@ -7,7 +7,7 @@ describe("Featured Content component renders with expected props", () => {
     const component = screen.getByTestId("featured-content-0");
     await waitFor(() => {
       expect(
-        within(component).getByText("Spotlight on the Public Domain")
+        within(component).getByText("Spotlight on the public domain")
       ).toBeInTheDocument();
       expect(within(component).getByRole("img")).toHaveAttribute(
         "src",
@@ -24,7 +24,7 @@ describe("Featured Content component renders with expected props", () => {
     const component = screen.getByTestId("featured-content-1");
     await waitFor(() => {
       expect(
-        within(component).getByText("Digital Collections Print Store")
+        within(component).getByText("Digital Collections print store")
       ).toBeInTheDocument();
       expect(within(component).getByRole("img")).toHaveAttribute(
         "src",

--- a/src/components/featuredContent/featuredContent.tsx
+++ b/src/components/featuredContent/featuredContent.tsx
@@ -10,7 +10,6 @@ import { FeaturedContentData } from "@/types/FeaturedContentData";
 
 const FeaturedContentComponent = ({ randomNumber }) => {
   const data: FeaturedContentData = featuredContentData[randomNumber];
-  // console.log()
   return (
     <FeaturedContent
       data-testid={`featured-content-${randomNumber}`}

--- a/src/components/featuredContent/featuredContent.tsx
+++ b/src/components/featuredContent/featuredContent.tsx
@@ -10,6 +10,7 @@ import { FeaturedContentData } from "@/types/FeaturedContentData";
 
 const FeaturedContentComponent = ({ randomNumber }) => {
   const data: FeaturedContentData = featuredContentData[randomNumber];
+  // console.log()
   return (
     <FeaturedContent
       data-testid={`featured-content-${randomNumber}`}

--- a/src/components/hero/campaignHero.tsx
+++ b/src/components/hero/campaignHero.tsx
@@ -23,7 +23,7 @@ const CampaignHero = () => {
         response = await fetch(`/api/featuredItem`);
         responseData = await response.json();
       } catch (e) {
-        console.log("error: ", e);
+        console.log("CampaignHero error: ", e);
         console.log("using fallback featured item");
         responseData = defaultFeaturedItemResponse;
       }

--- a/src/components/hero/campaignHero.tsx
+++ b/src/components/hero/campaignHero.tsx
@@ -17,13 +17,21 @@ const CampaignHero = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const response = await fetch(`/api/featuredItem`);
-      const responseData = await response.json();
+      let response;
+      let responseData: FeaturedItemData;
+      try {
+        response = await fetch(`/api/featuredItem`);
+        responseData = await response.json();
+      } catch (e) {
+        console.log("error: ", e);
+        console.log("using fallback featured item");
+        responseData = defaultFeaturedItemResponse;
+      }
       setData(responseData);
     };
 
     fetchData();
-  }, []);
+  }, [defaultFeaturedItemResponse]);
 
   const handleError = (e: any) => {
     console.log(e);

--- a/src/components/swimlanes/swimLanes.tsx
+++ b/src/components/swimlanes/swimLanes.tsx
@@ -35,7 +35,6 @@ const SwimLanes = ({ lanesWithNumItems }) => {
             color: "ui.blue",
             fontWeight: "500 !important",
             alignItems: "center",
-            // marginBottom: "1px",
             _hover: { textDecoration: "underline 1px dotted !important" },
           }}
         >

--- a/src/components/swimlanes/swimLanes.tsx
+++ b/src/components/swimlanes/swimLanes.tsx
@@ -30,9 +30,9 @@ const SwimLanes = ({ lanesWithNumItems }) => {
           href={`${DC_URL}/collections/lane/${lane.slug}`}
           aria-label={`See more ${lane.title.toLowerCase()}`}
           hasVisitedState={false}
-          sx={{
+          __css={{
             display: { sm: "none", md: "inline" },
-            color: "ui.blue",
+            color: "ui.primary.link",
             fontWeight: "500 !important",
             alignItems: "center",
             _hover: { textDecoration: "underline 1px dotted !important" },
@@ -82,6 +82,12 @@ const SwimLanes = ({ lanesWithNumItems }) => {
                   id={`item-count-${lane.slug}-${index}`}
                   size="subtitle2"
                   fontWeight="medium"
+                  __css={{
+                    display: "none",
+                    [`@media screen and (min-width: 600px)`]: {
+                      display: "inline",
+                    },
+                  }}
                 >
                   {" "}
                   {`${collection.numItems || 0} items`}{" "}
@@ -100,11 +106,13 @@ const SwimLanes = ({ lanesWithNumItems }) => {
         hasVisitedState={false}
         __css={{
           display: { sm: "flex", md: "none" },
-          fontWeight: "medium",
+          fontWeight: "regular",
           justifyContent: "flex-end",
           marginTop: "s",
-
           alignItems: "center", //idk why this doesn't work
+          "& svg": {
+            marginTop: "1px",
+          },
         }}
       >
         See more

--- a/src/components/swimlanes/swimLanes.tsx
+++ b/src/components/swimlanes/swimLanes.tsx
@@ -81,13 +81,7 @@ const SwimLanes = ({ lanesWithNumItems }) => {
                 <Text
                   id={`item-count-${lane.slug}-${index}`}
                   size="subtitle2"
-                  sx={{
-                    fontWeight: "400",
-                    display: "none",
-                    [`@media screen and (min-width: 600px)`]: {
-                      display: "inline",
-                    },
-                  }}
+                  fontWeight="medium"
                 >
                   {" "}
                   {`${collection.numItems || 0} items`}{" "}
@@ -104,19 +98,12 @@ const SwimLanes = ({ lanesWithNumItems }) => {
         aria-label={`See more ${lane.title.toLowerCase()}`}
         className="smlink"
         hasVisitedState={false}
-        sx={{
+        __css={{
           display: { sm: "flex", md: "none" },
-          fontWeight: "500",
+          fontWeight: "medium",
           justifyContent: "flex-end",
           marginTop: "s",
-          alignItems: "center",
-          "& svg": {
-            marginTop: "1px",
-          },
-          color: "ui.blue",
-          _hover: {
-            textDecoration: "underline 1px dotted !important",
-          },
+          alignItems: "center", //idk why this doesn't work
         }}
       >
         See more

--- a/src/components/swimlanes/swimLanes.tsx
+++ b/src/components/swimlanes/swimLanes.tsx
@@ -29,10 +29,14 @@ const SwimLanes = ({ lanesWithNumItems }) => {
           type="standalone"
           href={`${DC_URL}/collections/lane/${lane.slug}`}
           aria-label={`See more ${lane.title.toLowerCase()}`}
+          hasVisitedState={false}
           sx={{
             display: { sm: "none", md: "inline" },
-            fontWeight: "500",
+            color: "ui.blue",
+            fontWeight: "500 !important",
             alignItems: "center",
+            // marginBottom: "1px",
+            _hover: { textDecoration: "underline 1px dotted !important" },
           }}
         >
           See more
@@ -100,6 +104,7 @@ const SwimLanes = ({ lanesWithNumItems }) => {
         href={`${DC_URL}/collections/lane/${lane.slug}`}
         aria-label={`See more ${lane.title.toLowerCase()}`}
         className="smlink"
+        hasVisitedState={false}
         sx={{
           display: { sm: "flex", md: "none" },
           fontWeight: "500",
@@ -108,6 +113,10 @@ const SwimLanes = ({ lanesWithNumItems }) => {
           alignItems: "center",
           "& svg": {
             marginTop: "1px",
+          },
+          color: "ui.blue",
+          _hover: {
+            textDecoration: "underline 1px dotted !important",
           },
         }}
       >

--- a/src/components/swimlanes/swimLanes.tsx
+++ b/src/components/swimlanes/swimLanes.tsx
@@ -103,6 +103,7 @@ const SwimLanes = ({ lanesWithNumItems }) => {
           fontWeight: "medium",
           justifyContent: "flex-end",
           marginTop: "s",
+
           alignItems: "center", //idk why this doesn't work
         }}
       >

--- a/src/data/featuredContentData.ts
+++ b/src/data/featuredContentData.ts
@@ -2,7 +2,7 @@ import { FeaturedContentData } from "@/types/FeaturedContentData";
 
 const featuredContentData: FeaturedContentData[] = [
   {
-    heading: "Spotlight on the Public Domain",
+    heading: "Spotlight on the public domain",
     overline: "Featured",
     text: "The New York Public Library recently enhanced access to all public domain items in Digital Collections so that everyone has the freedom to enjoy and reuse these materials in almost limitless ways",
     link: "https://publicdomain.nypl.org",
@@ -13,7 +13,7 @@ const featuredContentData: FeaturedContentData[] = [
     imgAlt: "Public Domain banner",
   },
   {
-    heading: "Digital Collections Print Store",
+    heading: "Digital Collections print store",
     overline: "Featured",
     text: "Decorative prints for purchase: choose from archival prints, framed art, stretched canvas, vintage wood, and wall murals.",
     link: "https://nypl.artehouse.com/perl/home.pl",

--- a/src/pages/api/homepage.ts
+++ b/src/pages/api/homepage.ts
@@ -27,7 +27,7 @@ const homepageHandler = async (
     });
 
     // 24 hour cache
-    // response.setHeader("Cache-Control", "s-maxage=86400"); //removing bc the featured content is not
+    // response.setHeader("Cache-Control", "s-maxage=86400"); //removing bc the Featured Content does not change when we relead the page if we cache the data.
 
     return response.status(200).json({
       randomNumber,

--- a/src/pages/api/homepage.ts
+++ b/src/pages/api/homepage.ts
@@ -27,7 +27,7 @@ const homepageHandler = async (
     });
 
     // 24 hour cache
-    response.setHeader("Cache-Control", "s-maxage=86400");
+    // response.setHeader("Cache-Control", "s-maxage=86400"); //removing bc the featured content is not
 
     return response.status(200).json({
       randomNumber,


### PR DESCRIPTION
## Ticket:

- JIRA ticket [Fallback image for Featured Item](https://jira.nypl.org/browse/DR-2925)
- JIRA ticket [Update DS version on DC Facelift to v3.0](https://jira.nypl.org/browse/DR-2924)


## This PR does the following:
comparing https://digital-collections-git-release-018-nypl.vercel.app/  to https://new-digitalcollections.nypl.org/, this PR:
- updates the "see more" links in the swim lanes to be blue (instead of black) and display a dotted line (instead of a solid line).
- updates the links in the "Explore Further" card title to have a visited state after clicking.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
locally

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- 

## Other concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- the "see more" links - I am having issues adding some padding/a margin to the dotted line below the links on hover to match the style that exists on prod.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
