### PR TITLE
DR-3106: Render collection swimlane page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Rendered collections page with preliminary search/sort (DR-3099)
-- Rendered swimlane page (DR-3106)
-- Rendered division landing page (DR-3093)
+- Rendered `/collections` page with preliminary search/sort (DR-3099)
+- Rendered `/collections/lane/[slug]` collection lane landing page (DR-3106)
+- Rendered `/divisions/[slug]` division landing page (DR-3093)
 - Created item and item card models and mocks (DR-3094)
 
 ## [0.1.11] 2024-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Rendered collections page with preliminary search/sort (DR-3099)
+- Rendered swimlane page (DR-3106)
 - Rendered division landing page (DR-3093)
 - Created item and item card models and mocks (DR-3094)
 

--- a/app/collections/lane/[slug]/page.tsx
+++ b/app/collections/lane/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Metadata } from "next";
 import PageLayout from "../../../src/components/pageLayout/pageLayout";
+import CollectionLanePage from "@/src/components/pages/collectionLanePage/collectionLanePage";
+import { slugToString } from "@/src/utils/utils";
 
 type LaneProps = {
   params: { slug: string };
@@ -10,8 +12,9 @@ export async function generateMetadata({
   params,
 }: LaneProps): Promise<Metadata> {
   const slug = params.slug;
+  const title = slugToString(params.slug);
   return {
-    title: `${slug} - NYPL Digital Collections`,
+    title: `${title} - NYPL Digital Collections`,
   };
 }
 
@@ -28,8 +31,7 @@ export default function Lane({ params }: LaneProps) {
         },
       ]}
     >
-      <h2> {params.slug} Lane </h2>
-      <br />
+      <CollectionLanePage />
     </PageLayout>
   );
 }

--- a/app/src/components/pages/collectionLanePage/collectionLanePage.tsx
+++ b/app/src/components/pages/collectionLanePage/collectionLanePage.tsx
@@ -1,0 +1,65 @@
+"use client";
+import {
+  Box,
+  Heading,
+  HorizontalRule,
+  SimpleGrid,
+} from "@nypl/design-system-react-components";
+import PageLayout from "../../pageLayout/pageLayout";
+import { useNumColumns } from "../../../hooks/useNumColumns";
+import { useParams } from "next/navigation";
+import { headerBreakpoints } from "../../../utils/breakpoints";
+import { slugToString } from "../../../utils/utils";
+import CollectionCard from "../../../components/cards/collectionCard";
+import { CollectionCardModel } from "../../../models/collectionCard";
+import useBreakpoints from "../../../hooks/useBreakpoints";
+import CollectionDataType from "../../../types/CollectionDataType";
+import { mockCollections } from "../../../../../__tests__/__mocks__/data/mockCollections";
+import React from "react";
+
+export default function CollectionLanePage() {
+  const params = useParams();
+  const { isLargerThanLargeTablet } = useBreakpoints();
+  const slug = params.slug as string;
+  const title = slugToString(slug);
+  const numColumns = useNumColumns();
+  return (
+    <>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          "> h1": {
+            marginBottom: 0,
+          },
+          [`@media screen and (min-width: ${headerBreakpoints.smTablet})`]: {
+            maxWidth: "715px",
+          },
+          gap: "m",
+        }}
+      >
+        <Heading level="h1" text={title} />
+      </Box>
+      <HorizontalRule sx={{ marginTop: "xxl", marginBottom: "xxl" }} />
+      <SimpleGrid
+        columns={numColumns}
+        sx={{
+          gridTemplateColumns: `repeat(${numColumns}, minmax(0, 1fr))`,
+        }}
+      >
+        {mockCollections.map((collection: CollectionDataType, index) => {
+          const collectionModel = new CollectionCardModel(collection);
+          return (
+            <CollectionCard
+              key={index}
+              id={index}
+              slug={collectionModel.title}
+              collection={collectionModel}
+              isLargerThanLargeTablet={isLargerThanLargeTablet}
+            />
+          );
+        })}
+      </SimpleGrid>
+    </>
+  );
+}


### PR DESCRIPTION
## Ticket:

Resolves ticket [DR-3106](https://newyorkpubliclibrary.atlassian.net/browse/DR-3106)

## This PR does the following:

- Renders the swimlane landing page with dummy data

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Locally: ex `/collections/lane/hello`

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3106]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ