### PR TITLE
DR-3357: Correcting `/collections` 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `/healthcheck` endpoint (DR-3304)
 
 ### Updated
+
 - Update copy of sort menu for the all collections page (DR-3323)
 - Update `/collections` page to fetch data from Repo API and meet designs (DR-3100)
 - Update `/collections/lane/:slug` page to fetch data from Repo API (DR-3701)
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update timeout on API request to 10 seconds (DR-3304)
 - Update header to expand on scroll up on desktop (DR-3322)
 - Update google-site-verification meta tag (DR-3332)
+- Updated `/collections` 404 logic (DR-3357)
 
 ## [0.2.4] 2024-11-26
 

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -26,7 +26,7 @@ export default async function Collections({ searchParams }: CollectionsProps) {
   // Repo API returns 404s within the data.
   if (
     data?.headers?.code === "404" &&
-    data?.headers?.message !== "No collections found"
+    data?.headers?.message === "No collections found"
   ) {
     redirect("/404");
   }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3357](https://newyorkpubliclibrary.atlassian.net/browse/DR-3357)

## This PR does the following:

- 404 redirect was incorrectly checking that the message was NOT "No collections found", now fixed

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3357]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ