### PR TITLE
DR-3332 update google-site-verification meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update feedback form credentials to use official DR service account (DR-2794)
 - Update timeout on API request to 10 seconds (DR-3304)
 - Update header to expand on scroll up on desktop (DR-3322)
+- Update google-site-verification meta tag (DR-3332)
 
 ## [0.2.4] 2024-11-26
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
     ],
   },
   verification: {
-    google: "_shbOK1otHA_eFNFgJsOwITZrWQwRg4wr8nmrJPNVDM",
+    google: "oLXa8JvslCKNxtg-fzL1aL8Q_yNmWvxExwaGs8UgyRM",
   },
 };
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update feedback form credentials to use official DR service account (DR-2794)
 - Update timeout on API request to 10 seconds (DR-3304)
 - Update header to expand on scroll up on desktop (DR-3322)
+- Update google-site-verification meta tag (DR-3332)
 
 ## [0.2.4] 2024-11-26
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3332](https://newyorkpubliclibrary.atlassian.net/browse/DR-3332)

## This PR does the following:

- Updates the existing google-site-verification meta tag to a new value

