### PR TITLE
Spike: Layout/breadcrumbs in Pages router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "next": "13.4.19",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-router-dom": "^6.23.1",
         "request-ip": "^3.3.0",
         "ts-node": "10.9.1",
         "typescript": "4.9.5",
@@ -3311,6 +3312,14 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+      "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -11456,6 +11465,36 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
+      "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
+      "dependencies": {
+        "@remix-run/router": "1.16.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
+      "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
+      "dependencies": {
+        "@remix-run/router": "1.16.1",
+        "react-router": "6.23.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "next": "13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-router-dom": "^6.23.1",
     "request-ip": "^3.3.0",
     "ts-node": "10.9.1",
     "typescript": "4.9.5",

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -62,7 +62,7 @@ const Layout = ({
       ) : (
         <>
           <Breadcrumbs breadcrumbsData={breadcrumbs} />
-          <TemplateAppContainer contentPrimary={children} />
+          <TemplateAppContainer contentPrimary={children as JSX.Element} />
         </>
       )}
       <FeedbackBox

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -2,7 +2,6 @@ import {
   TemplateAppContainer,
   Breadcrumbs,
   DSProvider,
-  Heading,
   SkipNavigation,
   useFeedbackBox,
 } from "@nypl/design-system-react-components";

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -1,0 +1,80 @@
+import {
+  TemplateAppContainer,
+  Breadcrumbs,
+  DSProvider,
+  Heading,
+  SkipNavigation,
+  useFeedbackBox,
+} from "@nypl/design-system-react-components";
+import React from "react";
+import { type PropsWithChildren } from "react";
+import Header from "../header/header";
+import NotificationBanner from "../notificationBanner/notificationBanner";
+
+interface LayoutProps {
+  activePage: string;
+  breadcrumbs?: { text: string; url: string }[];
+}
+
+const Layout = ({
+  children,
+  activePage,
+  breadcrumbs,
+}: PropsWithChildren<LayoutProps>) => {
+  const [view, setView] = React.useState("form");
+  const { onOpen, isOpen, onClose, FeedbackBox } = useFeedbackBox();
+  const onSubmit = async (values) => {
+    try {
+      const response = await fetch("/api/feedback", {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(values),
+      });
+
+      if (response.ok) {
+        // ...
+        setView("confirmation");
+      } else {
+        setView("error");
+      }
+    } catch (error) {
+      // Reject the promise according to your application.
+      // And then call:
+      setView("error");
+    }
+  };
+
+  const onFormClose = () => {
+    if (isOpen) {
+      onClose();
+      setView("form");
+    }
+  };
+  return (
+    <DSProvider>
+      <SkipNavigation />
+      <NotificationBanner />
+      <Header />
+      {activePage === "home" || activePage === "about" ? (
+        children
+      ) : (
+        <>
+          <Breadcrumbs breadcrumbsData={breadcrumbs} />
+          <TemplateAppContainer contentPrimary={children} />
+        </>
+      )}
+      <FeedbackBox
+        showCategoryField
+        onSubmit={onSubmit}
+        onClose={onFormClose}
+        title="Feedback"
+        view={view}
+      />
+    </DSProvider>
+  );
+};
+
+export default Layout;

--- a/src/data/dcNavLinks.ts
+++ b/src/data/dcNavLinks.ts
@@ -6,11 +6,11 @@ export const dcNavLinks = [
     text: "Items",
   },
   {
-    href: `${DC_URL}/collections`,
+    href: `/collections`,
     text: "Collections",
   },
   {
-    href: `${DC_URL}/divisions`,
+    href: `/divisions`,
     text: "Divisions",
   },
   {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,6 @@
 // import '@/styles/globals.css'
 import type { AppProps } from "next/app";
 import Head from "next/head";
-import {
-  DSProvider,
-  useFeedbackBox,
-} from "@nypl/design-system-react-components";
 import React from "react";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
@@ -15,38 +11,6 @@ import { ADOBE_EMBED_URL, DC_URL } from "../config/constants";
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
-  const [view, setView] = React.useState("form");
-  const { onOpen, isOpen, onClose, FeedbackBox } = useFeedbackBox();
-  const onSubmit = async (values) => {
-    try {
-      const response = await fetch("/api/feedback", {
-        method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(values),
-      });
-
-      if (response.ok) {
-        // ...
-        setView("confirmation");
-      } else {
-        setView("error");
-      }
-    } catch (error) {
-      // Reject the promise according to your application.
-      // And then call:
-      setView("error");
-    }
-  };
-
-  const onFormClose = () => {
-    if (isOpen) {
-      onClose();
-      setView("form");
-    }
-  };
 
   // Track page view events to Adobe Analytics
   useEffect(() => {
@@ -123,16 +87,7 @@ export default function App({ Component, pageProps }: AppProps) {
         type="text/javascript"
         src={`/newrelic/` + appConfig.environment + `.js`}
       />
-      <DSProvider>
-        <Component {...pageProps} />
-        <FeedbackBox
-          showCategoryField
-          onSubmit={onSubmit}
-          onClose={onFormClose}
-          title="Feedback"
-          view={view}
-        />
-      </DSProvider>
+      <Component {...pageProps} />
     </>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import Script from "next/script";
 import { trackVirtualPageView } from "../utils/utils";
 import appConfig from "../../appConfig";
 import { ADOBE_EMBED_URL, DC_URL } from "../config/constants";
+import ContextProvider from "./breadcrumbsContext";
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
@@ -87,7 +88,9 @@ export default function App({ Component, pageProps }: AppProps) {
         type="text/javascript"
         src={`/newrelic/` + appConfig.environment + `.js`}
       />
-      <Component {...pageProps} />
+      <ContextProvider>
+        <Component {...pageProps} />
+      </ContextProvider>
     </>
   );
 }

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,8 +1,7 @@
-import { Box, SkipNavigation } from "@nypl/design-system-react-components";
-import Header from "@/components/header/header";
-import NotificationBanner from "@/components/notificationBanner/notificationBanner";
+import { Box } from "@nypl/design-system-react-components";
 import aboutPageElements from "@/data/aboutPageElements";
 import Head from "next/head";
+import Layout from "@/components/layout/layout";
 
 export default function About() {
   function createSection(heading: React.JSX.Element, body: React.JSX.Element) {
@@ -15,10 +14,7 @@ export default function About() {
   }
 
   return (
-    <>
-      <SkipNavigation />
-      <NotificationBanner />
-      <Header />
+    <Layout activePage="about">
       <Head>
         <title>About NYPL Digital Collections</title>
         <meta
@@ -41,6 +37,6 @@ export default function About() {
           createSection(section.heading, section.body)
         )}
       </Box>
-    </>
+    </Layout>
   );
 }

--- a/src/pages/breadcrumbsContext.tsx
+++ b/src/pages/breadcrumbsContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useCallback, useMemo, useReducer } from "react";
+
+export const breadcrumbsContext = createContext(null);
+
+const actionTypes = {
+  SET_BREADCRUMBS: "SET_BREADCRUMBS",
+};
+
+const reducer = (breadcrumbs, action) => {
+  switch (action.type) {
+    case "SET_BREADCRUMBS":
+      return [...breadcrumbs, action.newCrumb];
+    default:
+      return breadcrumbs;
+  }
+};
+
+function ContextProvider({ children }) {
+  const [breadcrumbs, dispatch] = useReducer(reducer, [
+    { text: "Home", url: "/" },
+  ]);
+
+  const setBreadcrumbs = useCallback((newCrumb) => {
+    dispatch({
+      type: actionTypes.SET_BREADCRUMBS,
+      newCrumb,
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({ breadcrumbs, setBreadcrumbs }),
+    [breadcrumbs, setBreadcrumbs]
+  );
+
+  return (
+    <breadcrumbsContext.Provider value={value}>
+      {children}
+    </breadcrumbsContext.Provider>
+  );
+}
+
+export default ContextProvider;

--- a/src/pages/breadcrumbsContext.tsx
+++ b/src/pages/breadcrumbsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useMemo, useReducer } from "react";
+import { createContext, useReducer } from "react";
 
 export const breadcrumbsContext = createContext(null);
 
@@ -20,20 +20,15 @@ function ContextProvider({ children }) {
     { text: "Home", url: "/" },
   ]);
 
-  const setBreadcrumbs = useCallback((newCrumb) => {
+  const setBreadcrumbs = (newCrumb) => {
     dispatch({
       type: actionTypes.SET_BREADCRUMBS,
       newCrumb,
     });
-  }, []);
-
-  const value = useMemo(
-    () => ({ breadcrumbs, setBreadcrumbs }),
-    [breadcrumbs, setBreadcrumbs]
-  );
+  };
 
   return (
-    <breadcrumbsContext.Provider value={value}>
+    <breadcrumbsContext.Provider value={{ breadcrumbs, setBreadcrumbs }}>
       {children}
     </breadcrumbsContext.Provider>
   );

--- a/src/pages/collections/[id].tsx
+++ b/src/pages/collections/[id].tsx
@@ -1,24 +1,36 @@
+import { useContext, useEffect } from "react";
+import { useRouter } from "next/router";
 import Layout from "@/components/layout/layout";
-
 import { Heading } from "@nypl/design-system-react-components";
-import Head from "next/head";
+import { breadcrumbsContext } from "../breadcrumbsContext";
 
-export default function Collection() {
+const Collection = () => {
+  const { breadcrumbs, setBreadcrumbs } = useContext(breadcrumbsContext);
+  useEffect(() => {
+    setBreadcrumbs({ text: "A Collection", url: "/collections/collection" });
+  }, []);
   return (
-    <>
-      <Head>
-        <title>Collection</title>
-        <meta property="og:title" content="All Collections" key="title" />
-      </Head>
-      <Layout
-        activePage="collection"
-        breadcrumbs={[
-          { text: "Collections", url: "/collections" },
-          { text: "I am one Collection", url: "/collections/hello" },
-        ]}
-      >
-        <Heading> I am one Collection </Heading>
-      </Layout>
-    </>
+    <Layout activePage="collection" breadcrumbs={breadcrumbs}>
+      <Heading>
+        <>Collection</>
+      </Heading>
+    </Layout>
   );
-}
+};
+
+export const getServerSideProps = async () => {
+  //const response = await fetch(`/api/featuredItem`);
+  //const responseData = await response.json();
+  let breadcrumbs = [
+    { text: "Home", url: "/" },
+    { text: "Collections", url: "/collcetions" },
+    { text: "A Collection", url: "/collections/collection" },
+  ];
+  return {
+    props: {
+      breadcrumbs,
+    },
+  };
+};
+
+export default Collection;

--- a/src/pages/collections/[id].tsx
+++ b/src/pages/collections/[id].tsx
@@ -1,0 +1,24 @@
+import Layout from "@/components/layout/layout";
+
+import { Heading } from "@nypl/design-system-react-components";
+import Head from "next/head";
+
+export default function Collection() {
+  return (
+    <>
+      <Head>
+        <title>Collection</title>
+        <meta property="og:title" content="All Collections" key="title" />
+      </Head>
+      <Layout
+        activePage="collection"
+        breadcrumbs={[
+          { text: "Collections", url: "/collections" },
+          { text: "I am one Collection", url: "/collections/hello" },
+        ]}
+      >
+        <Heading> I am one Collection </Heading>
+      </Layout>
+    </>
+  );
+}

--- a/src/pages/collections/[id].tsx
+++ b/src/pages/collections/[id].tsx
@@ -1,5 +1,4 @@
 import { useContext, useEffect } from "react";
-import { useRouter } from "next/router";
 import Layout from "@/components/layout/layout";
 import { Heading } from "@nypl/design-system-react-components";
 import { breadcrumbsContext } from "../breadcrumbsContext";
@@ -18,9 +17,8 @@ const Collection = () => {
   );
 };
 
+// Imagine an API call somewhere in here
 export const getServerSideProps = async () => {
-  //const response = await fetch(`/api/featuredItem`);
-  //const responseData = await response.json();
   let breadcrumbs = [
     { text: "Home", url: "/" },
     { text: "Collections", url: "/collcetions" },

--- a/src/pages/collections/[id].tsx
+++ b/src/pages/collections/[id].tsx
@@ -1,13 +1,11 @@
-import { useContext, useEffect } from "react";
 import Layout from "@/components/layout/layout";
 import { Heading } from "@nypl/design-system-react-components";
-import { breadcrumbsContext } from "../breadcrumbsContext";
 
-const Collection = () => {
-  const { breadcrumbs, setBreadcrumbs } = useContext(breadcrumbsContext);
-  useEffect(() => {
-    setBreadcrumbs({ text: "A Collection", url: "/collections/collection" });
-  }, []);
+const Collection = ({ breadcrumbs }) => {
+  // const { breadcrumbs, setBreadcrumbs } = useContext(breadcrumbsContext);
+  // useEffect(() => {
+  //   setBreadcrumbs({ text: "A Collection", url: "/collections/collection" });
+  // }, []);
   return (
     <Layout activePage="collection" breadcrumbs={breadcrumbs}>
       <Heading>
@@ -17,8 +15,8 @@ const Collection = () => {
   );
 };
 
-// Imagine an API call somewhere in here
 export const getServerSideProps = async () => {
+  // Fetch something
   let breadcrumbs = [
     { text: "Home", url: "/" },
     { text: "Collections", url: "/collcetions" },

--- a/src/pages/collections/index.tsx
+++ b/src/pages/collections/index.tsx
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useReducer,
-  useState,
-} from "react";
+import { useContext, useEffect } from "react";
 import Link from "next/link";
 import Head from "next/head";
 import Layout from "@/components/layout/layout";

--- a/src/pages/collections/index.tsx
+++ b/src/pages/collections/index.tsx
@@ -1,27 +1,34 @@
-import HomePageMainContent from "@/components/homePageMainContent/homePageMainContent";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useReducer,
+  useState,
+} from "react";
+import Link from "next/link";
+import Head from "next/head";
 import Layout from "@/components/layout/layout";
-
 import {
   Card,
   CardContent,
   CardHeading,
   Heading,
-  Link,
 } from "@nypl/design-system-react-components";
-import Head from "next/head";
+import { breadcrumbsContext } from "../breadcrumbsContext";
 
 export default function Collections() {
+  const { breadcrumbs, setBreadcrumbs } = useContext(breadcrumbsContext);
+  useEffect(() => {
+    setBreadcrumbs({ text: "All Collections", url: "/collections" });
+  }, []);
   return (
     <>
       <Head>
         <title>All Collections</title>
         <meta property="og:title" content="All Collections" key="title" />
       </Head>
-      <Layout
-        activePage="collections"
-        breadcrumbs={[{ text: "Collections", url: "/collections" }]}
-      >
-        <Heading> All Collections </Heading>
+      <Layout activePage="collections" breadcrumbs={breadcrumbs}>
+        <Heading>All Collections</Heading>
         <Card
           width="500px"
           imageProps={{
@@ -32,11 +39,26 @@ export default function Collections() {
           }}
         >
           <CardHeading level="h3" size="heading5">
-            {" "}
-            I am one collection{" "}
+            I am one collection
           </CardHeading>
           <CardContent>
-            <Link href="/collections/collection"> Go to collection page </Link>
+            <Link href="/collections/hello">Go to collection page</Link>
+          </CardContent>
+        </Card>
+        <Card
+          width="500px"
+          imageProps={{
+            alt: "",
+            isLazy: true,
+            aspectRatio: "twoByOne",
+            src: "pd_banner.png",
+          }}
+        >
+          <CardHeading level="h3" size="heading5">
+            I am another collection
+          </CardHeading>
+          <CardContent>
+            <Link href="/collections/hello2">Go to collection page</Link>
           </CardContent>
         </Card>
       </Layout>

--- a/src/pages/collections/index.tsx
+++ b/src/pages/collections/index.tsx
@@ -1,0 +1,45 @@
+import HomePageMainContent from "@/components/homePageMainContent/homePageMainContent";
+import Layout from "@/components/layout/layout";
+
+import {
+  Card,
+  CardContent,
+  CardHeading,
+  Heading,
+  Link,
+} from "@nypl/design-system-react-components";
+import Head from "next/head";
+
+export default function Collections() {
+  return (
+    <>
+      <Head>
+        <title>All Collections</title>
+        <meta property="og:title" content="All Collections" key="title" />
+      </Head>
+      <Layout
+        activePage="collections"
+        breadcrumbs={[{ text: "Collections", url: "/collections" }]}
+      >
+        <Heading> All Collections </Heading>
+        <Card
+          width="500px"
+          imageProps={{
+            alt: "",
+            isLazy: true,
+            aspectRatio: "twoByOne",
+            src: "pd_banner.png",
+          }}
+        >
+          <CardHeading level="h3" size="heading5">
+            {" "}
+            I am one collection{" "}
+          </CardHeading>
+          <CardContent>
+            <Link href="/collections/collection"> Go to collection page </Link>
+          </CardContent>
+        </Card>
+      </Layout>
+    </>
+  );
+}

--- a/src/pages/divisions/[id].tsx
+++ b/src/pages/divisions/[id].tsx
@@ -1,0 +1,58 @@
+import { useContext, useEffect } from "react";
+import Layout from "@/components/layout/layout";
+import {
+  Card,
+  CardContent,
+  CardHeading,
+  Heading,
+  Link,
+} from "@nypl/design-system-react-components";
+import { breadcrumbsContext } from "../breadcrumbsContext";
+
+const Division = () => {
+  const { breadcrumbs, setBreadcrumbs } = useContext(breadcrumbsContext);
+  useEffect(() => {
+    setBreadcrumbs({ text: "A Division", url: "/divisions/division" });
+  }, []);
+  return (
+    <Layout activePage="division" breadcrumbs={breadcrumbs}>
+      <Heading>
+        <>Division</>
+      </Heading>
+      <Card
+        width="500px"
+        imageProps={{
+          alt: "",
+          isLazy: true,
+          aspectRatio: "twoByOne",
+          src: "pd_banner.png",
+        }}
+      >
+        <CardHeading level="h3" size="heading5">
+          I am one collection
+        </CardHeading>
+        <CardContent>
+          <Link href="/collections/hello">Go to collection page</Link>
+        </CardContent>
+      </Card>
+      <Card
+        width="500px"
+        imageProps={{
+          alt: "",
+          isLazy: true,
+          aspectRatio: "twoByOne",
+          src: "pd_banner.png",
+        }}
+      >
+        <CardHeading level="h3" size="heading5">
+          I am division
+        </CardHeading>
+        <CardContent>
+          <Link href="/divisions/goodbye">Go to another division</Link>
+        </CardContent>
+      </Card>
+    </Layout>
+  );
+};
+
+export default Division;

--- a/src/pages/divisions/index.tsx
+++ b/src/pages/divisions/index.tsx
@@ -1,0 +1,45 @@
+import { useContext, useEffect, useState } from "react";
+import Link from "next/link";
+import Head from "next/head";
+import Layout from "@/components/layout/layout";
+import {
+  Card,
+  CardContent,
+  CardHeading,
+  Heading,
+} from "@nypl/design-system-react-components";
+import { breadcrumbsContext } from "../breadcrumbsContext";
+
+export default function Divisions() {
+  const { breadcrumbs, setBreadcrumbs } = useContext(breadcrumbsContext);
+  useEffect(() => {
+    setBreadcrumbs({ text: "All Divisions", url: "/divisions" });
+  }, []);
+  return (
+    <>
+      <Head>
+        <title>All Collections</title>
+        <meta property="og:title" content="All Divisions" key="title" />
+      </Head>
+      <Layout activePage="divisions" breadcrumbs={breadcrumbs}>
+        <Heading>All Divisions</Heading>
+        <Card
+          width="500px"
+          imageProps={{
+            alt: "",
+            isLazy: true,
+            aspectRatio: "twoByOne",
+            src: "pd_banner.png",
+          }}
+        >
+          <CardHeading level="h3" size="heading5">
+            I am one division
+          </CardHeading>
+          <CardContent>
+            <Link href="/divisions/hello">Go to division page</Link>
+          </CardContent>
+        </Card>
+      </Layout>
+    </>
+  );
+}

--- a/src/pages/divisions/index.tsx
+++ b/src/pages/divisions/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect } from "react";
 import Link from "next/link";
 import Head from "next/head";
 import Layout from "@/components/layout/layout";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import CampaignHero from "../components/hero/campaignHero";
 import {
+  DSProvider,
   SkipNavigation,
   TemplateAppContainer,
 } from "@nypl/design-system-react-components";
@@ -7,16 +8,11 @@ import Header from "@/components/header/header";
 import HomePageMainContent from "@/components/homePageMainContent/homePageMainContent";
 import ExploreFurther from "@/components/exploreFurther/exploreFurther";
 import NotificationBanner from "@/components/notificationBanner/notificationBanner";
+import Layout from "@/components/layout/layout";
 
 export default function Home(props: any = {}) {
   return (
-    <>
-      <SkipNavigation target="#hero" />
-      {/**
-       * * @TODO: Header will need to be pulled into a reusable Layout component (DC Facelift phase 2)
-       * * Let this be @7emansell 's problem if possible **/}
-      <NotificationBanner />
-      <Header />
+    <Layout activePage="home">
       <TemplateAppContainer
         breakout={
           <div id="hero">
@@ -26,6 +22,6 @@ export default function Home(props: any = {}) {
         contentPrimary={<HomePageMainContent />}
       />
       <ExploreFurther />
-    </>
+    </Layout>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,18 +1,18 @@
 import CampaignHero from "../components/hero/campaignHero";
-import {
-  DSProvider,
-  SkipNavigation,
-  TemplateAppContainer,
-} from "@nypl/design-system-react-components";
-import Header from "@/components/header/header";
+import { TemplateAppContainer } from "@nypl/design-system-react-components";
 import HomePageMainContent from "@/components/homePageMainContent/homePageMainContent";
 import ExploreFurther from "@/components/exploreFurther/exploreFurther";
-import NotificationBanner from "@/components/notificationBanner/notificationBanner";
 import Layout from "@/components/layout/layout";
+import { useContext, useEffect } from "react";
+import { breadcrumbsContext } from "./breadcrumbsContext";
 
 export default function Home(props: any = {}) {
+  const { breadcrumbs, setBreadcrumbs } = useContext(breadcrumbsContext);
+  useEffect(() => {
+    setBreadcrumbs([{ text: "Home", url: "/" }]);
+  }, []);
   return (
-    <Layout activePage="home">
+    <Layout activePage="home" breadcrumbs={breadcrumbs}>
       <TemplateAppContainer
         breakout={
           <div id="hero">


### PR DESCRIPTION
## Ticket:

Investigates [DR-2966](https://jira.nypl.org/browse/DR-2966).

## This PR does the following:
- Creates collections and divisions directory structure
- Adds `Layout` component that contains header, DS provider, feedback, etc
- Adds `Layout` to all pages
- Creates a breadcrumbs context provider
- Adds breadcrumbs context to `/divisions/[slug]`, `/collections/[slug]`, `/divisions`, `/collections`

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
