### PR TITLE
No ref: `/search` and `collections/:uuid` schema corrections

### DIFF
--- a/app/src/data/schemas/CHANGELOG.md
+++ b/app/src/data/schemas/CHANGELOG.md
@@ -2,10 +2,22 @@
 
 All notable changes to the schemas for the Collections API requirements to support the frontend will be documented in this file.
 
+## Prerelease 2025-2-13
+
+### Added
+
+- Added `collections/:uuid/children` endpoint
+
+### Updated
+
+- Updated `collections/:uuid` endpoint, now complete
+
 ## [0.1.0] 2025-1-24
 
 ### Added
-- Added details to /collections and /search API schemas following many convos with the team and the reqs in the BRD
+
+- Added details to `/collections` and `/search` API schemas
 
 ### Created
-- Created a template for the /collections/:uuid endpoint, awaiting product decisions before finalizing the details for the schema 
+
+- Created a template for the `/collections/:uuid` endpoint

--- a/app/src/data/schemas/collectionsUUIDSchema.ts
+++ b/app/src/data/schemas/collectionsUUIDSchema.ts
@@ -16,6 +16,7 @@ const collectionsUUIDSchema = {
   //more identifiers, need to go through DC to see which ones we return beyond bNumber, MSS ID, and uuid
   contentNote: "string",
   abstract: "string",
+  donorCredit: "string",
   // DESCRIPTION: includes related resources, collection history, etc. lives as HTML in DC database, not in MMS.
 };
 export default collectionsUUIDSchema;

--- a/app/src/data/schemas/searchSchema.ts
+++ b/app/src/data/schemas/searchSchema.ts
@@ -153,7 +153,7 @@ const searchSchema = {
       containsOnSiteMaterial: "boolean",
       containsAVMaterial: "boolean", // keeping bc the logic exists and it's already there
       containsMultipleCaptures: "boolean", // used to determine whether or not an item should display the "multiple images" tag
-      contentType: "image | audio | video | pdf | null", // null
+      contentType: "image | audio | video | null", // null
       highlights: { highlighted_field_name: ["string"] },
       firstIndexed_dt: "date",
     },


### PR DESCRIPTION
## Ticket:

- n/a

## This PR does the following:

- Adds `donorCredit` field to `collections/:uuid`schema
- Removes "PDF" as an option for `contentType` on `search` schema
- Updates schema changelog in general

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.
