### PR TITLE
DR-3336: Update `fetchApi` to accept cache options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Updated
+
+- Updated `fetchApi` to accept cache strategy/revalidation parameters (DR-3336)
+
 ## [0.2.6] 2025-1-13
 
 ### Updated

--- a/app/src/utils/fetchApi.test.tsx
+++ b/app/src/utils/fetchApi.test.tsx
@@ -84,6 +84,32 @@ describe("fetchApi", () => {
     expect(response).toEqual("mockGetResponseWithParams");
   });
 
+  it("adds caching options to GET requests", async () => {
+    const mockResponse = { nyplAPI: { response: "mockResponse" } };
+    (global as any).fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => mockResponse,
+      })
+    ) as jest.Mock;
+
+    const response = await fetchApi(mockApiUrl, {
+      cacheTime: 3600,
+      cacheSetting: "no-store",
+    });
+    expect(fetch).toHaveBeenCalledWith(mockApiUrl, {
+      method: "GET",
+      headers: {
+        Authorization: `Token token=${mockAuthToken}`,
+      },
+      body: undefined,
+      cache: "no-store",
+      next: { revalidate: 3600 },
+    });
+    expect(response).toEqual("mockResponse");
+  });
+
   it("throws an error for non-200 status", async () => {
     (global as any).fetch = jest.fn(() =>
       Promise.resolve({

--- a/app/src/utils/fetchApi.ts
+++ b/app/src/utils/fetchApi.ts
@@ -15,7 +15,8 @@ export const fetchApi = async (
     method?: "GET" | "POST";
     params?: { [key: string]: any };
     body?: any;
-  }
+  },
+  cacheTime?: number
 ) => {
   const apiKey = process.env.AUTH_TOKEN;
   const method = options?.method || "GET";
@@ -48,6 +49,7 @@ export const fetchApi = async (
       method,
       headers,
       body: method === "POST" ? JSON.stringify(options?.body) : undefined,
+      ...(cacheTime && { next: { revalidate: cacheTime } }),
     })) as Response;
     if (!response.ok && response.status !== 200) {
       throw new Error(

--- a/app/src/utils/fetchApi.ts
+++ b/app/src/utils/fetchApi.ts
@@ -7,6 +7,8 @@ import logger from "logger";
  *   - method: "GET" or "POST" (default is "GET").
  *   - params: URL parameters for GET requests.
  *   - body: Body data for POST requests.
+ *   - cacheTime: The revalidation period (in seconds).
+ *   - cacheSetting: The cache strategy, default is 'force-cache'.
  * @returns {Promise<any>} - The API response.
  */
 export const fetchApi = async (
@@ -15,8 +17,9 @@ export const fetchApi = async (
     method?: "GET" | "POST";
     params?: { [key: string]: any };
     body?: any;
-  },
-  cacheTime?: number
+    cacheTime?: number;
+    cacheSetting?: RequestCache;
+  }
 ) => {
   const apiKey = process.env.AUTH_TOKEN;
   const method = options?.method || "GET";
@@ -33,6 +36,7 @@ export const fetchApi = async (
   const timeout = 10000;
 
   const fetchWithTimeout = (url: string, opts: RequestInit) => {
+    console.log(url, opts);
     return Promise.race([
       fetch(url, opts),
       new Promise((_, reject) =>
@@ -49,7 +53,8 @@ export const fetchApi = async (
       method,
       headers,
       body: method === "POST" ? JSON.stringify(options?.body) : undefined,
-      ...(cacheTime && { next: { revalidate: cacheTime } }),
+      ...(options?.cacheTime && { next: { revalidate: options.cacheTime } }),
+      ...(options?.cacheSetting && { cache: options.cacheSetting }),
     })) as Response;
     if (!response.ok && response.status !== 200) {
       throw new Error(

--- a/app/src/utils/fetchApi.ts
+++ b/app/src/utils/fetchApi.ts
@@ -7,8 +7,8 @@ import logger from "logger";
  *   - method: "GET" or "POST" (default is "GET").
  *   - params: URL parameters for GET requests.
  *   - body: Body data for POST requests.
- *   - cacheTime: The revalidation period (in seconds).
- *   - cacheSetting: The cache strategy, default is 'force-cache'.
+ *   - cacheTime: The serverside revalidation period (in seconds).
+ *   - cacheSetting: The browser cache strategy, default is 'force-cache'.
  * @returns {Promise<any>} - The API response.
  */
 export const fetchApi = async (


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3336](https://newyorkpubliclibrary.atlassian.net/browse/DR-3336)

## This PR does the following:

- In anticipation of changing the DCF caching strategy, updates `fetchApi` to accept time-based revalidation and a browser cache setting

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- Do we want to prevent our future selves from passing confusing/conflicting cache options (for example, as in the test, `cache: 'no-store'` with `next: {revalidate: 3600}`– setting time revalidation on the serverside request means nothing if the browser won't use cached responses at all) or add a `console.warn` or something?

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3336]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ