### PR TITLE
DR-3297: Restore API request timeout 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- removed unneccessary variables post reverse proxy launch
+- Removed unnecessary variables post reverse proxy launch
 - Removed new relic files from frontend (DR-3311)
 
 ### Added
@@ -18,9 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
-- refactored implementation of default featured item & updated default number of digitized items (DR-3305)
+- Refactored implementation of default featured item & updated default number of digitized items (DR-3305)
 - Update thumbnail logic so thumbnails are never restricted (DR-3293)
 - Update feedback form credentials to use official DR service account (DR-2794)
+- Update timeout on API request to 10 seconds (DR-3304)
 
 ## [0.2.4] 2024-11-26
 

--- a/app/src/utils/fetchApi.test.tsx
+++ b/app/src/utils/fetchApi.test.tsx
@@ -106,12 +106,12 @@ describe("fetchApi", () => {
 
     const apiCall = fetchApi(mockApiUrl);
 
-    jest.advanceTimersByTime(14000);
+    jest.advanceTimersByTime(10000);
 
     await expect(apiCall).rejects.toEqual(
       new Error("fetchApi: Request timed out")
     );
 
     jest.useRealTimers();
-  }, 20000);
+  }, 15000);
 });

--- a/app/src/utils/fetchApi.ts
+++ b/app/src/utils/fetchApi.ts
@@ -1,6 +1,6 @@
 /**
  * Makes a GET or POST request to the Repo API and returns the response.
- * Times out at 14 seconds to prevent 504 crash.
+ * Times out at 10 seconds to prevent 504 crash.
  * @param {string} apiUrl - The URL for the API request.
  * @param {object} options - Options for the request:
  *   - method: "GET" or "POST" (default is "GET").
@@ -28,7 +28,7 @@ export const fetchApi = async (
     apiUrl += queryString;
   }
 
-  const timeout = 14000;
+  const timeout = 10000;
 
   const fetchWithTimeout = (url: string, opts: RequestInit) => {
     return Promise.race([


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3304](https://newyorkpubliclibrary.atlassian.net/browse/DR-3297)

## This PR does the following:

- Reduces the timeout on Repo API requests to 10 seconds, following investigation of average response time
    - This is with input from team– general discomfort with it being shorter than 10, but this can be revisited as Repo API evolves

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3304]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ