### PR TITLE
No ref: Add unique key so images re-render on Card

### DIFF
--- a/app/src/components/card/card.tsx
+++ b/app/src/components/card/card.tsx
@@ -45,6 +45,7 @@ export const Card = forwardRef<HTMLDivElement, DCCardProps>(
       <ChakraCard
         ref={ref}
         id={`card-${identifier}`}
+        key={record.imageID}
         mainActionLink={record.url}
         imageProps={{
           component: <CardImage imageHeight={imageHeight} record={record} />,


### PR DESCRIPTION
## Ticket:

N/A, hot fix

## This PR does the following:

- Fixes the issue of images not re-rendering on pagination by adding `key` to the `Card`

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.
