### PR TITLE
DR-3229 update tab index to be -1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Refactored collection/item lanes into one `Lane` component (DR-3191)
+- Updated header on /divisions/:slug page to have a tabIndex of -1 (DR-3229)
 
 ## [0.1.14] 2024-10-03
 

--- a/app/src/components/pages/divisionPage/divisionPage.tsx
+++ b/app/src/components/pages/divisionPage/divisionPage.tsx
@@ -115,7 +115,7 @@ export default function DivisionPage({ data }: any) {
 
       <Heading
         ref={headingRef}
-        tabIndex={0}
+        tabIndex={-1}
         level="h2"
         id={slug}
         size="heading3"


### PR DESCRIPTION
## Ticket:

- JIRA ticket [update tab index of header on division landing page](https://newyorkpubliclibrary.atlassian.net/browse/DR-3229)

## This PR does the following:

- updates tabIndex to be -1

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
