### PR TITLE
DR-3322: Expand desktop nav on scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update thumbnail logic so thumbnails are never restricted (DR-3293)
 - Update feedback form credentials to use official DR service account (DR-2794)
 - Update timeout on API request to 10 seconds (DR-3304)
+- Update header to expand on scroll up on desktop (DR-3322)
 
 ## [0.2.4] 2024-11-26
 

--- a/app/src/components/header/header.tsx
+++ b/app/src/components/header/header.tsx
@@ -61,10 +61,10 @@ const Header = () => {
           <DCLogo isMobile={false} />
           <Box
             sx={{
-              display: "none",
+              display: "block",
               [`@media screen and (min-width: ${headerBreakpoints.smTablet}px)`]:
                 {
-                  display: isScrolled ? "block" : "none",
+                  display: isScrollingUp ? "block" : "none",
                 },
               [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]:
                 {
@@ -117,7 +117,7 @@ const Header = () => {
               display: "none",
               [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]:
                 {
-                  display: isScrolled ? "block" : "none",
+                  display: isScrollingUp ? "block" : "none",
                 },
             }}
           >

--- a/app/src/components/header/header.tsx
+++ b/app/src/components/header/header.tsx
@@ -62,10 +62,6 @@ const Header = () => {
           <Box
             sx={{
               display: "block",
-              [`@media screen and (min-width: ${headerBreakpoints.smTablet}px)`]:
-                {
-                  display: isScrollingUp ? "block" : "none",
-                },
               [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]:
                 {
                   display: "none",


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3322](https://newyorkpubliclibrary.atlassian.net/browse/DR-3322)

## This PR does the following:

- Adjusts header behavior so that it expands to show nav links on scroll up on tablet/desktop (previously only did this on mobile)

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Scroll down and then up :)

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Don't think this needs to be flagged since this behavior is already approved on mobile

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3322]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ