### PR TITLE
DR-3168: 404/Not found page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added Adobe Analytics to top level category pages, search based pages, and item pages (DR-3061)
+- Added 404 page which catches nonexistent routes (DR-3168)
 
 ## [0.1.12] 2024-08-29
 

--- a/__tests__/pages/notfoundpage.test.tsx
+++ b/__tests__/pages/notfoundpage.test.tsx
@@ -1,0 +1,20 @@
+import NotFoundPage from "@/src/components/pages/notFoundPage/notFoundPage";
+import { render, screen } from "@testing-library/react";
+import { useRouter } from "next/navigation";
+import React from "react";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+describe("Not Found Page", () => {
+  it("renders a 404 error message", () => {
+    (useRouter as jest.Mock).mockImplementation(() => ({
+      pathname: "/404",
+    }));
+
+    render(<NotFoundPage />);
+    const heading = screen.getByRole("heading", { name: /404/i });
+    expect(heading).toBeInTheDocument();
+  });
+});

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,5 @@
+import NotFoundPage from "./src/components/pages/notFoundPage/notFoundPage";
+
+export default function NotFound() {
+  return <NotFoundPage />;
+}

--- a/app/src/components/pageLayout/pageLayout.tsx
+++ b/app/src/components/pageLayout/pageLayout.tsx
@@ -19,7 +19,7 @@ import { trackVirtualPageView } from "../../utils/utils";
 interface PageLayoutProps {
   activePage: string;
   breadcrumbs?: BreadcrumbsDataProps[];
-  adobeAnalyticsPageName: string;
+  adobeAnalyticsPageName?: string;
 }
 
 const PageLayout = ({
@@ -84,7 +84,9 @@ const PageLayout = ({
         <SkipNavigation />
         <NotificationBanner />
         <Header />
-        {activePage === "home" || activePage === "about" ? (
+        {activePage === "home" ||
+        activePage === "about" ||
+        activePage === "notFound" ? (
           children
         ) : (
           <>

--- a/app/src/components/pages/notFoundPage/notFoundPage.tsx
+++ b/app/src/components/pages/notFoundPage/notFoundPage.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { Box, Heading } from "@nypl/design-system-react-components";
+import PageLayout from "../../pageLayout/pageLayout";
+import Link from "next/link";
+import appConfig from "appConfig";
+import { ENV_KEY } from "@/src/types/EnvironmentType";
+
+export default function NotFoundPage() {
+  return (
+    <PageLayout activePage="notFound">
+      <Box sx={{ margin: "xl" }}>
+        <Heading level="h1">404 Not Found</Heading>
+        <p>We&apos;re sorry...</p>
+        <p>The page you were looking for doesn&apos;t exist.</p>
+        <p>
+          Return to{" "}
+          <Link href={appConfig.DC_URL[appConfig.environment as ENV_KEY]}>
+            Digital Collections
+          </Link>
+          .
+        </p>
+      </Box>
+    </PageLayout>
+  );
+}


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3168](https://newyorkpubliclibrary.atlassian.net/browse/DR-3168)

## This PR does the following:

- Adds `not-found.tsx` file and `notFoundPage` client component
- Adds test

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- The test I wrote isn't truly end to end but that's the coverage Research Catalog has. Wondering if we should look into Cypress or something since Jest on its own is not great for this
- Designers have a universal 404/error page design in the works, so this may have visual updates soon

## How has this been tested? How should a reviewer test this?

Hit `/404`

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3168]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ