### PR TITLE
fix division title on division landing pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored Repo API handler with added timeout errors (DR-3251)
 - Removed canonical tag to old DC (DR-3264)
 
+
+### Fixed
+- fixed division titles on division landing pages (DR-3274)
+
 ## [0.1.16] 2024-10-31
 
 ### Updated

--- a/app/src/components/pages/divisionPage/divisionPage.tsx
+++ b/app/src/components/pages/divisionPage/divisionPage.tsx
@@ -62,7 +62,7 @@ export default function DivisionPage({ data }: any) {
       breadcrumbs={[
         { text: "Home", url: "/" },
         { text: "Divisions", url: "/divisions" },
-        { text: `${title}`, url: `/divisions/${data.slug}` },
+        { text: `${data.name}`, url: `/divisions/${data.slug}` },
       ]}
       adobeAnalyticsPageName={pageName}
     >
@@ -86,7 +86,7 @@ export default function DivisionPage({ data }: any) {
           gap: "m",
         }}
       >
-        <Heading level="h1" text={title} subtitle={data.summary} />
+        <Heading level="h1" text={data.name} subtitle={data.summary} />
         <Link
           type="standalone"
           target="_blank"

--- a/app/src/components/pages/divisionPage/divisionPage.tsx
+++ b/app/src/components/pages/divisionPage/divisionPage.tsx
@@ -16,7 +16,7 @@ import React, { useEffect, useState, useRef } from "react";
 import PageLayout from "../../pageLayout/pageLayout";
 import { headerBreakpoints } from "../../../utils/breakpoints";
 import { CardsGrid } from "../../grids/cardsGrid";
-import { slugToString, totalNumPages } from "../../../utils/utils";
+import { totalNumPages } from "../../../utils/utils";
 import useBreakpoints from "../../../hooks/useBreakpoints";
 import { DC_URL } from "@/src/config/constants";
 import { Lane as DCLane } from "../../lane/lane";
@@ -25,7 +25,6 @@ import LaneLoading from "../../lane/laneLoading";
 export default function DivisionPage({ data }: any) {
   const params = useParams();
   const slug = params.slug as string;
-  const title = slugToString(slug);
   const pageName = `divisions|${slug}`;
   const [isLoaded, setIsLoaded] = useState(false);
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -10,10 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Updated cards to use Next Image (DR-3056)
+- Refactored Repo API handler with added timeout errors (DR-3251)
+- Removed canonical tag to old DC (DR-3264)
+
+## [0.1.16] 2024-10-31
+
+### Updated
+
 - Updated links in QA to point internally for reverse proxy (DR-3237)
 - Updated how env vars are read for New Relic Browser implementation (DR-3235)
-- Updated 500 and 404 error page designs, adding link to open feedback box (DR-3203)
 - Refactored collections/items grid into one `CardsGrid` component (DR-3193)
+- Updated 500 and 404 error page designs, adding link to open feedback box (DR-3203)
 
 ## [0.1.15] 2024-10-10
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3274](https://newyorkpubliclibrary.atlassian.net/browse/DR-3274)

## This PR does the following:

- uses the data returned from repo api for the title and breadcrumb data instead of the slug

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- Lana mentioned the title gets cut off but I only see that in the breadcrumb? am I missing something?

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->
locally

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3274]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ