### PR TITLE
Release 0.1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.19] 2024-11-18
+
+## Updated
+
+- Updated collection card urls to use uuid
+- Moved `/divisions` and `/divisions/[slug]` from behind middleware, now accessible
+
+## [0.1.18] 2024-11-18
+
+## Updated
+
+- Updated item card urls to use uuid
+- Updated collection card urls to use legacy url
+
 ## [0.1.17] 2024-11-14
 
 ### Updated

--- a/app/src/models/collectionCard.ts
+++ b/app/src/models/collectionCard.ts
@@ -16,10 +16,7 @@ export class CollectionCardModel {
   constructor(data: any) {
     this.uuid = data.uuid;
     this.title = data.title;
-    this.url =
-      process.env.APP_ENV === "development" || process.env.APP_ENV === "qa"
-        ? `/collections/${stringToSlug(data.title)}`
-        : data.url;
+    this.url = data.url.replace("https://digitalcollections.nypl.org", "");
     this.imageID = data.image_id || data.imageID;
     this.imageURL = imageURL(data.imageID, "full", "288,", "0");
     this.numberOfDigitizedItems =

--- a/app/src/models/collectionCard.ts
+++ b/app/src/models/collectionCard.ts
@@ -1,6 +1,5 @@
 // import { CollectionCardData } from "app/types/Collection";
 import { imageURL } from "../utils/utils";
-import { stringToSlug } from "../utils/utils";
 import { parseBoolean } from "../utils/utils";
 
 // TODO: Connect to typescript interface for CollectionCardData
@@ -16,7 +15,7 @@ export class CollectionCardModel {
   constructor(data: any) {
     this.uuid = data.uuid;
     this.title = data.title;
-    this.url = data.url.replace("https://digitalcollections.nypl.org", "");
+    this.url = `/collections/${data.uuid}`;
     this.imageID = data.image_id || data.imageID;
     this.imageURL = imageURL(data.imageID, "full", "288,", "0");
     this.numberOfDigitizedItems =

--- a/app/src/models/itemCard.ts
+++ b/app/src/models/itemCard.ts
@@ -10,10 +10,7 @@ export class ItemCardModel {
   constructor(data: any) {
     this.uuid = data.uuid;
     this.title = data.title;
-    this.url =
-      process.env.APP_ENV === "development" || process.env.APP_ENV === "qa"
-        ? `/items/${data.uuid}`
-        : data.href || data.url;
+    this.url = `/items/${data.uuid}`;
     this.imageID = data.imageID;
     this.imageURL = imageURL(data.imageID, "full", "288,", "0");
   }

--- a/middleware.tsx
+++ b/middleware.tsx
@@ -14,8 +14,6 @@ export const config = {
   matcher: [
     "/collections",
     "/collections/:path*",
-    "/divisions",
-    "/divisions/:path*",
     "/items/:path*",
     "/search/:path*",
   ],


### PR DESCRIPTION
## [0.1.19] 2024-11-18

## Updated

- Updated collection card urls to use uuid
- Moved `/divisions` and `/divisions/[slug]` from behind middleware, now accessible