### PR TITLE
Small change to re-enable tooltips on swimlane collection cards

### DIFF
--- a/app/components/swimlanes/swimLanes.tsx
+++ b/app/components/swimlanes/swimLanes.tsx
@@ -20,6 +20,7 @@ import useBreakpoints from "../../hooks/useBreakpoints";
 
 const SwimLanes = ({ lanesWithNumItems }) => {
   const { isLargerThanLargeTablet } = useBreakpoints();
+
   return lanesWithNumItems.map((lane, key) => (
     <Box className={styles.lane} data-testid={lane.slug} mt="xxl" key={key}>
       <Flex alignItems="baseline">
@@ -80,7 +81,9 @@ const SwimLanes = ({ lanesWithNumItems }) => {
               >
                 {isLargerThanLargeTablet ? (
                   <Tooltip content={collection.title}>
-                    <Text sx={{ marginBottom: "0" }}>{collection.title}</Text>
+                    <Link href={collection.url} sx={{ marginBottom: "0" }}>
+                      {collection.title}
+                    </Link>
                   </Tooltip>
                 ) : (
                   collection.title


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3024](https://newyorkpubliclibrary.atlassian.net/browse/DR-3024)

## This PR does the following:

- Fixes an issue where the tooltip on a swimlane collection card's title was not triggered.
- This issue, I think, comes from a combination of DS components that Marty and I have not considered. We need to rework how the full-clickable `Card` and `Tooltip` components work together. Not a big problem for now!
- No update in the changelog since this fixes an issue with newly introduced features.

## How has this been tested?

Locally and Vercel.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
