### PR TITLE
DR-3337: `collection_keywords` redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Updated
+
+- Updated collection search to use `q` param and added redirect for `collection_keywords` (DR-3337)
+
+## [0.3.2] 2025-02-13
+
 ### Added
 
 - Added custom searchbar to handle search submit

--- a/__tests__/middleware/redirect.test.tsx
+++ b/__tests__/middleware/redirect.test.tsx
@@ -25,7 +25,7 @@ describe("redirects collection_keywords to q on collections search", () => {
 
     expect(NextResponse.redirect).toHaveBeenCalledWith(
       "http://localhost/collections?q=test",
-      308
+      301
     );
     expect(response).toBe("redirect response");
   });

--- a/__tests__/middleware/redirect.test.tsx
+++ b/__tests__/middleware/redirect.test.tsx
@@ -1,0 +1,43 @@
+import { middleware } from "middleware";
+import { NextRequest, NextResponse } from "next/server";
+
+jest.mock("next/server", () => {
+  return {
+    NextRequest: jest.fn(),
+    NextResponse: {
+      redirect: jest.fn(() => "redirect response"),
+      next: jest.fn(() => "next response"),
+    },
+  };
+});
+
+describe("redirects collection_keywords to q on collections search", () => {
+  let request: NextRequest;
+
+  beforeEach(() => {
+    request = {
+      nextUrl: new URL("http://localhost/collections?collection_keywords=test"),
+    } as NextRequest;
+  });
+
+  test("redirects collection_keywords to q", () => {
+    const response = middleware(request);
+
+    expect(NextResponse.redirect).toHaveBeenCalledWith(
+      "http://localhost/collections?q=test",
+      308
+    );
+    expect(response).toBe("redirect response");
+  });
+
+  test("goes through unchanged if no collection_keywords= param", () => {
+    request = {
+      nextUrl: new URL("http://localhost/collections?sort=title-asc"),
+    } as NextRequest;
+
+    const response = middleware(request);
+
+    expect(NextResponse.next).toHaveBeenCalled();
+    expect(response).toBe("next response");
+  });
+});

--- a/__tests__/middleware/redirect.test.tsx
+++ b/__tests__/middleware/redirect.test.tsx
@@ -14,13 +14,10 @@ jest.mock("next/server", () => {
 describe("redirects collection_keywords to q on collections search", () => {
   let request: NextRequest;
 
-  beforeEach(() => {
-    request = {
+  it("redirects collection_keywords to q", () => {
+    const request = {
       nextUrl: new URL("http://localhost/collections?collection_keywords=test"),
     } as NextRequest;
-  });
-
-  test("redirects collection_keywords to q", () => {
     const response = middleware(request);
 
     expect(NextResponse.redirect).toHaveBeenCalledWith(
@@ -30,7 +27,22 @@ describe("redirects collection_keywords to q on collections search", () => {
     expect(response).toBe("redirect response");
   });
 
-  test("goes through unchanged if no collection_keywords= param", () => {
+  it("redirects collection_keywords to q and maintains other parameters", () => {
+    const request = {
+      nextUrl: new URL(
+        "http://localhost/collections?collection_keywords=test&sort=title-asc&page=23"
+      ),
+    } as NextRequest;
+    const response = middleware(request);
+
+    expect(NextResponse.redirect).toHaveBeenCalledWith(
+      "http://localhost/collections?sort=title-asc&page=23&q=test",
+      301
+    );
+    expect(response).toBe("redirect response");
+  });
+
+  it("goes through unchanged if no collection_keywords= param", () => {
     request = {
       nextUrl: new URL("http://localhost/collections?sort=title-asc"),
     } as NextRequest;

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 
 export default async function Collections({ searchParams }: CollectionsProps) {
   const data = await getCollectionsData({
-    keyword: searchParams.collection_keywords,
+    keyword: searchParams.q,
     sort: searchParams.sort,
     page: searchParams.page,
   });

--- a/app/src/components/pages/collectionsPage/collectionsPage.tsx
+++ b/app/src/components/pages/collectionsPage/collectionsPage.tsx
@@ -42,8 +42,7 @@ export function CollectionsPage({ data, collectionSearchParams }) {
   const collectionSearchManager = new CollectionSearchManager({
     initialPage: Number(collectionSearchParams?.page) || DEFAULT_PAGE_NUM,
     initialSort: collectionSearchParams?.sort || DEFAULT_COLLECTION_SORT,
-    initialKeywords:
-      collectionSearchParams?.collection_keywords || DEFAULT_SEARCH_TERM,
+    initialKeywords: collectionSearchParams?.q || DEFAULT_SEARCH_TERM,
   });
 
   const updateURL = async (queryString: string) => {
@@ -205,7 +204,7 @@ export function CollectionsPage({ data, collectionSearchParams }) {
           <CardsGrid records={collections} />
         ) : (
           <NoResultsFound
-            searchTerm={collectionSearchParams.collection_keywords}
+            searchTerm={collectionSearchParams.q}
             page={collectionSearchParams.page}
           />
         )

--- a/app/src/types/CollectionSearchParams.ts
+++ b/app/src/types/CollectionSearchParams.ts
@@ -1,5 +1,5 @@
 export interface CollectionSearchParams {
-  collection_keywords: string;
+  q: string;
   sort: string;
   page: number;
 }

--- a/app/src/utils/searchManager.test.tsx
+++ b/app/src/utils/searchManager.test.tsx
@@ -132,17 +132,17 @@ describe("SearchManager", () => {
 
     it("should handle search submit", () => {
       const result = manager.handleSearchSubmit();
-      expect(result).toBe("collection_keywords=test");
+      expect(result).toBe("q=test");
     });
 
     it("should handle sort change", () => {
       const result = manager.handleSortChange("title-asc");
-      expect(result).toBe("collection_keywords=test&sort=title-asc");
+      expect(result).toBe("q=test&sort=title-asc");
     });
 
     it("should handle page change", () => {
       const result = manager.handlePageChange(2);
-      expect(result).toBe("collection_keywords=test&sort=title-asc&page=2");
+      expect(result).toBe("q=test&sort=title-asc&page=2");
     });
   });
 });

--- a/app/src/utils/searchManager.tsx
+++ b/app/src/utils/searchManager.tsx
@@ -143,7 +143,7 @@ export class CollectionSearchManager extends BaseSearchManager {
     this.currentPage = DEFAULT_PAGE_NUM;
     this.currentSort = DEFAULT_COLLECTION_SORT;
     return this.createQueryString({
-      collection_keywords: this.currentKeywords,
+      q: this.currentKeywords,
       sort: this.currentSort,
       page: this.currentPage,
     });
@@ -152,7 +152,7 @@ export class CollectionSearchManager extends BaseSearchManager {
   handlePageChange(pageNumber: number) {
     this.currentPage = pageNumber;
     return this.createQueryString({
-      collection_keywords: this.currentKeywords,
+      q: this.currentKeywords,
       sort: this.currentSort,
       page: pageNumber,
     });
@@ -161,7 +161,7 @@ export class CollectionSearchManager extends BaseSearchManager {
   handleSortChange(sort: string) {
     this.currentSort = sort;
     return this.createQueryString({
-      collection_keywords: this.currentKeywords,
+      q: this.currentKeywords,
       sort: sort,
       page: this.currentPage,
     });

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(req: NextRequest) {
+  const url = req.nextUrl;
+  const searchParams = url.searchParams;
+
+  if (searchParams.has("collection_keywords")) {
+    const keywordValue = searchParams.get("collection_keywords");
+
+    searchParams.delete("collection_keywords");
+    searchParams.set("q", keywordValue!);
+
+    const newUrl = `${url.origin}${url.pathname}?${searchParams.toString()}`;
+
+    return NextResponse.redirect(newUrl, 308);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/:path*",
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,7 +12,7 @@ export function middleware(req: NextRequest) {
 
     const newUrl = `${url.origin}${url.pathname}?${searchParams.toString()}`;
 
-    return NextResponse.redirect(newUrl, 308);
+    return NextResponse.redirect(newUrl, 301);
   }
 
   return NextResponse.next();

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,15 @@
 const nrExternals = require("newrelic/load-externals");
 
 const nextConfig = {
+  async redirects() {
+    return [
+      {
+        source: "/old-page",
+        destination: "/new-page",
+        permanent: true,
+      },
+    ];
+  },
   experimental: {
     // Without this setting, the Next.js compilation step will routinely
     // try to import files such as `LICENSE` from the `newrelic` module.

--- a/next.config.js
+++ b/next.config.js
@@ -4,15 +4,6 @@
 const nrExternals = require("newrelic/load-externals");
 
 const nextConfig = {
-  async redirects() {
-    return [
-      {
-        source: "/old-page",
-        destination: "/new-page",
-        permanent: true,
-      },
-    ];
-  },
   experimental: {
     // Without this setting, the Next.js compilation step will routinely
     // try to import files such as `LICENSE` from the `newrelic` module.

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added custom searchbar to handle search submit
+- Added new search context and `searchManager` class, implemented on `/collections` page (DR-3365)
+
+### Updated
+
+- Updated 3rd party scripts with explicit loading strategies (DR-3376)
+
 ## [0.3.1] 2025-01-30
 
 ### Updated

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
     "__tests__/**/*.test.tsx",
     "__tests__/__mocks__/next/logger.js",
     "jest.setup.ts",
-    "middleware.tsx",
+    "middleware.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3337](https://newyorkpubliclibrary.atlassian.net/browse/DR-3337)

## This PR does the following:

- Replaces `collection_keywords` with `q` in the collection search params
- Adds a 301 redirect so that bookmarked URLs with `collection_keywords` go to `q`
- Tests the above

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

Try to hit `/collections?collection_keywords=something` and watch the magic unfold (also try with a sort or a page number applied as well)

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3337]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ