### PR TITLE
DR-3357 (pt 2): Collections "no results" edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update timeout on API request to 10 seconds (DR-3304)
 - Update header to expand on scroll up on desktop (DR-3322)
 - Update google-site-verification meta tag (DR-3332)
-- Updated `/collections` 404 logic (DR-3357)
+- Updated `/collections` no results logic (DR-3357)
 
 ## [0.2.4] 2024-11-26
 

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -26,7 +26,7 @@ export default async function Collections({ searchParams }: CollectionsProps) {
   // Repo API returns 404s within the data.
   if (
     data?.headers?.code === "404" &&
-    data?.headers?.message === "No collections found"
+    data?.headers?.message !== "No collections found"
   ) {
     redirect("/404");
   }

--- a/app/src/components/pages/collectionsPage/collectionsPage.tsx
+++ b/app/src/components/pages/collectionsPage/collectionsPage.tsx
@@ -230,7 +230,10 @@ export function CollectionsPage({ data, params, renderCollections }) {
         collections.length > 0 ? (
           <CardsGrid records={collections} />
         ) : (
-          <NoResultsFound searchTerm={params.collection_keywords} />
+          <NoResultsFound
+            searchTerm={params.collection_keywords}
+            page={params.page}
+          />
         )
       ) : (
         Array(Math.ceil(collections.length / 4)).fill(

--- a/app/src/components/results/noResultsFound.tsx
+++ b/app/src/components/results/noResultsFound.tsx
@@ -7,9 +7,9 @@ import {
 import styles from "../../styles/Collections.module.css";
 
 export default function NoResultsFound({ searchTerm, page }) {
-  const headingText = `No Results for "${searchTerm}"${
-    page > 1 ? `, page ${page}` : ``
-  }`;
+  const headingText = searchTerm
+    ? `No Results for "${searchTerm}"${page > 1 ? `, page ${page}` : ``}`
+    : "No Results";
   return (
     <Flex
       flexDir="column"

--- a/app/src/components/results/noResultsFound.tsx
+++ b/app/src/components/results/noResultsFound.tsx
@@ -6,8 +6,10 @@ import {
 } from "@nypl/design-system-react-components";
 import styles from "../../styles/Collections.module.css";
 
-export default function NoResultsFound({ searchTerm }) {
-  const headingText = `No Results for "${searchTerm}"`;
+export default function NoResultsFound({ searchTerm, page }) {
+  const headingText = `No Results for "${searchTerm}"${
+    page > 1 ? `, page ${page}` : ``
+  }`;
   return (
     <Flex
       flexDir="column"

--- a/app/src/components/results/noResultsFound.tsx
+++ b/app/src/components/results/noResultsFound.tsx
@@ -8,8 +8,9 @@ import styles from "../../styles/Collections.module.css";
 
 export default function NoResultsFound({ searchTerm, page }) {
   const headingText = searchTerm
-    ? `No Results for "${searchTerm}"${page > 1 ? `, page ${page}` : ``}`
-    : "No Results";
+    ? `No results for "${searchTerm}"
+    ${page > 1 ? `found on page ${page}` : ``}`
+    : "No results";
   return (
     <Flex
       flexDir="column"


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3357](https://newyorkpubliclibrary.atlassian.net/browse/DR-3357)

## This PR does the following:

- Updates `/collections` "no results" to handle edge cases that return 404s
    - Necessary bc Repo API doesn't differentiate between a page number out of bounds 404 and a keyword no results 404

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

** By "invalid keyword" below, I mean a keyword that returns no results.

A search with invalid keyword, no page number = "No results for '[keyword]'":
https://digital-collections-git-dr-3357-correcting-collections-404-nypl.vercel.app/collections?collection_keywords=hello

A search with no keyword, invalid page number = "No results":
https://digital-collections-git-dr-3357-correcting-collections-404-nypl.vercel.app/collections?page=9000

A search with valid keyword, invalid page number = "No results for '[keyword]' found on page [page number]":
https://digital-collections-git-dr-3357-correcting-collections-404-nypl.vercel.app/collections?collection_keywords=collection&page=9000

A search with invalid keyword, invalid page number (any page number would be invalid) = "No results for '[keyword]' found on page [page number]":
https://digital-collections-git-dr-3357-correcting-collections-404-nypl.vercel.app/collections?collection_keywords=hello&page=9000

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3357]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ