### PR TITLE
DR-3024 make entire card clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Migrated to Next v14 (App Router) (DR-3010, DR-3011)
-- Make the entire card clickable (DR-3024)
+- Make the entire card clickable for Collection and Explore Further cards (DR-3024)
 
 ## [0.1.8] 2024-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Migrated to Next v14 (App Router) (DR-3010, DR-3011)
+- Make the entire card clickable (DR-3024)
 
 ## [0.1.8] 2024-06-06
 

--- a/app/components/exploreFurther/exploreFurther.tsx
+++ b/app/components/exploreFurther/exploreFurther.tsx
@@ -67,6 +67,7 @@ const ExploreFurther = () => {
             id={`card-id-${index}`}
             key={`card-key-${index}`}
             data-testid={`test-id-${index}`}
+            mainActionLink={item.url}
             imageProps={{
               alt: "",
               aspectRatio: "sixteenByNine",

--- a/app/components/swimlanes/swimLanes.tsx
+++ b/app/components/swimlanes/swimLanes.tsx
@@ -50,6 +50,7 @@ const SwimLanes = ({ lanesWithNumItems }) => {
             <Card
               key={index}
               id={`card-${lane.slug}-${index}`}
+              mainActionLink={collection.url}
               imageProps={{
                 alt: "",
                 id: `image-${lane.slug}-${index}`,
@@ -75,7 +76,6 @@ const SwimLanes = ({ lanesWithNumItems }) => {
                 level="h3"
                 size="heading5"
                 className={styles.collectiontitle}
-                url={collection.url}
                 noOfLines={3}
               >
                 {isLargerThanLargeTablet ? (


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3024](https://newyorkpubliclibrary.atlassian.net/browse/DR-3024)

## This PR does the following:

- makes the whole card clickable by addding `mainActionLink` prop to the Card components rendered  in the `swimLanes` and `exploreFurther` components

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3024]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ