### PR TITLE
DR-2867: Enable strict typing

### DIFF
--- a/__tests__/data/swimlaneProps.tsx
+++ b/__tests__/data/swimlaneProps.tsx
@@ -1,5 +1,7 @@
-export const props = {
-  randomNumber: 1,
+import { SwimLanesProps } from "@/components/swimlanes/swimLanes";
+import type { CollectionItem } from "@/components/swimlanes/swimLanes";
+
+export const props: SwimLanesProps = {
   lanesWithNumItems: [
     {
       title: "Test collections 1",
@@ -34,7 +36,7 @@ export const props = {
           image_id: "58591658",
           numItems: 55,
         },
-      ],
+      ] as CollectionItem[],
     },
     {
       title: "Test collections 2",

--- a/__tests__/data/swimlaneProps.tsx
+++ b/__tests__/data/swimlaneProps.tsx
@@ -36,7 +36,7 @@ export const props: SwimLanesProps = {
           image_id: "58591658",
           numItems: 55,
         },
-      ] as CollectionItem[],
+      ],
     },
     {
       title: "Test collections 2",

--- a/__tests__/data/swimlaneProps.tsx
+++ b/__tests__/data/swimlaneProps.tsx
@@ -1,5 +1,4 @@
 import { SwimLanesProps } from "@/components/swimlanes/swimLanes";
-import type { CollectionItem } from "@/components/swimlanes/swimLanes";
 
 export const props: SwimLanesProps = {
   lanesWithNumItems: [

--- a/app/api/featuredItem/route.tsx
+++ b/app/api/featuredItem/route.tsx
@@ -1,3 +1,4 @@
+import { ENV_KEY } from "@/types/EnvironmentType";
 import {
   getNumDigitizedItems,
   getFeaturedImage,
@@ -27,7 +28,7 @@ export const GET = async (request: NextRequest, response: NextResponse) => {
     ),
     uuid: featuredImageData.uuid,
     title: featuredImageData.title,
-    href: `${appConfig.DC_URL[appConfig.environment]}/items/${
+    href: `${appConfig.DC_URL[appConfig.environment as ENV_KEY]}/items/${
       featuredImageData.uuid
     }`,
   };

--- a/app/api/feedback/route.tsx
+++ b/app/api/feedback/route.tsx
@@ -66,13 +66,19 @@ export const POST = async (request: NextRequest) => {
     );
   } catch (e: unknown) {
     if (e instanceof Error) {
-      return NextResponse.json({
-        message: e.message,
-      });
+      return NextResponse.json(
+        {
+          message: e.message,
+        },
+        { status: 400 }
+      );
     } else {
-      return NextResponse.json({
-        message: "unknown error occurred",
-      });
+      return NextResponse.json(
+        {
+          message: "unknown error occurred",
+        },
+        { status: 400 }
+      );
     }
   }
 };

--- a/app/api/feedback/route.tsx
+++ b/app/api/feedback/route.tsx
@@ -13,7 +13,9 @@ export const POST = async (request: NextRequest) => {
     const origin = request.headers.get("origin") || "";
     const page = referer.replace(origin, "");
     const ipAddress = request.headers.get("x-forwarded-for") || "";
-    const userAgentParser = new UAParser(request.headers.get("user-agent"));
+    const userAgentParser = new UAParser(
+      request.headers.get("user-agent") ?? undefined
+    );
     const userAgent = userAgentParser.getResult();
     const userPlatform = userAgent.device.model || "";
     const userBrowser = userAgent.browser.name || "";
@@ -62,13 +64,15 @@ export const POST = async (request: NextRequest) => {
       },
       { status: 200 }
     );
-  } catch (e) {
-    return NextResponse.json(
-      {
+  } catch (e: unknown) {
+    if (e instanceof Error) {
+      return NextResponse.json({
         message: e.message,
-        error: "server error",
-      },
-      { status: 400 }
-    );
+      });
+    } else {
+      return NextResponse.json({
+        message: "unknown error occurred",
+      });
+    }
   }
 };

--- a/app/components/cards/collectionCard.tsx
+++ b/app/components/cards/collectionCard.tsx
@@ -11,6 +11,7 @@ import {
 import styles from "./CollectionCard.module.css";
 import { headerBreakpoints } from "../../utils/breakpoints";
 import { CollectionCardDataType } from "../..//types/CollectionCard";
+
 interface CollectionCardProps {
   slug: string;
   id: number;

--- a/app/components/collections/collections.tsx
+++ b/app/components/collections/collections.tsx
@@ -1,6 +1,11 @@
 "use client";
 import SearchResults from "../search/results";
-const CollectionsPage = ({ slug }) => {
+
+interface CollectionPageProps {
+  slug: String;
+}
+
+const CollectionsPage = ({ slug }: CollectionPageProps) => {
   return (
     <>
       <h2>{slug}</h2>

--- a/app/components/exploreFurther/exploreFurther.tsx
+++ b/app/components/exploreFurther/exploreFurther.tsx
@@ -17,7 +17,7 @@ import useBreakpoints from "../../hooks/useBreakpoints";
 const ExploreFurther = () => {
   const data: ExploreFurtherDataType[] = exploreFurtherData;
   const { isLargerThanLargeTablet } = useBreakpoints();
-  function exploreFurtherLink(item: ExploreFurtherData) {
+  function exploreFurtherLink(item: ExploreFurtherDataType) {
     return (
       <Link
         href={item.url}

--- a/app/components/exploreFurther/exploreFurther.tsx
+++ b/app/components/exploreFurther/exploreFurther.tsx
@@ -17,7 +17,7 @@ import useBreakpoints from "../../hooks/useBreakpoints";
 const ExploreFurther = () => {
   const data: ExploreFurtherData[] = exploreFurtherData;
   const { isLargerThanLargeTablet } = useBreakpoints();
-  function exploreFurtherLink(item) {
+  function exploreFurtherLink(item: ExploreFurtherData) {
     return (
       <Link
         href={item.url}

--- a/app/components/featuredContent/featuredContent.tsx
+++ b/app/components/featuredContent/featuredContent.tsx
@@ -8,7 +8,11 @@ import React from "react";
 import featuredContentData from "../../data/featuredContentData";
 import { FeaturedContentData } from "../../types/FeaturedContentData";
 
-const FeaturedContentComponent = ({ randomNumber }) => {
+interface FeaturedContentProps {
+  randomNumber: number;
+}
+
+const FeaturedContentComponent = ({ randomNumber }: FeaturedContentProps) => {
   const data: FeaturedContentData = featuredContentData[randomNumber];
   return (
     <FeaturedContent

--- a/app/components/hero/campaignHero.tsx
+++ b/app/components/hero/campaignHero.tsx
@@ -8,10 +8,11 @@ import defaultFeaturedItem from "../../data/defaultFeaturedItemData";
 import appConfig from "../../../appConfig";
 import { FeaturedItemData } from "../../types/FeaturedItemData";
 import React from "react";
+import { ENV_KEY } from "@/types/EnvironmentType";
 
 const CampaignHero = () => {
   const defaultFeaturedItemResponse =
-    defaultFeaturedItem[appConfig["environment"]];
+    defaultFeaturedItem[appConfig["environment"] as ENV_KEY];
 
   const [data, setData] = useState<FeaturedItemData>();
 
@@ -36,7 +37,7 @@ const CampaignHero = () => {
     fetchData();
   }, [defaultFeaturedItemResponse]);
 
-  const handleError = (e: any) => {
+  const handleError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
     console.log(e);
     setData(defaultFeaturedItemResponse);
     console.log("data is:", data);

--- a/app/components/hero/campaignHero.tsx
+++ b/app/components/hero/campaignHero.tsx
@@ -1,6 +1,5 @@
 import { Hero } from "@nypl/design-system-react-components";
 import { useEffect, useState } from "react";
-
 import CampaignHeroSubText from "./campaignHeroSubText";
 import CampaignHeroHeading from "./campaignHeroHeading";
 import CampaignHeroLoading from "./campaignHeroLoading";

--- a/app/components/hero/campaignHeroHeading.tsx
+++ b/app/components/hero/campaignHeroHeading.tsx
@@ -1,7 +1,13 @@
 import { Heading } from "@nypl/design-system-react-components";
 import React from "react";
 
-const CampaignHeroHeading = ({ numberOfDigitizedItems }: any) => {
+interface CampaignHeroHeadingProps {
+  numberOfDigitizedItems: string;
+}
+
+const CampaignHeroHeading = ({
+  numberOfDigitizedItems,
+}: CampaignHeroHeadingProps) => {
   return (
     <Heading level="h1" id="campaign-hero" size="heading2">
       <>

--- a/app/components/hero/campaignHeroSubText.tsx
+++ b/app/components/hero/campaignHeroSubText.tsx
@@ -1,4 +1,3 @@
-import { FeaturedContentData } from "@/types/FeaturedContentData";
 import useBreakpoints from "../../hooks/useBreakpoints";
 import {
   Link as DSLink,

--- a/app/components/hero/campaignHeroSubText.tsx
+++ b/app/components/hero/campaignHeroSubText.tsx
@@ -1,3 +1,4 @@
+import { FeaturedContentData } from "@/types/FeaturedContentData";
 import useBreakpoints from "../../hooks/useBreakpoints";
 import {
   Link as DSLink,
@@ -8,7 +9,18 @@ import {
 } from "@nypl/design-system-react-components";
 import React from "react";
 
-const CampaignHeroSubText = ({ featuredItem }: any) => {
+interface CampaignHeroSubtextProps {
+  featuredItem: {
+    title: string;
+    uuid: string;
+    href: string;
+    imageID: string;
+    backgroundImageSrc: string;
+    foregroundImageSrc: string;
+  };
+}
+
+const CampaignHeroSubText = ({ featuredItem }: CampaignHeroSubtextProps) => {
   const { isLargerThanLargeTablet } = useBreakpoints();
   const featuredItemLink = (
     <DSLink hasVisitedState={false} href={featuredItem.href}>

--- a/app/components/homePageMainContent/homePageMainContent.tsx
+++ b/app/components/homePageMainContent/homePageMainContent.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useEffect, useState } from "react";
-
 import FeaturedContentComponent from "../featuredContent/featuredContent";
 import SwimLanes from "../swimlanes/swimLanes";
 import SwimLanesLoading from "../swimlanes/swimLanesLoading";

--- a/app/components/items/clover/image/image.tsx
+++ b/app/components/items/clover/image/image.tsx
@@ -3,6 +3,11 @@ import dynamic from "next/dynamic";
 import Header from "@/components/header/header";
 import { Box } from "@nypl/design-system-react-components";
 import { imageURL } from "@/utils/utils";
+
+interface ImageViewerProps {
+  imageID: string;
+}
+
 const Image: any = dynamic(
   () => import("@samvera/clover-iiif").then((Clover) => (Clover as any).Image),
   {
@@ -10,7 +15,7 @@ const Image: any = dynamic(
   }
 );
 
-const ImageViewer = ({ imageID }) => {
+const ImageViewer = ({ imageID }: ImageViewerProps) => {
   // const imageID = item.capture.imageID.$;
   return (
     <>

--- a/app/components/items/item.tsx
+++ b/app/components/items/item.tsx
@@ -4,8 +4,13 @@ import AudioViewer from "./clover/audio/viewer";
 import VideoViewer from "./clover/video/viewer";
 import BookViewer from "./clover/book/viewer";
 import PDFViewer from "./clover/pdf/viewer";
+import { ItemModel } from "@/models/item";
 
-const Item = ({ item }) => {
+interface ItemProps {
+  item: ItemModel;
+}
+
+const Item = ({ item }: ItemProps) => {
   let viewer;
   switch (item.typeOfResource) {
     case "still image":

--- a/app/components/logo/logo.tsx
+++ b/app/components/logo/logo.tsx
@@ -1,6 +1,9 @@
 import { Logo, Link } from "@nypl/design-system-react-components";
 import React from "react";
-import { DCLogoProps } from "../../types/DCLogoProps";
+
+interface DCLogoProps {
+  isMobile?: boolean;
+}
 
 const DCLogo = ({ isMobile = false }: DCLogoProps) => {
   return (

--- a/app/components/navMenu/mobileNavMenu.test.tsx
+++ b/app/components/navMenu/mobileNavMenu.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import appConfig from "../../../__tests__/data/appConfig";
 import MobileNavMenu from "./mobileNavMenu";
+import { ENV_KEY } from "@/types/EnvironmentType";
 
 describe("Mobile nav menu component", () => {
   it("renders mobile nav menu component", () => {
@@ -27,16 +28,16 @@ describe("Mobile nav menu component", () => {
     expect(screen.getByLabelText("Items")).toHaveAttribute(
       "href",
       `${
-        appConfig.DC_URL[appConfig.environment]
+        appConfig.DC_URL[appConfig.environment as ENV_KEY]
       }/search/index?utf8=%E2%9C%93&keywords=`
     );
     expect(screen.getByLabelText("Divisions")).toHaveAttribute(
       "href",
-      `${appConfig.DC_URL[appConfig.environment]}/divisions`
+      `${appConfig.DC_URL[appConfig.environment as ENV_KEY]}/divisions`
     );
     expect(screen.getByLabelText("Collections")).toHaveAttribute(
       "href",
-      `${appConfig.DC_URL[appConfig.environment]}/collections`
+      `${appConfig.DC_URL[appConfig.environment as ENV_KEY]}/collections`
     );
     expect(screen.getByLabelText("About")).toHaveAttribute("href", `/about`);
   });

--- a/app/components/navMenu/navMenu.test.tsx
+++ b/app/components/navMenu/navMenu.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import appConfig from "../../../__tests__/data/appConfig";
 import NavMenu from "./navMenu";
+import { ENV_KEY } from "@/types/EnvironmentType";
 
 describe("Nav menu component", () => {
   it("renders nav menu component", () => {
@@ -17,16 +18,16 @@ describe("Nav menu component", () => {
     const { getByLabelText } = render(<NavMenu render={1} />);
     expect(getByLabelText("Items")).toHaveAttribute(
       "href",
-      appConfig.DC_URL[appConfig.environment] +
+      appConfig.DC_URL[appConfig.environment as ENV_KEY] +
         `/search/index?utf8=%E2%9C%93&keywords=`
     );
     expect(getByLabelText("Divisions")).toHaveAttribute(
       "href",
-      appConfig.DC_URL[appConfig.environment] + `/divisions`
+      appConfig.DC_URL[appConfig.environment as ENV_KEY] + `/divisions`
     );
     expect(getByLabelText("Collections")).toHaveAttribute(
       "href",
-      appConfig.DC_URL[appConfig.environment] + `/collections`
+      appConfig.DC_URL[appConfig.environment as ENV_KEY] + `/collections`
     );
     expect(getByLabelText("About")).toHaveAttribute("href", "/about");
   });

--- a/app/components/navMenu/navMenu.tsx
+++ b/app/components/navMenu/navMenu.tsx
@@ -2,7 +2,11 @@ import { dcNavLinks } from "../../data/dcNavLinks";
 import { Link, List } from "@nypl/design-system-react-components";
 import React from "react";
 
-const NavMenu = ({ render }) => {
+interface NavMenuProps {
+  render: number;
+}
+
+const NavMenu = ({ render }: NavMenuProps) => {
   const listItems = dcNavLinks.map(({ href, text }) => (
     <Link
       isUnderlined={false}

--- a/app/components/pageLayout/pageLayout.tsx
+++ b/app/components/pageLayout/pageLayout.tsx
@@ -14,10 +14,11 @@ import { ADOBE_EMBED_URL } from "app/config/constants";
 import Script from "next/script";
 import { trackVirtualPageView } from "app/utils/utils";
 import { usePathname } from "next/navigation";
+import { BreadcrumbsDataProps } from "@nypl/design-system-react-components/dist/src/components/Breadcrumbs/Breadcrumbs";
 
 interface PageLayoutProps {
   activePage: string;
-  breadcrumbs?;
+  breadcrumbs?: BreadcrumbsDataProps[];
 }
 
 const PageLayout = ({
@@ -37,7 +38,7 @@ const PageLayout = ({
   });
   const [view, setView] = React.useState("form");
   const { isOpen, onClose, FeedbackBox } = useFeedbackBox();
-  const onSubmit = async (values) => {
+  const onSubmit = async (values: { category: string; comment: string }) => {
     try {
       const response = await fetch("/api/feedback", {
         method: "POST",
@@ -90,7 +91,7 @@ const PageLayout = ({
           children
         ) : (
           <>
-            <Breadcrumbs breadcrumbsData={breadcrumbs} />
+            <Breadcrumbs breadcrumbsData={breadcrumbs || []} />
             <TemplateAppContainer contentPrimary={children as JSX.Element} />
           </>
         )}

--- a/app/components/pages/homePage/homePage.tsx
+++ b/app/components/pages/homePage/homePage.tsx
@@ -6,7 +6,7 @@ import CampaignHero from "../../hero/campaignHero";
 import HomePageMainContent from "../../homePageMainContent/homePageMainContent";
 import PageLayout from "../../pageLayout/pageLayout";
 
-export default function HomePage(props: any) {
+export default function HomePage() {
   return (
     <PageLayout activePage="home">
       <TemplateAppContainer

--- a/app/components/publicDomainFilter/publicDomainFilter.tsx
+++ b/app/components/publicDomainFilter/publicDomainFilter.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from "react";
 import { Box, Checkbox, Link } from "@nypl/design-system-react-components";
-import { PublicDomainFilterProps } from "../../types/PublicDomainFilterProps";
+
+export interface PublicDomainFilterProps {
+  onCheckChange: (isChecked: boolean) => void;
+}
 
 const PublicDomainFilter = ({ onCheckChange }: PublicDomainFilterProps) => {
   const [isChecked, setIsChecked] = useState(false);
@@ -12,7 +15,7 @@ const PublicDomainFilter = ({ onCheckChange }: PublicDomainFilterProps) => {
     </>
   );
 
-  const handleCheckChange = (event) => {
+  const handleCheckChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.checked;
     setIsChecked(newValue);
     onCheckChange(newValue);

--- a/app/components/search/search.test.tsx
+++ b/app/components/search/search.test.tsx
@@ -4,6 +4,7 @@ import "@testing-library/jest-dom";
 import Search from "./search";
 import { useRouter } from "next/navigation";
 import appConfig from "../../../__tests__/data/appConfig";
+import { ENV_KEY } from "@/types/EnvironmentType";
 
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn(),
@@ -27,7 +28,7 @@ describe("Search component", () => {
     });
     fireEvent.submit(getByLabelText("Search Digital Collections"));
     expect(mockRouter.push).toHaveBeenCalledWith(
-      appConfig.DC_URL[appConfig.environment] +
+      appConfig.DC_URL[appConfig.environment as ENV_KEY] +
         `/search/index?keywords=test%20word`
     );
   });
@@ -46,7 +47,7 @@ describe("Search component", () => {
     fireEvent.submit(screen.getByLabelText("Search Digital Collections"));
 
     expect(mockRouter.push).toHaveBeenCalledWith(
-      appConfig.DC_URL[appConfig.environment] +
+      appConfig.DC_URL[appConfig.environment as ENV_KEY] +
         `/search/index?utf8=✓&filters%5Brights%5D=pd&keywords=test%20words`
     );
   });

--- a/app/components/search/search.tsx
+++ b/app/components/search/search.tsx
@@ -11,7 +11,10 @@ const Search = () => {
   const [keywords, setKeywords] = useState("");
   const [publicDomainOnly, setPublicDomainOnly] = useState(false);
 
-  const handleSubmit = (event, router) => {
+  const handleSubmit = (
+    event: React.FormEvent<HTMLFormElement>,
+    router: ReturnType<typeof useRouter>
+  ) => {
     event.preventDefault();
     const searchUrl =
       DC_URL +
@@ -21,11 +24,11 @@ const Search = () => {
     router.push(searchUrl);
   };
 
-  const handleTextChange = (event) => {
+  const handleTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setKeywords(event.target.value);
   };
 
-  const handleCheckChange = (isChecked): void => {
+  const handleCheckChange = (isChecked: boolean): void => {
     setPublicDomainOnly(isChecked);
   };
 
@@ -53,7 +56,9 @@ const Search = () => {
           id="searchbar"
           invalidText="Could not find the item"
           labelText="Search Digital Collections"
-          onSubmit={(event) => handleSubmit(event, router)}
+          onSubmit={(event: React.FormEvent<HTMLFormElement>) =>
+            handleSubmit(event, router)
+          }
           textInputProps={{
             labelText: "Search keyword(s)",
             name: "textInputName",

--- a/app/components/search/search.tsx
+++ b/app/components/search/search.tsx
@@ -11,10 +11,7 @@ const Search = () => {
   const [keywords, setKeywords] = useState("");
   const [publicDomainOnly, setPublicDomainOnly] = useState(false);
 
-  const handleSubmit = (
-    event: React.FormEvent<HTMLFormElement>,
-    router: ReturnType<typeof useRouter>
-  ) => {
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const searchUrl =
       DC_URL +
@@ -57,7 +54,7 @@ const Search = () => {
           invalidText="Could not find the item"
           labelText="Search Digital Collections"
           onSubmit={(event: React.FormEvent<HTMLFormElement>) =>
-            handleSubmit(event, router)
+            handleSubmit(event)
           }
           textInputProps={{
             labelText: "Search keyword(s)",

--- a/app/components/swimlanes/swimLanes.tsx
+++ b/app/components/swimlanes/swimLanes.tsx
@@ -20,14 +20,6 @@ import CollectionCard from "../cards/collectionCard";
 import type { CollectionCardDataType } from "../../types/CollectionCard";
 import { CollectionCardModel } from "../../models/collectionCard";
 
-// export type CollectionItem = {
-//   uuid: string;
-//   title: string;
-//   image_id: string;
-//   url: string;
-//   numItems: number;
-// };
-
 export interface SwimLanesProps {
   numColumns: number;
   lanesWithNumItems: {

--- a/app/components/swimlanes/swimLanes.tsx
+++ b/app/components/swimlanes/swimLanes.tsx
@@ -18,9 +18,26 @@ import { imageURL } from "../../utils/utils";
 import { DC_URL } from "../../config/constants";
 import useBreakpoints from "../../hooks/useBreakpoints";
 
-const SwimLanes = ({ lanesWithNumItems }) => {
+export type CollectionItem = {
+  uuid: string;
+  title: string;
+  image_id: string;
+  url: string;
+  numItems: number;
+};
+
+export interface SwimLanesProps {
+  lanesWithNumItems: {
+    slug: string;
+    title: string;
+    rank: number;
+    collections: CollectionItem[];
+  }[];
+}
+
+const SwimLanes = ({ lanesWithNumItems }: SwimLanesProps) => {
   const { isLargerThanLargeTablet } = useBreakpoints();
-  return lanesWithNumItems.map((lane, key) => (
+  const lanes = lanesWithNumItems.map((lane, key) => (
     <Box className={styles.lane} data-testid={lane.slug} mt="xxl" key={key}>
       <Flex alignItems="baseline">
         <Heading id={`row-heading-${lane.slug}`} level="h2" size="heading3">
@@ -128,6 +145,7 @@ const SwimLanes = ({ lanesWithNumItems }) => {
       </Link>
     </Box>
   ));
+  return <>{lanes}</>;
 };
 
 export default SwimLanes;

--- a/app/config/constants.ts
+++ b/app/config/constants.ts
@@ -1,3 +1,4 @@
+import { ENV_KEY } from "@/types/EnvironmentType";
 import appConfig from "../../appConfig";
 
 export const BASE_URL = "/";
@@ -13,5 +14,6 @@ export const ADOBE_ANALYTICS_PAGE_NAMES = {
   NOT_FOUND_404: "error|404",
 };
 
-export const DC_URL = appConfig.DC_URL[appConfig.environment];
-export const ADOBE_EMBED_URL = appConfig.adobeEmbedUrl[appConfig.environment];
+export const DC_URL = appConfig.DC_URL[appConfig.environment as ENV_KEY];
+export const ADOBE_EMBED_URL =
+  appConfig.adobeEmbedUrl[appConfig.environment as ENV_KEY];

--- a/app/hooks/useScrolled.ts
+++ b/app/hooks/useScrolled.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 
 /* Returns if the page is scrolled past the header, could be refactored for other elements. */
-export function useScrolled(elementId) {
+export function useScrolled(elementId: string) {
   const [isScrolled, setIsScrolled] = useState(true);
 
   useEffect(() => {

--- a/app/hooks/useStickyMargin.ts
+++ b/app/hooks/useStickyMargin.ts
@@ -10,7 +10,10 @@ import { useEffect } from "react";
 
 export function useStickyMargin() {
   useEffect(() => {
-    const applyStickyMargin = (sticky) => {
+    const applyStickyMargin = (sticky: {
+      header?: HTMLElement | null;
+      offset: number;
+    }) => {
       // Specifying which element on the page is focused, if none then defaulting to body.
       const focused = (document.activeElement || document.body) as HTMLElement;
       let applicable = focused !== document.body;
@@ -40,9 +43,10 @@ export function useStickyMargin() {
      **/
     let sticky: {
       header?: HTMLElement | null;
-      // Could have footer, other sticky elements.
-      offset?: number;
-    } = {};
+      offset: number;
+    } = {
+      offset: 0,
+    };
 
     sticky.header = document.querySelector(
       `[data-sticky-${"header"}]`
@@ -59,7 +63,7 @@ export function useStickyMargin() {
     const observer = new ResizeObserver(() => applyStickyMargin(sticky));
 
     // Handles "focus" events.
-    const applyStickyMarginWithEvent = (ev) => {
+    const applyStickyMarginWithEvent = (ev: FocusEvent) => {
       applyStickyMargin(sticky);
     };
 

--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -12,7 +12,7 @@ type ItemProps = {
   };
 };
 
-const getItemModel = async (uuid) => {
+const getItemModel = async (uuid: string) => {
   const data = await getItemData(uuid);
   const item = new ItemModel(data);
   return item;
@@ -28,7 +28,7 @@ export async function generateMetadata({
   };
 }
 
-export default async function ItemPage({ params }) {
+export default async function ItemPage({ params }: ItemProps) {
   const item = await getItemModel(params.uuid);
   return (
     <PageLayout

--- a/app/models/collectionCard.ts
+++ b/app/models/collectionCard.ts
@@ -6,7 +6,7 @@ export class CollectionCardModel {
   uuid: string;
   title: string;
   url: string;
-  image_id: string;
+  imageID: string;
   imageURL: string;
   numItems: string;
 
@@ -14,6 +14,7 @@ export class CollectionCardModel {
     this.uuid = data.uuid;
     this.title = data.title;
     this.url = data.url;
+    this.imageID = data.image_id;
     this.imageURL = imageURL(data.image_id, "full", "288,", "0");
     this.numItems = data.numItems || 0;
   }

--- a/app/models/item.ts
+++ b/app/models/item.ts
@@ -4,8 +4,8 @@ export class ItemModel {
   capture: any;
   typeOfResource: string;
   title: string;
-  isPDF: boolean;
-  isBook: boolean;
+  isPDF?: boolean;
+  isBook?: boolean;
   isSingleCapture: boolean;
 
   constructor(data: any) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
 import HomePage from "./components/pages/homePage/homePage";
-export default function Home(props: any) {
+export default function Home() {
   return <HomePage />;
 }

--- a/app/types/CollectionCard.ts
+++ b/app/types/CollectionCard.ts
@@ -2,7 +2,7 @@ export interface CollectionCardDataType {
   uuid: string;
   title: string;
   url: string;
-  image_id: string;
+  imageID: string;
   imageURL: string;
   numItems: string;
   // TODO: containsAVMaterial: boolean; // to be added in phase 2

--- a/app/types/DCLogoProps.ts
+++ b/app/types/DCLogoProps.ts
@@ -1,3 +1,0 @@
-export interface DCLogoProps {
-  isMobile?: boolean;
-}

--- a/app/types/EnvironmentType.ts
+++ b/app/types/EnvironmentType.ts
@@ -1,0 +1,1 @@
+export type ENV_KEY = "development" | "qa" | "production";

--- a/app/types/NavMenuProps.ts
+++ b/app/types/NavMenuProps.ts
@@ -1,4 +1,0 @@
-export interface NavMenuProps {
-  isMobile?: boolean;
-  isScrolled?: boolean;
-}

--- a/app/types/PublicDomainFilterProps.ts
+++ b/app/types/PublicDomainFilterProps.ts
@@ -1,3 +1,0 @@
-export interface PublicDomainFilterProps {
-  onCheckChange: (isChecked: boolean) => void;
-}

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -9,6 +9,7 @@
  */
 import appConfig from "../../appConfig";
 import defaultFeaturedItems from "../data/defaultFeaturedItemData";
+import { ENV_KEY } from "@/types/EnvironmentType";
 
 export const imageURL = (
   imageId: any,
@@ -201,7 +202,6 @@ import {
   ADOBE_ANALYTICS_DC_PREFIX,
   BASE_URL,
 } from "../config/constants";
-import { ENV_KEY } from "@/types/EnvironmentType";
 
 /**
  * adobeAnalyticsParam

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -9,6 +9,11 @@
  */
 import appConfig from "../../appConfig";
 import defaultFeaturedItems from "../data/defaultFeaturedItemData";
+interface AdobeDataLayerEvent {
+  event?: string;
+  page_name?: string;
+  site_section?: string;
+}
 
 export const imageURL = (
   imageId: any,
@@ -17,7 +22,7 @@ export const imageURL = (
   rotation = "0"
 ) => {
   return `${
-    appConfig.IIIF_URL[appConfig.environment]
+    appConfig.IIIF_URL[appConfig.environment as ENV_KEY]
   }/iiif/2/${imageId}/${region}/${size}/${rotation}/default.jpg`;
 };
 
@@ -30,7 +35,8 @@ export const getNumDigitizedItems = async () => {
   const res = await apiCall(apiUrl);
 
   const fallbackCount =
-    defaultFeaturedItems[appConfig.environment].numberOfDigitizedItems;
+    defaultFeaturedItems[appConfig.environment as ENV_KEY]
+      .numberOfDigitizedItems;
   const totalItems = res?.count?.$ ? addCommas(res.count.$) : fallbackCount; // only add commas to repo api response data
   return totalItems;
 };
@@ -57,10 +63,19 @@ export const getItemsCountFromUUIDs = async (uuids: string[]) => {
   //   uuid1: count1
   //
   const uuidCounts = counts?.count || [];
-  const cleanCounts = uuidCounts.reduce((acc, count) => {
-    acc[count.uuid["$"]] = count.count_value["$"];
-    return acc;
-  }, {});
+  const cleanCounts = uuidCounts.reduce(
+    (
+      acc: { [x: string]: any },
+      count: {
+        uuid: { [x: string]: string | number };
+        count_value: { [x: string]: any };
+      }
+    ) => {
+      acc[count.uuid["$"]] = count.count_value["$"];
+      return acc;
+    },
+    {}
+  );
 
   return cleanCounts ? cleanCounts : {};
 };
@@ -151,7 +166,7 @@ export const apiPOSTCall = async (apiUrl: string, postData: any) => {
 export const getFeaturedImage = async () => {
   //console.log(`getFeaturedImage: About call getAPIResponse`);
   const defaultResponse =
-    defaultFeaturedItems[appConfig.environment].featuredItem;
+    defaultFeaturedItems[appConfig.environment as ENV_KEY].featuredItem;
   const apiResponse = await getAPIResponse("featured", "", { random: "true" });
 
   return {
@@ -161,7 +176,7 @@ export const getFeaturedImage = async () => {
   };
 };
 
-function addCommas(number) {
+function addCommas(number: string) {
   // Return the formatted number
   return Number(number).toLocaleString("en-US");
 }
@@ -191,6 +206,7 @@ import {
   ADOBE_ANALYTICS_DC_PREFIX,
   BASE_URL,
 } from "../config/constants";
+import { ENV_KEY } from "@/types/EnvironmentType";
 
 /**
  * adobeAnalyticsParam

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -9,11 +9,6 @@
  */
 import appConfig from "../../appConfig";
 import defaultFeaturedItems from "../data/defaultFeaturedItemData";
-interface AdobeDataLayerEvent {
-  event?: string;
-  page_name?: string;
-  site_section?: string;
-}
 
 export const imageURL = (
   imageId: any,

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -237,6 +237,7 @@ export const adobeAnalyticsRouteToPageName = (route = "", queryParams = "") => {
  * Tracks a virtual page view to Adobe Analytics on page navigation.
  */
 export const trackVirtualPageView = (pathname = "") => {
+  // @ts-ignore
   const adobeDataLayer = window["adobeDataLayer"] || [];
   const route = pathname.toLowerCase().replace(BASE_URL, "");
   const queryIndex = route.indexOf("?");

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -26,7 +26,7 @@ export const imageURL = (
  * Returns the number of digitized items in repo api.
  */
 
-export const getItemData = async (uuid) => {
+export const getItemData = async (uuid: string) => {
   const apiUrl = `${process.env.API_URL}/api/v2/items/mods_captures/${uuid}`;
   const res = await RepoAPICall(apiUrl);
   // console.log("res is: ", res)
@@ -70,7 +70,7 @@ export const getItemsCountFromUUIDs = async (uuids: string[]) => {
   //   uuid1: count1
   //
   const uuidCounts = counts?.count || [];
-  const cleanCounts = uuidCounts.reduce((acc, count) => {
+  const cleanCounts = uuidCounts.reduce((acc: any, count: any) => {
     acc[count.uuid["$"]] = count.count_value["$"];
     return acc;
   }, {});

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -233,6 +233,7 @@ export const adobeAnalyticsRouteToPageName = (route = "", queryParams = "") => {
  */
 export const trackVirtualPageView = (pathname = "") => {
   // @ts-ignore
+  // Adobe does not support TS types.
   const adobeDataLayer = window["adobeDataLayer"] || [];
   const route = pathname.toLowerCase().replace(BASE_URL, "");
   const queryIndex = route.indexOf("?");

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/jest": "29.5.5",
         "@types/jest-axe": "3.5.6",
         "@types/newrelic": "^9.14.3",
+        "@types/ua-parser-js": "0.7.39",
         "eslint-config-next": "14.2.3",
         "eslint-config-prettier": "9.0.0",
         "husky": "8.0.0",
@@ -4731,6 +4732,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+    },
+    "node_modules/@types/ua-parser-js": {
+      "version": "0.7.39",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.39.tgz",
+      "integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/jest": "29.5.5",
     "@types/jest-axe": "3.5.6",
     "@types/newrelic": "^9.14.3",
+    "@types/ua-parser-js": "0.7.39",
     "eslint-config-next": "14.2.3",
     "eslint-config-prettier": "9.0.0",
     "husky": "8.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Ticket:

Resolves JIRA ticket [DR-2867](https://newyorkpubliclibrary.atlassian.net/browse/DR-2867)

## This PR does the following:

- Turns on `strict` flag for Typescript
- Adds types accordingly 
- Moves component prop interfaces into component files (this is maybe not the pattern we want though? Could also be in a `/props` folder

## How has this been tested?

Locally

## Accessibility concerns or updates


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.

[DR-2867]: https://newyorkpubliclibrary.atlassian.net/browse/DR-2867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ