### PR TITLE
Hot fix: Soft launch divisions, more collection url debugging

### DIFF
--- a/app/src/models/collectionCard.ts
+++ b/app/src/models/collectionCard.ts
@@ -1,6 +1,5 @@
 // import { CollectionCardData } from "app/types/Collection";
 import { imageURL } from "../utils/utils";
-import { stringToSlug } from "../utils/utils";
 import { parseBoolean } from "../utils/utils";
 
 // TODO: Connect to typescript interface for CollectionCardData
@@ -16,7 +15,7 @@ export class CollectionCardModel {
   constructor(data: any) {
     this.uuid = data.uuid;
     this.title = data.title;
-    this.url = data.url.replace("https://digitalcollections.nypl.org", "");
+    this.url = `/collections/${data.uuid}`;
     this.imageID = data.image_id || data.imageID;
     this.imageURL = imageURL(data.imageID, "full", "288,", "0");
     this.numberOfDigitizedItems =

--- a/middleware.tsx
+++ b/middleware.tsx
@@ -14,8 +14,6 @@ export const config = {
   matcher: [
     "/collections",
     "/collections/:path*",
-    "/divisions",
-    "/divisions/:path*",
     "/items/:path*",
     "/search/:path*",
   ],


### PR DESCRIPTION
## This PR does the following:

- Removes `/divisions` and `/divisions/[slug]` from middleware, effectively soft launching these pages on the reverse proxy
- Updates collection model to use uuid url on card, which seems a lot less prone to be broken

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
