### PR TITLE
DR-3264: Remove canonical tag linking to old DC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Updated cards to use Next Image (DR-3056)
+- Removed canonical tag to old DC (DR-3264)
 
 ## [0.1.16] 2024-10-31
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,9 +10,6 @@ export const metadata: Metadata = {
   title: "NYPL Digital Collections",
   description:
     "NYPL's Digital Collections is a living database featuring prints, photographs, maps, manuscripts, video, and more unique research materials.",
-  alternates: {
-    canonical: "https://digitalcollections.nypl.org/",
-  },
   openGraph: {
     title: "NYPL Digital Collections",
     description:


### PR DESCRIPTION
## Ticket:

Resolves JIRA ticket [DR-3264](https://newyorkpubliclibrary.atlassian.net/browse/DR-3264)

## This PR does the following:

- Removes canonical url for old DC in anticipation of reverse proxy launch

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

- Check `<head>`

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3264]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ