### PR TITLE
Hot fix: Item cards use uuid urls

### DIFF
--- a/app/src/models/itemCard.ts
+++ b/app/src/models/itemCard.ts
@@ -10,10 +10,7 @@ export class ItemCardModel {
   constructor(data: any) {
     this.uuid = data.uuid;
     this.title = data.title;
-    this.url =
-      process.env.APP_ENV === "development" || process.env.APP_ENV === "qa"
-        ? `/items/${data.uuid}`
-        : data.href || data.url;
+    this.url = `/items/${data.uuid}`;
     this.imageID = data.imageID;
     this.imageURL = imageURL(data.imageID, "full", "288,", "0");
   }


### PR DESCRIPTION
## This PR does the following:

- Updates the url on item cards to be exclusively the uuid, rather than the `href` or `url`. This helps us debug since we are only expecting one thing and it's not environment dependent


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
