### PR TITLE
Hot fix: Rewinding collection links

### DIFF
--- a/app/src/models/collectionCard.ts
+++ b/app/src/models/collectionCard.ts
@@ -17,7 +17,7 @@ export class CollectionCardModel {
     this.title = data.title;
     this.url =
       process.env.APP_ENV === "production"
-        ? data.url
+        ? `https://digitalcollections.nypl.org/collections/${data.uuid}`
         : `/collections/${data.uuid}`;
     this.imageID = data.image_id || data.imageID;
     this.imageURL = imageURL(data.imageID, "full", "288,", "0");

--- a/app/src/models/collectionCard.ts
+++ b/app/src/models/collectionCard.ts
@@ -15,7 +15,10 @@ export class CollectionCardModel {
   constructor(data: any) {
     this.uuid = data.uuid;
     this.title = data.title;
-    this.url = `/collections/${data.uuid}`;
+    this.url =
+      process.env.APP_ENV === "production"
+        ? data.url.replace("https://digitalcollections.nypl.org", "")
+        : `/collections/${data.uuid}`;
     this.imageID = data.image_id || data.imageID;
     this.imageURL = imageURL(data.imageID, "full", "288,", "0");
     this.numberOfDigitizedItems =

--- a/app/src/models/collectionCard.ts
+++ b/app/src/models/collectionCard.ts
@@ -17,7 +17,7 @@ export class CollectionCardModel {
     this.title = data.title;
     this.url =
       process.env.APP_ENV === "production"
-        ? data.url.replace("https://digitalcollections.nypl.org", "")
+        ? data.url
         : `/collections/${data.uuid}`;
     this.imageID = data.image_id || data.imageID;
     this.imageURL = imageURL(data.imageID, "full", "288,", "0");


### PR DESCRIPTION
- Hardcodes collection card urls to go back to legacy DC
