### PR TITLE
DR-3297: Rewrite getHomePageData to no longer use `items/counts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Updated
+
+- Refactor `getHomePageData` to pull item counts from collection endpoints (DR-3297)
+
 ## [0.2.0] 2024-11-20
 
 ### Removed

--- a/app/src/components/pages/divisionsPage/divisionsPage.tsx
+++ b/app/src/components/pages/divisionsPage/divisionsPage.tsx
@@ -33,7 +33,7 @@ export default function DivisionsPage({ summary, divisions }: DivisionsProps) {
       ]}
       adobeAnalyticsPageName={createAdobeAnalyticsPageName("divisions")}
     >
-      {divisions && divisions.length > 0 ? (
+      {divisions && divisions?.length > 0 ? (
         <>
           <Box
             sx={{

--- a/app/src/utils/api.ts
+++ b/app/src/utils/api.ts
@@ -6,6 +6,7 @@ import appConfig from "../../../appConfig";
 import defaultFeaturedItems from "../data/defaultFeaturedItemData";
 import { CARDS_PER_PAGE } from "../config/constants";
 import { DC_URL } from "../config/constants";
+import { getItemsCountFromCollections } from "./itemCount";
 
 export const getHomePageData = async () => {
   const randomNumber = Math.floor(Math.random() * 2);
@@ -15,7 +16,8 @@ export const getHomePageData = async () => {
   const allCollectionUUIDs: string[] = lanes.reduce((acc, lane) => {
     return acc.concat(lane.collections.map((collection) => collection.uuid));
   }, [] as string[]);
-  const uuidtoItemCountMap = await getItemsCountFromUUIDs(allCollectionUUIDs);
+  const uuidtoItemCountMap =
+    await getItemsCountFromCollections(allCollectionUUIDs);
 
   // Update the collections for each lane with the number of items
   const updatedLanes = lanes.map((lane) => {

--- a/app/src/utils/itemCount.test.tsx
+++ b/app/src/utils/itemCount.test.tsx
@@ -1,0 +1,67 @@
+import { apiResponse } from "./api";
+import { getItemsCountFromCollections } from "./itemCount";
+
+jest.mock("./api");
+
+describe("getItemsCountFromCollections()", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return the correct numItems for each UUID", async () => {
+    (apiResponse as jest.Mock)
+      .mockResolvedValueOnce(
+        Promise.resolve({
+          status: 200,
+          numItems: 10,
+        })
+      )
+      .mockResolvedValueOnce(
+        Promise.resolve({
+          status: 200,
+          numItems: 20,
+        })
+      );
+
+    const uuids = ["uuid1", "uuid2"];
+
+    const results = await getItemsCountFromCollections(uuids);
+
+    expect(results).toEqual({
+      uuid1: 10,
+      uuid2: 20,
+    });
+  });
+
+  it("should handle server error gracefully", async () => {
+    const uuids = ["uuid1"];
+    (apiResponse as jest.Mock).mockRejectedValueOnce(
+      Promise.resolve({
+        status: 400,
+      })
+    );
+    const results = await getItemsCountFromCollections(uuids);
+    expect(results).toEqual({
+      uuid1: 0,
+    });
+  });
+
+  it("should handle missing numItems field gracefully", async () => {
+    const uuids = ["uuid1"];
+    (apiResponse as jest.Mock).mockResolvedValueOnce(
+      Promise.resolve({
+        status: 200,
+      })
+    );
+    const results = await getItemsCountFromCollections(uuids);
+    expect(results).toEqual({
+      uuid1: 0,
+    });
+  });
+
+  it("should handle an empty array of UUIDs", async () => {
+    const uuids = [];
+    const results = await getItemsCountFromCollections(uuids);
+    expect(results).toEqual({});
+  });
+});

--- a/app/src/utils/itemCount.ts
+++ b/app/src/utils/itemCount.ts
@@ -7,17 +7,17 @@ import { apiResponse } from "./api";
 export const getItemsCountFromCollections = async (uuids: string[]) => {
   const results = {};
   const apiUrl = `${process.env.API_URL}/api/v2/collections/`;
-  await Promise.all(
-    uuids.map(async (uuid) => {
-      try {
-        const response = await apiResponse(`${apiUrl}${uuid}`);
-        const numItems = response.numItems || 0;
-        results[uuid] = numItems;
-      } catch (error) {
-        console.error(`Error fetching collection ${uuid}:`, error.message);
-        results[uuid] = 0;
-      }
-    })
-  );
+  const fetchPromises = uuids.map(async (uuid) => {
+    try {
+      const response = await apiResponse(`${apiUrl}${uuid}`);
+      const numItems = response.numItems || 0;
+      results[uuid] = numItems;
+    } catch (error) {
+      console.error(`Error fetching collection ${uuid}:`, error.message);
+      results[uuid] = 0;
+    }
+  });
+
+  await Promise.all(fetchPromises);
   return results;
 };

--- a/app/src/utils/itemCount.ts
+++ b/app/src/utils/itemCount.ts
@@ -1,0 +1,23 @@
+import { apiResponse } from "./api";
+
+/**
+ * Returns a map of collection uuids with corresponding item counts.
+ * @param {string[]} uuids - collection uuids
+ */
+export const getItemsCountFromCollections = async (uuids: string[]) => {
+  const results = {};
+  const apiUrl = `${process.env.API_URL}/api/v2/collections/`;
+  await Promise.all(
+    uuids.map(async (uuid) => {
+      try {
+        const response = await apiResponse(`${apiUrl}${uuid}`);
+        const numItems = response.numItems || 0;
+        results[uuid] = numItems;
+      } catch (error) {
+        console.error(`Error fetching collection ${uuid}:`, error.message);
+        results[uuid] = 0;
+      }
+    })
+  );
+  return results;
+};


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3297](https://newyorkpubliclibrary.atlassian.net/browse/DR-3297)

## This PR does the following:

- Adds new `getItemsCountFromCollections()` which hits `/collections/{uuid}`  to get `numItems` for each passed `uuid` (really only a helper for `getHomePageData`)
- NOTE: this is declared and tested in a separate file because of Jest mocking conventions. When I get to this https://newyorkpubliclibrary.atlassian.net/browse/DR-3271 I'll refactor all of the API helper tests and it'll be less weird

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

Go to the homepage and think to yourself, is this slower than usual 

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3297]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ