### PR TITLE
No ref: DC custom search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added custom searchbar to handle search submit
+
 ## [0.3.1] 2025-01-30
 
 ### Updated

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -32,7 +32,6 @@ export default async function Collections({ searchParams }: CollectionsProps) {
   ) {
     redirect("/404");
   }
-  console.log("page rendering client component");
 
   return (
     <PageLayout

--- a/app/src/components/pages/collectionsPage/collectionsPage.tsx
+++ b/app/src/components/pages/collectionsPage/collectionsPage.tsx
@@ -83,7 +83,8 @@ export function CollectionsPage({ data, collectionSearchParams }) {
           subtitle="Explore the New York Public Library's diverse collections, including digitized photographs, manuscripts, maps, and more. Start exploring by using the search bar below or browse through the collections."
         />
         <DCSearchBar
-          id={"search-collections"}
+          id="search-collections"
+          labelText="Search collections"
           maxWrapperWidth="462px"
           textInputProps={{
             id: "textinput",

--- a/app/src/components/pages/collectionsPage/collectionsPage.tsx
+++ b/app/src/components/pages/collectionsPage/collectionsPage.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   Heading,
   HorizontalRule,
-  SearchBar,
   Menu,
   Pagination,
   Flex,
@@ -23,6 +22,7 @@ import {
 } from "@/src/config/constants";
 import { SearchManagerFactory } from "@/src/utils/searchManager";
 import { headerBreakpoints } from "@/src/utils/breakpoints";
+import DCSearchBar from "../../search/dcSearchBar";
 
 export function CollectionsPage({ data, collectionSearchParams }) {
   const { push } = useRouter();
@@ -82,41 +82,11 @@ export function CollectionsPage({ data, collectionSearchParams }) {
           text="Collections"
           subtitle="Explore the New York Public Library's diverse collections, including digitized photographs, manuscripts, maps, and more. Start exploring by using the search bar below or browse through the collections."
         />
-        <SearchBar
-          sx={{
-            maxWidth: "462px",
-            flexFlow: "row nowrap",
-            button: {
-              borderRadius: "0px 2px 2px 0px",
-              "> svg": {
-                width: "14px",
-                height: "14px",
-              },
-              paddingTop: "xs",
-              paddingBottom: "xs",
-              paddingLeft: "s !important",
-              paddingRight: "s !important",
-              "> span": {
-                display: "block !important",
-              },
-            },
-            [`@media screen and (max-width: ${headerBreakpoints.lgMobile}px)`]:
-              {
-                button: {
-                  padding: "xs !important",
-                  gap: 0,
-                  "> span": {
-                    display: "none !important",
-                  },
-                  "> svg": {
-                    width: "18px",
-                    height: "18px",
-                  },
-                },
-              },
-          }}
+        <DCSearchBar
           id={"search-collections"}
+          maxWrapperWidth="462px"
           textInputProps={{
+            id: "textinput",
             isClearable: true,
             isClearableCallback: () =>
               collectionSearchManager.handleKeywordChange(DEFAULT_SEARCH_TERM),
@@ -132,8 +102,6 @@ export function CollectionsPage({ data, collectionSearchParams }) {
           onSubmit={() => {
             updateURL(collectionSearchManager.handleSearchSubmit());
           }}
-          labelText="Search collections by title"
-          aria-label="Search collections by title"
         />
       </Box>
 

--- a/app/src/components/pages/collectionsPage/collectionsPage.tsx
+++ b/app/src/components/pages/collectionsPage/collectionsPage.tsx
@@ -84,10 +84,10 @@ export function CollectionsPage({ data, collectionSearchParams }) {
         />
         <DCSearchBar
           id="search-collections"
-          labelText="Search collections"
+          labelText="Search collections by title"
           maxWrapperWidth="462px"
           textInputProps={{
-            id: "textinput",
+            id: "collections-search-text",
             isClearable: true,
             isClearableCallback: () =>
               collectionSearchManager.handleKeywordChange(DEFAULT_SEARCH_TERM),

--- a/app/src/components/pages/collectionsPage/collectionsPage.tsx
+++ b/app/src/components/pages/collectionsPage/collectionsPage.tsx
@@ -28,6 +28,7 @@ export function CollectionsPage({ data, collectionSearchParams }) {
   const { push } = useRouter();
   const pathname = usePathname();
   const headingRef = useRef<HTMLHeadingElement>(null);
+  const isFirstLoad = useRef<boolean>(false);
 
   const [isLoaded, setIsLoaded] = useState(false);
   const totalPages = totalNumPages(data.numResults, data.perPage);
@@ -53,7 +54,11 @@ export function CollectionsPage({ data, collectionSearchParams }) {
 
   useEffect(() => {
     setIsLoaded(true);
-    headingRef.current?.focus();
+    if (isFirstLoad.current) {
+      headingRef.current?.focus();
+    }
+    isFirstLoad.current = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collections]);
 
   return (

--- a/app/src/components/search/dcSearchBar.tsx
+++ b/app/src/components/search/dcSearchBar.tsx
@@ -88,7 +88,7 @@ const SearchBarComponent = forwardRef<HTMLDivElement, SearchBarProps>(
 
     const textInput = textInputProps && (
       <TextInput
-        labelText=""
+        labelText={labelText}
         className="textInput"
         defaultValue={textInputProps?.defaultValue}
         id={textInputProps?.id || `searchbar-textinput-${id}`}
@@ -118,7 +118,7 @@ const SearchBarComponent = forwardRef<HTMLDivElement, SearchBarProps>(
         isDisabled={isDisabled}
         onClick={onSubmit}
         type="submit"
-        aria-label="Search"
+        aria-labelledBy="searchbar-text"
         sx={{
           minWidth: "44px",
           borderLeftRadius: "none",
@@ -161,7 +161,7 @@ const SearchBarComponent = forwardRef<HTMLDivElement, SearchBarProps>(
           name="search"
           size="small"
         />
-        <span>Search</span>
+        <span id="searchbar-text">Search</span>
       </Button>
     );
 

--- a/app/src/components/search/dcSearchBar.tsx
+++ b/app/src/components/search/dcSearchBar.tsx
@@ -8,32 +8,54 @@ import {
 } from "@nypl/design-system-react-components";
 import { headerBreakpoints } from "@/src/utils/breakpoints";
 
-export interface TextInputProps {
+export type TextInputProps = {
+  /** The starting value of the input field. */
   defaultValue?: string;
+  /** ID that other components can cross reference for accessibility purposes */
   id: string;
+  /** Adds a button to clear existing text in the input field. */
   isClearable?: boolean;
+  /** The callback function that is called when the clear button is clicked. */
   isClearableCallback?: () => void;
+  /** Provides text for a `Label` component if `showLabel` is set to true;
+   * populates an `aria-label` attribute if `showLabel` is set to false. */
   labelText: string;
+  /** Used to reference the input element in forms. */
   name?: string;
+  /** The action to perform on the `input`/`textarea`'s onChange function  */
   onChange?: (
     event:
       | React.ChangeEvent<HTMLInputElement>
       | React.ChangeEvent<HTMLTextAreaElement>
   ) => void;
+  /** Regex to query the user input against. */
   pattern?: string;
+  /** Populates the placeholder for the input/textarea elements */
   placeholder?: string;
+  /** Populates the value of the input/textarea elements */
   value?: string;
-}
+};
 
 export interface SearchBarProps {
+  /** The onClick callback function for the `Button` component. */
   buttonOnClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
+  /** ID that other components can cross reference for accessibility purposes */
   id: string;
+  /** Sets children form components in the disabled state. */
   isDisabled?: boolean;
+  /** Sets children form components in the error state. */
   isInvalid?: boolean;
+  /** Sets children form components in the required state. */
   isRequired?: boolean;
+  /** Populates the `aria-label` attribute on the wrapper. */
+  labelText: string;
+  /** Handler function when the form is submitted. */
   onSubmit: (event: React.FormEvent) => void;
+  /** Custom input element to render instead of a `TextInput` element. */
   textInputElement?: JSX.Element;
-  textInputProps?: TextInputProps;
+  /** Required props to render a `TextInput` element. */
+  textInputProps?: TextInputProps | undefined;
+  /** Maximum width of wrapper. */
   maxWrapperWidth?: string;
 }
 
@@ -46,6 +68,7 @@ const SearchBarComponent = forwardRef<HTMLDivElement, SearchBarProps>(
       isRequired = false,
       onSubmit,
       textInputProps,
+      labelText,
       maxWrapperWidth,
     } = props;
 
@@ -145,7 +168,7 @@ const SearchBarComponent = forwardRef<HTMLDivElement, SearchBarProps>(
     return (
       <Box
         role="search"
-        aria-label="Search collections"
+        aria-label={labelText}
         sx={{
           display: "flex",
           marginBottom: {

--- a/app/src/components/search/dcSearchBar.tsx
+++ b/app/src/components/search/dcSearchBar.tsx
@@ -1,0 +1,181 @@
+import React, { forwardRef } from "react";
+import { chakra, ChakraComponent } from "@chakra-ui/react";
+import {
+  TextInput,
+  Box,
+  Button,
+  Icon,
+} from "@nypl/design-system-react-components";
+import { headerBreakpoints } from "@/src/utils/breakpoints";
+
+export interface TextInputProps {
+  defaultValue?: string;
+  id: string;
+  isClearable?: boolean;
+  isClearableCallback?: () => void;
+  labelText: string;
+  name?: string;
+  onChange?: (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>
+  ) => void;
+  pattern?: string;
+  placeholder?: string;
+  value?: string;
+}
+
+export interface SearchBarProps {
+  buttonOnClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
+  id: string;
+  isDisabled?: boolean;
+  isInvalid?: boolean;
+  isRequired?: boolean;
+  onSubmit: (event: React.FormEvent) => void;
+  textInputElement?: JSX.Element;
+  textInputProps?: TextInputProps;
+  maxWrapperWidth?: string;
+}
+
+const SearchBarComponent = forwardRef<HTMLDivElement, SearchBarProps>(
+  (props, ref?) => {
+    const {
+      id,
+      isDisabled = false,
+      isInvalid = false,
+      isRequired = false,
+      onSubmit,
+      textInputProps,
+      maxWrapperWidth,
+    } = props;
+
+    const stateProps = {
+      helperText: "",
+      isDisabled,
+      isInvalid,
+      isRequired,
+      showHelperInvalidText: false,
+      showLabel: false,
+    };
+
+    const inputPlaceholder = textInputProps?.placeholder || "Search terms";
+    const textInputPlaceholder = `${inputPlaceholder} ${
+      isRequired ? "(required)" : ""
+    }`;
+
+    const textInput = textInputProps && (
+      <TextInput
+        labelText=""
+        className="textInput"
+        defaultValue={textInputProps?.defaultValue}
+        id={textInputProps?.id || `searchbar-textinput-${id}`}
+        isClearable={textInputProps?.isClearable}
+        isClearableCallback={textInputProps?.isClearableCallback}
+        name={textInputProps?.name}
+        onChange={textInputProps?.onChange}
+        pattern={textInputProps?.pattern}
+        placeholder={textInputPlaceholder}
+        textInputType="searchBar"
+        type="text"
+        value={textInputProps?.value}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            onSubmit(event);
+          }
+        }}
+        {...stateProps}
+      />
+    );
+
+    const buttonElem = (
+      <Button
+        className="searchButton"
+        buttonType="primary"
+        id={`searchbar-button-${id}`}
+        isDisabled={isDisabled}
+        onClick={onSubmit}
+        type="submit"
+        aria-label="Search"
+        sx={{
+          minWidth: "44px",
+          borderLeftRadius: "none",
+          lineHeight: "1.70",
+          marginBottom: "auto",
+          gap: "xxs",
+          borderRightRadius: "sm",
+          " > span": {
+            display: { base: "none", md: "block" },
+          },
+          borderRadius: "0px 2px 2px 0px",
+          "> svg": {
+            margin: 0,
+            width: "14px",
+            height: "14px",
+          },
+          paddingTop: "xs",
+          paddingBottom: "xs",
+          paddingLeft: "s",
+          paddingRight: "s",
+          "> span": {
+            display: "block",
+          },
+          [`@media screen and (max-width: ${headerBreakpoints.lgMobile}px)`]: {
+            padding: "xs",
+            gap: 0,
+            "> span": {
+              display: "none",
+            },
+            "> svg": {
+              width: "18px",
+              height: "18px",
+            },
+          },
+        }}
+      >
+        <Icon
+          align="left"
+          id={`searchbar-icon-${id}`}
+          name="search"
+          size="small"
+        />
+        <span>Search</span>
+      </Button>
+    );
+
+    return (
+      <Box
+        role="search"
+        aria-label="Search collections"
+        sx={{
+          display: "flex",
+          marginBottom: {
+            base: "xs",
+            md: "auto",
+          },
+          ".textInput": {
+            flexGrow: 1,
+            "div > input": {
+              borderRightRadius: 0,
+            },
+          },
+          flexFlow: "row",
+          maxWidth: maxWrapperWidth,
+        }}
+      >
+        {textInput}
+        {buttonElem}
+      </Box>
+    );
+  }
+);
+
+SearchBarComponent.displayName = "SearchBarComponent";
+
+export const DCSearchBar: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    SearchBarProps & React.RefAttributes<HTMLDivElement>
+  >,
+  SearchBarProps
+> = chakra(SearchBarComponent, { shouldForwardProp: () => true });
+
+export default DCSearchBar;

--- a/app/src/components/search/search.test.tsx
+++ b/app/src/components/search/search.test.tsx
@@ -20,11 +20,15 @@ describe("Search component", () => {
   });
 
   it("handles form submission correctly", () => {
-    const { getByLabelText, getByPlaceholderText } = render(<Search />);
+    const { getByPlaceholderText } = render(<Search />);
     fireEvent.change(getByPlaceholderText("Search keyword(s)"), {
       target: { value: "test word" },
     });
-    fireEvent.submit(getByLabelText("Search Digital Collections"));
+
+    const searchButton = screen.getByRole("button");
+
+    fireEvent.click(searchButton);
+
     expect(mockRouter.push).toHaveBeenCalledWith(
       `/search/index?keywords=test%20word`
     );
@@ -41,7 +45,9 @@ describe("Search component", () => {
 
     fireEvent.click(checkbox);
 
-    fireEvent.submit(screen.getByLabelText("Search Digital Collections"));
+    const searchButton = screen.getByRole("button");
+
+    fireEvent.click(searchButton);
 
     expect(mockRouter.push).toHaveBeenCalledWith(
       `/search/index?utf8=✓&filters%5Brights%5D=pd&keywords=test%20words`

--- a/app/src/components/search/search.test.tsx
+++ b/app/src/components/search/search.test.tsx
@@ -14,8 +14,10 @@ const mockRouter = {
 
 describe("Search component", () => {
   it("renders Search component", () => {
-    const { getByLabelText, getByPlaceholderText } = render(<Search />);
-    expect(getByLabelText("Search Digital Collections")).toBeInTheDocument();
+    const { getAllByLabelText, getByPlaceholderText } = render(<Search />);
+    expect(
+      getAllByLabelText("Search Digital Collections")[0]
+    ).toBeInTheDocument();
     expect(getByPlaceholderText("Search keyword(s)")).toBeInTheDocument();
   });
 

--- a/app/src/components/search/search.tsx
+++ b/app/src/components/search/search.tsx
@@ -48,7 +48,7 @@ const Search = () => {
         textInputProps={{
           id: "search-text",
           labelText: "Search keyword(s)",
-          name: "textInputName",
+          name: "keywords",
           onChange: handleTextChange,
           value: keywords,
           placeholder: "Search keyword(s)",

--- a/app/src/components/search/search.tsx
+++ b/app/src/components/search/search.tsx
@@ -5,6 +5,7 @@ import { Box, SearchBar } from "@nypl/design-system-react-components";
 import { useRouter } from "next/navigation";
 import PublicDomainFilter from "../publicDomainFilter/publicDomainFilter";
 import { headerBreakpoints } from "../../utils/breakpoints";
+import DCSearchBar from "./dcSearchBar";
 
 const Search = () => {
   const router = useRouter();
@@ -40,19 +41,11 @@ const Search = () => {
           [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]: {
             paddingTop: "0px !important",
           },
-          "#searchbar-form-searchbar": {
-            marginBottom: "0px !important",
-          },
-          "#searchbar-form-searchbar > button": {
-            maxWidth: "unset",
-          },
         }}
       >
-        <SearchBar
+        <DCSearchBar
           id="searchbar"
-          invalidText="Could not find the item"
           labelText="Search Digital Collections"
-          onSubmit={(event) => handleSubmit(event)}
           textInputProps={{
             labelText: "Search keyword(s)",
             name: "textInputName",
@@ -60,37 +53,7 @@ const Search = () => {
             value: keywords,
             placeholder: "Search keyword(s)",
           }}
-          sx={{
-            flexFlow: "row nowrap",
-            button: {
-              borderRadius: "0px 2px 2px 0px",
-              "> svg": {
-                width: "14px",
-                height: "14px",
-              },
-              paddingTop: "xs",
-              paddingBottom: "xs",
-              paddingLeft: "s !important",
-              paddingRight: "s !important",
-              "> span": {
-                display: "block !important",
-              },
-            },
-            [`@media screen and (max-width: ${headerBreakpoints.lgMobile}px)`]:
-              {
-                button: {
-                  padding: "xs !important",
-                  gap: 0,
-                  "> span": {
-                    display: "none !important",
-                  },
-                  "> svg": {
-                    width: "18px",
-                    height: "18px",
-                  },
-                },
-              },
-          }}
+          onSubmit={(e) => handleSubmit(e)}
         />
         <PublicDomainFilter onCheckChange={handleCheckChange} />
       </Box>

--- a/app/src/components/search/search.tsx
+++ b/app/src/components/search/search.tsx
@@ -1,7 +1,7 @@
-// @ts-nocheck
+//@ts-no-check
 "use client";
-import React, { FormEvent, useState } from "react";
-import { Box, SearchBar } from "@nypl/design-system-react-components";
+import React, { useState } from "react";
+import { Box } from "@nypl/design-system-react-components";
 import { useRouter } from "next/navigation";
 import PublicDomainFilter from "../publicDomainFilter/publicDomainFilter";
 import { headerBreakpoints } from "../../utils/breakpoints";
@@ -30,34 +30,33 @@ const Search = () => {
   };
 
   return (
-    <>
-      <Box
-        id="search-wrapper"
-        sx={{
-          alignItems: "start",
-          width: "100%",
-          marginTop: "0px !important",
-          paddingTop: "xs",
-          [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]: {
-            paddingTop: "0px !important",
-          },
+    <Box
+      id="search-wrapper"
+      sx={{
+        alignItems: "start",
+        width: "100%",
+        marginTop: "0px !important",
+        paddingTop: "xs",
+        [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]: {
+          paddingTop: "0px !important",
+        },
+      }}
+    >
+      <DCSearchBar
+        id="searchbar"
+        labelText="Search Digital Collections"
+        textInputProps={{
+          id: "search-text",
+          labelText: "Search keyword(s)",
+          name: "textInputName",
+          onChange: handleTextChange,
+          value: keywords,
+          placeholder: "Search keyword(s)",
         }}
-      >
-        <DCSearchBar
-          id="searchbar"
-          labelText="Search Digital Collections"
-          textInputProps={{
-            labelText: "Search keyword(s)",
-            name: "textInputName",
-            onChange: handleTextChange,
-            value: keywords,
-            placeholder: "Search keyword(s)",
-          }}
-          onSubmit={(e) => handleSubmit(e)}
-        />
-        <PublicDomainFilter onCheckChange={handleCheckChange} />
-      </Box>
-    </>
+        onSubmit={(e) => handleSubmit(e)}
+      />
+      <PublicDomainFilter onCheckChange={handleCheckChange} />
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Ticket:

n/a

Should be merged in with [DR-3365](https://github.com/NYPL/digital-collections/pull/286) since it corrects the loading

## This PR does the following:

- Replicates the DS `Searchbar` component but pared down to what DC uses, specifically getting rid of the `<form>` wrapper, which was triggering extra search submits
    - Added `maxWidth` as a prop since that's something we have been overriding but not everywhere

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- Generally, is it okay to have removed so much of the `Searchbar`? Wanted to keep what we actually use (and will use in the foreseeable future), so for example I removed the entire `select` element and all its corresponding props.
- Is it okay to add the "Enter" keyboard behavior back in (see comment)?

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

`search.test.tsx` tests should still cover this, and it should look and work exactly the same as before

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Want to check I haven't dropped any `aria-labels` or anything in the migration

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3365]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ