### PR TITLE
DR-3122 add qa to middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rendered `/divisions/[slug]` division landing page (DR-3093)
 - Created item and item card models and mocks (DR-3094)
 - Added `/api/changelog` endpoint (DR-3048)
+
 ## [0.1.11] 2024-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
+### Updated
+- Update middleware file to not redirect urls created for phase 2-4 in 'qa' environment (DR-3122)
 
+### Added
 - Rendered `/collections` page with preliminary search/sort (DR-3099)
 - Rendered `/collections/lane/[slug]` collection lane landing page (DR-3106)
 - Rendered `/divisions/[slug]` division landing page (DR-3093)
 - Created item and item card models and mocks (DR-3094)
 - Added `/api/changelog` endpoint (DR-3048)
-
 ## [0.1.11] 2024-08-05
 
 ### Added

--- a/middleware.tsx
+++ b/middleware.tsx
@@ -2,7 +2,7 @@ import { NextResponse, NextRequest } from "next/server";
 
 export function middleware(request: NextRequest) {
   // Redirecting unreleased pages.
-  if (process.env.APP_ENV === "development") {
+  if (process.env.APP_ENV === "development" || process.env.APP_ENV === "qa") {
     return NextResponse.next();
   } else {
     return NextResponse.redirect(new URL("/", request.url));


### PR DESCRIPTION
## Ticket:

- JIRA ticket https://newyorkpubliclibrary.atlassian.net/browse/DR-3122

## This PR does the following:

- adds qa environment to middleware to prevent redirects to phase 2-4 pages from redirecting to the homepage in the qa environment

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
locally by updating APP_ENV in .env.local to "qa" and trying to hit http://localhost:3000/divisions/test-collections-1

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

 -

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.
