### PR TITLE
DR-3028 create url structure for phase 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `/collections`, `/divisions`, `/divisions/[slug]`, and `/collections/lane/[slug]` pages (DR-3021)
 - Added middleware to redirect unpublished pages (DR-3021)
 - Added `PageLayout` component (DR-3022)
-
+- Added `/search/index` and `/collections/slug` pages (DR-3028)
 
 ## [0.1.8] 2024-06-06
 

--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Metadata } from "next";
 import PageLayout from "app/components/pageLayout/pageLayout";
-import Collections from "app/components/collections/collections";
+import CollectionsPage from "app/components/collections/collections";
 import { useSearchParams } from "next/navigation";
 
 type CollectionProps = {
@@ -30,7 +30,7 @@ export default function Lane({ params }: CollectionProps) {
         },
       ]}
     >
-      <Collections slug={params.slug} />
+      <CollectionsPage slug={params.slug} />
     </PageLayout>
   );
 }

--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Metadata } from "next";
+import PageLayout from "app/components/pageLayout/pageLayout";
+import Collections from "app/components/collections/collections";
+import { useSearchParams } from "next/navigation";
+
+type CollectionProps = {
+  params: { slug: string };
+};
+
+export async function generateMetadata({
+  params,
+}: CollectionProps): Promise<Metadata> {
+  const slug = params.slug;
+  return {
+    title: `${slug} - NYPL Digital Collections`,
+  };
+}
+
+export default function Lane({ params }: CollectionProps) {
+  return (
+    <PageLayout
+      activePage="lane"
+      breadcrumbs={[
+        { text: "Home", url: "/" },
+        { text: "All Collections", url: "/collections" },
+        {
+          text: `${params.slug}`,
+          url: `/collections/${params.slug}`,
+        },
+      ]}
+    >
+      <Collections slug={params.slug} />
+    </PageLayout>
+  );
+}

--- a/app/components/collections/collections.tsx
+++ b/app/components/collections/collections.tsx
@@ -1,16 +1,11 @@
 "use client";
-import { useSearchParams } from "next/navigation";
-
+import SearchResults from "../search/results";
 const Collections = ({ slug }) => {
-  const queryParams = useSearchParams();
-  const tab = queryParams.get("tab");
-
   return (
     <>
-      <h2>
-        {slug} {queryParams.toString()}
-      </h2>
+      <h2>{slug}</h2>
       <br />
+      <SearchResults />
     </>
   );
 };

--- a/app/components/collections/collections.tsx
+++ b/app/components/collections/collections.tsx
@@ -1,6 +1,6 @@
 "use client";
 import SearchResults from "../search/results";
-const Collections = ({ slug }) => {
+const CollectionsPage = ({ slug }) => {
   return (
     <>
       <h2>{slug}</h2>
@@ -9,4 +9,4 @@ const Collections = ({ slug }) => {
     </>
   );
 };
-export default Collections;
+export default CollectionsPage;

--- a/app/components/collections/collections.tsx
+++ b/app/components/collections/collections.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { useSearchParams } from "next/navigation";
+
+const Collections = ({ slug }) => {
+  const queryParams = useSearchParams();
+  const tab = queryParams.get("tab");
+
+  return (
+    <>
+      <h2>
+        {slug} {queryParams.toString()}
+      </h2>
+      <br />
+    </>
+  );
+};
+export default Collections;

--- a/app/components/search/body.tsx
+++ b/app/components/search/body.tsx
@@ -1,0 +1,14 @@
+import { useSearchParams } from "next/navigation";
+
+const SearchBody = () => {
+  const queryParams = useSearchParams();
+  const query = queryParams.toString();
+  return (
+    <>
+      <h2>Search params: {query}</h2>
+      <br />
+    </>
+  );
+};
+
+export default SearchBody;

--- a/app/components/search/content.tsx
+++ b/app/components/search/content.tsx
@@ -1,6 +1,6 @@
 import { useSearchParams } from "next/navigation";
 
-const SearchBody = () => {
+const SearchContent = () => {
   const queryParams = useSearchParams();
   const query = queryParams.toString();
   return (
@@ -11,4 +11,4 @@ const SearchBody = () => {
   );
 };
 
-export default SearchBody;
+export default SearchContent;

--- a/app/components/search/results.tsx
+++ b/app/components/search/results.tsx
@@ -1,12 +1,15 @@
 "use client";
 import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 
 const SearchResults = ({}) => {
   const queryParams = useSearchParams();
   return (
     <>
-      <h2>Search: {queryParams.toString()}</h2>
-      <br />
+      <Suspense>
+        <h2>Search params: {queryParams.toString()}</h2>
+        <br />
+      </Suspense>
     </>
   );
 };

--- a/app/components/search/results.tsx
+++ b/app/components/search/results.tsx
@@ -1,14 +1,16 @@
 "use client";
-import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
+import SearchBody from "./body";
+
+function SearchBarFallback() {
+  return <>placeholder</>;
+}
 
 const SearchResults = ({}) => {
-  const queryParams = useSearchParams();
   return (
     <>
-      <Suspense>
-        <h2>Search params: {queryParams.toString()}</h2>
-        <br />
+      <Suspense fallback={<SearchBarFallback />}>
+        <SearchBody />
       </Suspense>
     </>
   );

--- a/app/components/search/results.tsx
+++ b/app/components/search/results.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { useSearchParams } from "next/navigation";
+
+const SearchResults = ({}) => {
+  const queryParams = useSearchParams();
+  return (
+    <>
+      <h2>Search: {queryParams.toString()}</h2>
+      <br />
+    </>
+  );
+};
+export default SearchResults;

--- a/app/components/search/results.tsx
+++ b/app/components/search/results.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Suspense } from "react";
-import SearchBody from "./body";
+import SearchContent from "./content";
 
 function SearchBarFallback() {
   return <>placeholder</>;
@@ -10,7 +10,7 @@ const SearchResults = ({}) => {
   return (
     <>
       <Suspense fallback={<SearchBarFallback />}>
-        <SearchBody />
+        <SearchContent />
       </Suspense>
     </>
   );

--- a/app/search/index/page.tsx
+++ b/app/search/index/page.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Metadata } from "next";
+import PageLayout from "app/components/pageLayout/pageLayout";
+import SearchResults from "@/components/search/results";
+export const metadata: Metadata = {
+  title: "Search - NYPL Digital Collections",
+};
+
+export default function Collections() {
+  return (
+    <PageLayout
+      activePage="collections"
+      breadcrumbs={[
+        { text: "Home", url: "/" },
+        { text: "Keyword Search", url: "/search/index" },
+      ]}
+    >
+      <SearchResults />
+    </PageLayout>
+  );
+}

--- a/middleware.tsx
+++ b/middleware.tsx
@@ -16,5 +16,6 @@ export const config = {
     "/collections/:path*",
     "/divisions",
     "/divisions/:path*",
+    "/search/:path*",
   ],
 };


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3028](https://newyorkpubliclibrary.atlassian.net/browse/DR-3028)

## This PR does the following:

creates url structure for the following pages:
 - `/search/index`
 - `/collections/[slug]`

also accepts query parameters and renders query param on the body

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
locally

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3028]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ