### PR TITLE
DR-2986: Add word break in hero

### DIFF
--- a/src/components/hero/campaignHeroSubText.tsx
+++ b/src/components/hero/campaignHeroSubText.tsx
@@ -14,9 +14,9 @@ const CampaignHeroSubText = ({ featuredItem }: any) => {
         featuring prints, photographs, maps, manuscripts, streaming video, and
         more.
       </Text>
-      <Text>
-        Our collections include some content that may be harmful or difficult to{" "}
-        <br /> view.{" "}
+      <Text sx={{ marginRight: "xxl" }}>
+        Our collections include some content that may be harmful or difficult to
+        view.{" "}
         <DSLink
           hasVisitedState={false}
           href="/about#nypl_harmful_content_statement"

--- a/src/components/hero/campaignHeroSubText.tsx
+++ b/src/components/hero/campaignHeroSubText.tsx
@@ -8,15 +8,14 @@ import {
 const CampaignHeroSubText = ({ featuredItem }: any) => {
   return (
     <>
-      {/* To Do: make the link color blue: */}
       <Text>
         This site is a living database with new materials added every day,
         featuring prints, photographs, maps, manuscripts, streaming video, and
         more.
       </Text>
-      <Text sx={{ marginRight: "xxl" }}>
-        Our collections include some content that may be harmful or difficult to
-        view.{" "}
+      <Text sx={{ marginRight: "s" }}>
+        Our collections include some content that may be harmful or difficult
+        to&nbsp;view.{" "}
         <DSLink
           hasVisitedState={false}
           href="/about#nypl_harmful_content_statement"


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-2986](https://jira.nypl.org/browse/DR-2986).

## This PR does the following:
- Adds a non-breaking space between "to" and "view" in the hero's body text.
## How has this been tested?

Locally, test all screen sizes.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
