### PR TITLE
tab index should be -1 for non interactive elements

### DIFF
--- a/app/src/components/grids/collectionsGrid.tsx
+++ b/app/src/components/grids/collectionsGrid.tsx
@@ -42,7 +42,7 @@ export const CollectionsGrid = ({ data }: any) => {
     <>
       <Heading
         ref={headingRef}
-        tabIndex={0}
+        tabIndex={-1}
         level="h2"
         id={data.slug}
         size="heading3"


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3098](https://newyorkpubliclibrary.atlassian.net/browse/DR-3098)

## This PR does the following:

- following Clare's feedback in https://docs.google.com/document/d/1aFNbdvedpTXfT6CVKBXZKMj71SXdhuP_CPepqUlAY8o/edit, tab index of the header should be -1

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3098]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ