### PR TITLE
DR-3273: Optimize Open Graph title tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Updated
+
 - Updated cards to use Next Image (DR-3056)
 - Refactored Repo API handler with added timeout errors (DR-3251)
 - Removed canonical tag to old DC (DR-3264)
 - Refactored Adobe Analytics page names (DR-3257)
 - Updated New Relic server configurations to its default settings to capture transactions (DR-3261)
+- Updated metadata to include specific Open Graph titles (DR-3273)
 
 ### Fixed
 

--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -15,6 +15,9 @@ export async function generateMetadata({
   const slug = params.slug; //  TODO: this needs to support both a slug or a uuid. we will need to update this later to check if slug is a uuid and then get the slugified title of the collection
   return {
     title: `${slug} - NYPL Digital Collections`,
+    openGraph: {
+      title: `${slug} - NYPL Digital Collections`,
+    },
   };
 }
 

--- a/app/collections/lane/[slug]/page.tsx
+++ b/app/collections/lane/[slug]/page.tsx
@@ -10,10 +10,12 @@ type LaneProps = {
 export async function generateMetadata({
   params,
 }: LaneProps): Promise<Metadata> {
-  const slug = params.slug;
   const title = slugToString(params.slug);
   return {
     title: `${title} - NYPL Digital Collections`,
+    openGraph: {
+      title: `${title} - NYPL Digital Collections`,
+    },
   };
 }
 

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -5,6 +5,9 @@ import { mockCollectionCards } from "__tests__/__mocks__/data/mockCollectionCard
 
 export const metadata: Metadata = {
   title: "Collections - NYPL Digital Collections",
+  openGraph: {
+    title: "Collections - NYPL Digital Collections",
+  },
 };
 
 export default async function Collections() {

--- a/app/divisions/[slug]/page.tsx
+++ b/app/divisions/[slug]/page.tsx
@@ -17,6 +17,9 @@ export async function generateMetadata({
   const slug = slugToString(params.slug);
   return {
     title: `${slug} - NYPL Digital Collections`,
+    openGraph: {
+      title: `${slug} - NYPL Digital Collections`,
+    },
   };
 }
 

--- a/app/divisions/page.tsx
+++ b/app/divisions/page.tsx
@@ -6,6 +6,9 @@ import { redirect } from "next/navigation";
 
 export const metadata: Metadata = {
   title: "Divisions - NYPL Digital Collections",
+  openGraph: {
+    title: "Divisions - NYPL Digital Collections",
+  },
 };
 
 export default async function Divisions() {

--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -26,6 +26,9 @@ export async function generateMetadata({
   params.item = item;
   return {
     title: `${item.title} - NYPL Digital Collections`, //should be item title
+    openGraph: {
+      title: `${item.title} - NYPL Digital Collections`,
+    },
   };
 }
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -11,14 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated cards to use Next Image (DR-3056)
 - Refactored Repo API handler with added timeout errors (DR-3251)
 - Removed canonical tag to old DC (DR-3264)
-<<<<<<< HEAD
-- Updated New Relic server configurations to its default settings to capture transactions (DR-3261)
-=======
 - Refactored Adobe Analytics page names (DR-3257)
+- Updated New Relic server configurations to its default settings to capture transactions (DR-3261)
 
 ### Fixed
-- fixed division titles on division landing pages (DR-3274)
->>>>>>> main
+
+- Fixed division titles on division landing pages (DR-3274)
 
 ## [0.1.16] 2024-10-31
 


### PR DESCRIPTION
## Ticket:

Resolves JIRA ticket [DR-3273](https://newyorkpubliclibrary.atlassian.net/browse/DR-3273)

## This PR does the following:

- Adds specific Open Graph title tags to metadata, so that shared pages have their own title instead of the generic "NYPL Digital Collections"

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Check the `<head>` on a page with a slug

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3273]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ