### PR TITLE
hotfix to fix the collection card urls

### DIFF
--- a/app/src/models/collectionCard.ts
+++ b/app/src/models/collectionCard.ts
@@ -16,10 +16,7 @@ export class CollectionCardModel {
   constructor(data: any) {
     this.uuid = data.uuid;
     this.title = data.title;
-    this.url =
-      process.env.APP_ENV === "development" || process.env.APP_ENV === "qa"
-        ? `/collections/${stringToSlug(data.title)}`
-        : data.url;
+    this.url = data.url.replace("https://digitalcollections.nypl.org", "");
     this.imageID = data.image_id || data.imageID;
     this.imageURL = imageURL(data.imageID, "full", "288,", "0");
     this.numberOfDigitizedItems =


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3288)](https://newyorkpubliclibrary.atlassian.net/browse/DR-3288)

## This PR does the following:

- uses the URL returned by Repo API instead of the title to generate the card links

## Notes
- The url was using the title in only dev and qa, I remember setting this for the interal linking changing. Good thing we caught this now. 

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- decided to use '.replace("https://digitalcollections.nypl.org",'') to return the path of the url to avoid breaking the links in the RP.

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->
Locally to make sure the links generate correctly (don't have multiple ''//' or 'digitalcollections.nypl.org'). However, this needs to be and can really only be formally be tested in QA.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
