### PR TITLE
DR-3378: Public domain link correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Updated
+
+- Public domain link correction (DR-3378)
+
 ## [0.2.6] 2025-1-13
 
 ### Updated

--- a/app/src/components/featuredContent/featuredContent.test.tsx
+++ b/app/src/components/featuredContent/featuredContent.test.tsx
@@ -16,7 +16,10 @@ describe("Featured Content component renders with expected props", () => {
       );
 
       const button = within(component).getByTestId("featured-learn-more");
-      expect(button).toHaveAttribute("href", "https://publicdomain.nypl.org");
+      expect(button).toHaveAttribute(
+        "href",
+        "https://www.nypl.org/research/resources/public-domain-collections"
+      );
     });
   });
 

--- a/app/src/data/featuredContentData.ts
+++ b/app/src/data/featuredContentData.ts
@@ -5,7 +5,7 @@ const featuredContentData: FeaturedContentDataType[] = [
     heading: "Spotlight on the public domain",
     overline: "Featured",
     text: "The New York Public Library recently enhanced access to all public domain items in Digital Collections so that everyone has the freedom to enjoy and reuse these materials in almost limitless ways.",
-    link: "https://publicdomain.nypl.org",
+    link: "https://www.nypl.org/research/resources/public-domain-collections",
     buttonText: "Learn more",
     buttonId: "featured-learn-more",
     ariaLabel: "Learn more about the public domain",


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3378](https://newyorkpubliclibrary.atlassian.net/browse/DR-3378)

## This PR does the following:

- Corrects link to page on public domain resources from the `FeaturedContent` on homepage

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3378]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ