### PR TITLE
DR-3367: Active filters 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added active filters panel, `activeFilters` (DR-3367)
 - Added sort component, `sortMenu` (DR-3366)
 - Added custom select component, `selectFilter` for facet filters (DR-3394)
 - Added search result model, mock data, card component, and card grid component (DR-3363)

--- a/__tests__/pages/collectionpage.test.tsx
+++ b/__tests__/pages/collectionpage.test.tsx
@@ -1,4 +1,5 @@
 import CollectionPage from "@/src/components/pages/collectionPage/collectionPage";
+import { SearchProvider } from "@/src/context/SearchProvider";
 import { render } from "@testing-library/react";
 import { mockItems } from "__tests__/__mocks__/data/mockItems";
 
@@ -25,11 +26,13 @@ describe("Collection page accessibility", () => {
   };
   it("passes axe accessibility test", async () => {
     const { container } = render(
-      <CollectionPage
-        searchParams={searchParams}
-        slug="Example collection"
-        data={mockItems}
-      />
+      <SearchProvider>
+        <CollectionPage
+          searchParams={searchParams}
+          slug="Example collection"
+          data={mockItems}
+        />
+      </SearchProvider>
     );
     expect(await axe(container)).toHaveNoViolations();
   }, 60000);

--- a/app/src/components/pages/collectionPage/collectionPage.tsx
+++ b/app/src/components/pages/collectionPage/collectionPage.tsx
@@ -4,8 +4,6 @@ import {
   Text,
   Heading,
   Flex,
-  HorizontalRule,
-  TagSet,
   ButtonGroup,
   Button,
   Link,
@@ -25,10 +23,13 @@ import {
   SEARCH_SORT_LABELS,
 } from "@/src/config/constants";
 import SearchCardsGrid from "../../grids/searchCardsGrid";
-import { GeneralSearchManager } from "@/src/utils/searchManager";
-import { stringToFilter } from "@/src/context/SearchProvider";
+import {
+  GeneralSearchManager,
+  stringToFilter,
+} from "@/src/utils/searchManager";
 import { usePathname, useRouter } from "next/navigation";
 import SortMenu from "../../sortMenu/sortMenu";
+import ActiveFilters from "../../search/filters/activeFilters";
 
 const textLink = (href, text) => {
   return (
@@ -99,22 +100,7 @@ const CollectionPage = ({ slug, data, searchParams }) => {
           paddingRight: { base: "m", xl: "s" },
         }}
       >
-        <Flex alignContent="center" alignItems="center" gap="xs">
-          <Text size="subtitle2" sx={{ margin: 0, fontWeight: 400 }}>
-            Filters applied:
-          </Text>
-          <TagSet
-            isDismissible
-            id="search-filter-tags"
-            onClick={() => {}}
-            tagSetData={[
-              { id: "audio", label: "Audio" },
-              { id: "video", label: "Video" },
-            ]}
-            type="filter"
-          />
-        </Flex>
-        <HorizontalRule />
+        <ActiveFilters />
         <Flex marginTop="m" marginBottom="m" flexDir="column">
           <Heading size="heading6" marginBottom="xs">
             Collection data

--- a/app/src/components/pages/searchPage/searchPage.tsx
+++ b/app/src/components/pages/searchPage/searchPage.tsx
@@ -20,6 +20,7 @@ import { usePathname, useRouter } from "next/navigation";
 import SearchCardsGrid from "../../grids/searchCardsGrid";
 import { headerBreakpoints } from "@/src/utils/breakpoints";
 import SortMenu from "../../sortMenu/sortMenu";
+import ActiveFilters from "../../search/filters/activeFilters";
 
 const SearchPage = ({ data }) => {
   const { searchManager } = useSearchContext();
@@ -29,6 +30,7 @@ const SearchPage = ({ data }) => {
   const updateURL = async (queryString) => {
     push(`${pathname}?${queryString}`);
   };
+
   const headingRef = useRef<HTMLHeadingElement>(null);
 
   return (
@@ -79,22 +81,7 @@ const SearchPage = ({ data }) => {
           },
         }}
       >
-        <Flex alignContent="center" gap="xs">
-          <Text size="subtitle2" sx={{ margin: 0, fontWeight: 400 }}>
-            Filters applied:
-          </Text>
-          <TagSet
-            isDismissible
-            id="search-filter-tags"
-            onClick={() => {}}
-            tagSetData={[
-              { id: "audio", label: "Audio" },
-              { id: "video", label: "Video" },
-            ]}
-            type="filter"
-          />
-        </Flex>
-        <HorizontalRule />
+        <ActiveFilters />
         <Flex
           sx={{
             [`@media screen and (min-width: ${headerBreakpoints.lgMobile}px)`]:

--- a/app/src/components/pages/searchPage/searchPage.tsx
+++ b/app/src/components/pages/searchPage/searchPage.tsx
@@ -1,15 +1,11 @@
 "use client";
 import {
   Box,
-  Text,
   Pagination,
   Heading,
   Flex,
-  HorizontalRule,
-  TagSet,
   Link,
   Icon,
-  Menu,
 } from "@nypl/design-system-react-components";
 import React, { useRef } from "react";
 import { CARDS_PER_PAGE, SEARCH_SORT_LABELS } from "@/src/config/constants";

--- a/app/src/components/search/filters/activeFilters.test.tsx
+++ b/app/src/components/search/filters/activeFilters.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ActiveFilters from "./activeFilters";
+import { SearchProvider } from "@/src/context/SearchProvider";
+import { useRouter } from "next/navigation";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+  })),
+  usePathname: jest.fn(),
+}));
+
+describe("ActiveFilters", () => {
+  const searchParams = {
+    page: 2,
+    sort: "date-asc",
+    filters: "[topic=art][format=book]",
+    keywords: "painting",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const component = (
+    <SearchProvider searchParams={searchParams}>
+      <ActiveFilters />
+    </SearchProvider>
+  );
+
+  it("renders the applied filters", () => {
+    render(component);
+    expect(screen.getByText("Filters applied:")).toBeInTheDocument();
+    expect(screen.getByText("art")).toBeInTheDocument();
+    expect(screen.getByText("book")).toBeInTheDocument();
+  });
+
+  it("removes a filter when a tag is clicked", () => {
+    render(component);
+    const tag = screen.getByText("book");
+    fireEvent.click(tag);
+
+    setTimeout(() => {
+      expect(screen.getByText("book")).not.toBeInTheDocument();
+    }, 100);
+  });
+
+  it("clears all filters when the clear button is clicked", () => {
+    render(component);
+    fireEvent.click(screen.getByText("Clear filters"));
+    setTimeout(() => {
+      expect(screen.queryByText("Filters applied:")).not.toBeInTheDocument();
+    }, 100);
+  });
+
+  it("does not render if there are no active filters", () => {
+    render(
+      <SearchProvider searchParams={{ ...searchParams, filters: "" }}>
+        <ActiveFilters />
+      </SearchProvider>
+    );
+    expect(screen.queryByText("Filters applied:")).not.toBeInTheDocument();
+  });
+});

--- a/app/src/components/search/filters/activeFilters.tsx
+++ b/app/src/components/search/filters/activeFilters.tsx
@@ -1,0 +1,55 @@
+import { useSearchContext } from "@/src/context/SearchProvider";
+import { Filter } from "@/src/types/FilterType";
+import {
+  Flex,
+  HorizontalRule,
+  TagSet,
+  Text,
+} from "@nypl/design-system-react-components";
+import { usePathname, useRouter } from "next/navigation";
+
+const ActiveFilters = () => {
+  const { searchManager } = useSearchContext();
+  const { push } = useRouter();
+  const pathname = usePathname();
+  const updateURL = async (queryString) => {
+    push(`${pathname}?${queryString}`);
+  };
+
+  const handleOnClick = (tag) => {
+    if (tag.id === "clear-filters") {
+      updateURL(searchManager.clearAllFilters());
+    } else {
+      const filterToRemove = searchManager.filters.find(
+        (filter) => filter.value === tag.id
+      );
+      if (filterToRemove) {
+        updateURL(searchManager.handleRemoveFilter(filterToRemove));
+      }
+    }
+  };
+  console.log(searchManager.filters);
+
+  return (
+    <>
+      <Flex alignContent="center" alignItems="center" gap="xs">
+        <Text size="subtitle2" sx={{ margin: 0, fontWeight: 400 }}>
+          Filters applied:
+        </Text>
+        <TagSet
+          isDismissible
+          id="search-filter-tags"
+          onClick={handleOnClick}
+          tagSetData={searchManager.filters.map((filter: Filter) => ({
+            id: filter.filter,
+            label: filter.value,
+          }))}
+          type="filter"
+        />
+      </Flex>
+      <HorizontalRule />
+    </>
+  );
+};
+
+export default ActiveFilters;

--- a/app/src/components/search/filters/activeFilters.tsx
+++ b/app/src/components/search/filters/activeFilters.tsx
@@ -17,7 +17,6 @@ const ActiveFilters = () => {
   };
 
   const handleOnClick = (tag) => {
-    console.log(tag);
     if (tag.id === "clear-filters") {
       updateURL(searchManager.clearAllFilters());
     } else {

--- a/app/src/components/search/filters/activeFilters.tsx
+++ b/app/src/components/search/filters/activeFilters.tsx
@@ -29,29 +29,27 @@ const ActiveFilters = () => {
     }
   };
 
-  return (
-    searchManager.filters.length > 0 && (
-      <>
-        <Flex alignContent="center" alignItems="center" gap="xs" flexDir="row">
-          <Text size="subtitle2" sx={{ margin: 0, fontWeight: 400 }}>
-            Filters applied:
-          </Text>
-          <TagSet
-            isDismissible
-            id="search-filter-tags"
-            onClick={handleOnClick}
-            tagSetData={searchManager.filters.map((filter: Filter) => ({
-              id: filter.filter,
-              label: filter.value,
-            }))}
-            type="filter"
-            sx={{ flexWrap: "unset" }}
-          />
-        </Flex>
-        <HorizontalRule />
-      </>
-    )
-  );
+  return searchManager.filters.length > 0 ? (
+    <>
+      <Flex alignContent="center" alignItems="center" gap="xs" flexDir="row">
+        <Text size="subtitle2" sx={{ margin: 0, fontWeight: 400 }}>
+          Filters applied:
+        </Text>
+        <TagSet
+          isDismissible
+          id="search-filter-tags"
+          onClick={handleOnClick}
+          tagSetData={searchManager.filters.map((filter: Filter) => ({
+            id: filter.filter,
+            label: filter.value,
+          }))}
+          type="filter"
+          sx={{ flexWrap: "unset" }}
+        />
+      </Flex>
+      <HorizontalRule />
+    </>
+  ) : null;
 };
 
 export default ActiveFilters;

--- a/app/src/components/search/filters/activeFilters.tsx
+++ b/app/src/components/search/filters/activeFilters.tsx
@@ -17,38 +17,41 @@ const ActiveFilters = () => {
   };
 
   const handleOnClick = (tag) => {
+    console.log(tag);
     if (tag.id === "clear-filters") {
       updateURL(searchManager.clearAllFilters());
     } else {
       const filterToRemove = searchManager.filters.find(
-        (filter) => filter.value === tag.id
+        (filter) => filter.filter === tag.id
       );
       if (filterToRemove) {
         updateURL(searchManager.handleRemoveFilter(filterToRemove));
       }
     }
   };
-  console.log(searchManager.filters);
 
   return (
-    <>
-      <Flex alignContent="center" alignItems="center" gap="xs">
-        <Text size="subtitle2" sx={{ margin: 0, fontWeight: 400 }}>
-          Filters applied:
-        </Text>
-        <TagSet
-          isDismissible
-          id="search-filter-tags"
-          onClick={handleOnClick}
-          tagSetData={searchManager.filters.map((filter: Filter) => ({
-            id: filter.filter,
-            label: filter.value,
-          }))}
-          type="filter"
-        />
-      </Flex>
-      <HorizontalRule />
-    </>
+    searchManager.filters.length > 0 && (
+      <>
+        <Flex alignContent="center" alignItems="center" gap="xs" flexDir="row">
+          <Text size="subtitle2" sx={{ margin: 0, fontWeight: 400 }}>
+            Filters applied:
+          </Text>
+          <TagSet
+            isDismissible
+            id="search-filter-tags"
+            onClick={handleOnClick}
+            tagSetData={searchManager.filters.map((filter: Filter) => ({
+              id: filter.filter,
+              label: filter.value,
+            }))}
+            type="filter"
+            sx={{ flexWrap: "unset" }}
+          />
+        </Flex>
+        <HorizontalRule />
+      </>
+    )
   );
 };
 

--- a/app/src/components/search/filters/selectFilter.test.tsx
+++ b/app/src/components/search/filters/selectFilter.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import SelectFilter, { FilterCategory } from "./selectFilter";
+import { useRouter } from "next/navigation";
+import { SearchProvider } from "@/src/context/SearchProvider";
 
 const mockFacetFilter: FilterCategory = {
   name: "Publishers",
@@ -10,14 +12,26 @@ const mockFacetFilter: FilterCategory = {
   ],
 };
 
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+  })),
+  usePathname: jest.fn(),
+}));
+
 describe("SelectFilter", () => {
+  let component = (
+    <SearchProvider>
+      <SelectFilter filter={mockFacetFilter} />
+    </SearchProvider>
+  );
   it("renders the filter category name", () => {
-    render(<SelectFilter filter={mockFacetFilter} />);
+    render(component);
     expect(screen.getByText("Publishers")).toBeInTheDocument();
   });
 
   it("renders a radio button for each filter option", () => {
-    render(<SelectFilter filter={mockFacetFilter} />);
+    render(component);
     fireEvent.click(screen.getByText("Publishers"));
     mockFacetFilter.options.forEach((option) => {
       expect(screen.getByText(option.name)).toBeInTheDocument();
@@ -26,13 +40,13 @@ describe("SelectFilter", () => {
   });
 
   it("shows modal link for the filter", () => {
-    render(<SelectFilter filter={mockFacetFilter} />);
+    render(component);
     fireEvent.click(screen.getByText("Publishers"));
     expect(screen.getByText("View all publishers")).toBeInTheDocument();
   });
 
   it("should select an option and update accordingly", async () => {
-    render(<SelectFilter filter={mockFacetFilter} />);
+    render(component);
     fireEvent.click(screen.getByText("Publishers"));
 
     const radio1 = screen.getAllByRole("radio")[0];
@@ -46,7 +60,7 @@ describe("SelectFilter", () => {
 
   it("should abort previous selection when selecting a new option", async () => {
     jest.useFakeTimers();
-    render(<SelectFilter filter={mockFacetFilter} />);
+    render(component);
     fireEvent.click(screen.getByText("Publishers"));
 
     const radio1 = screen.getAllByRole("radio")[0];

--- a/app/src/components/search/filters/selectFilter.tsx
+++ b/app/src/components/search/filters/selectFilter.tsx
@@ -14,6 +14,8 @@ import React, {
   useState,
 } from "react";
 import FilterAccordion from "./filterAccordion";
+import { usePathname, useRouter } from "next/navigation";
+import { useSearchContext } from "@/src/context/SearchProvider";
 
 export type FilterOption = {
   name: string;
@@ -36,6 +38,12 @@ const SelectFilterComponent = forwardRef<
   const { filter, ...rest } = props;
   const [userClickedOutside, setUserClickedOutside] = useState<boolean>(false);
   const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout | null>(null);
+  const { push } = useRouter();
+  const pathname = usePathname();
+  const updateURL = async (queryString) => {
+    push(`${pathname}?${queryString}`);
+  };
+  const { searchManager } = useSearchContext();
 
   // Create a ref to hold a reference to the accordion button, enabling us
   // to programmatically focus it.
@@ -104,9 +112,16 @@ const SelectFilterComponent = forwardRef<
     const newTimeoutId = setTimeout(() => {
       console.log(`selected: ${newSelection}`);
       setUserClickedOutside(true);
-      (
-        headingRef as MutableRefObject<HTMLHeadingElement | null>
-      )?.current?.focus();
+      updateURL(
+        searchManager.handleAddFilter({
+          filter: filter.name,
+          value: newSelection,
+        })
+      );
+      //setUserClickedOutside(true);
+      // (
+      //   headingRef as MutableRefObject<HTMLHeadingElement | null>
+      // )?.current?.focus();
     }, 600);
 
     setTimeoutId(newTimeoutId);

--- a/app/src/components/search/filters/selectFilterGrid.test.tsx
+++ b/app/src/components/search/filters/selectFilterGrid.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import SelectFilterGrid from "./selectFilterGrid";
 import { FilterCategory } from "./selectFilter";
+import { SearchProvider } from "@/src/context/SearchProvider";
 
 const mockFilters: FilterCategory[] = [
   { name: "Collection", options: [{ name: "Collection 1", count: 10 }] },
@@ -10,9 +11,23 @@ const mockFilters: FilterCategory[] = [
   { name: "Genre", options: [{ name: "Genre 1", count: 30 }] },
 ];
 
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+  })),
+  usePathname: jest.fn(),
+}));
+
 describe("SelectFilterGrid", () => {
+  const component = (expanded: boolean) => {
+    return (
+      <SearchProvider>
+        <SelectFilterGrid filters={mockFilters} isExpanded={expanded} />
+      </SearchProvider>
+    );
+  };
   it("renders the correct number of filters when collapsed", () => {
-    render(<SelectFilterGrid filters={mockFilters} isExpanded={false} />);
+    render(component(false));
 
     expect(screen.getByText("Collection")).toBeInTheDocument();
     expect(screen.getByText("Format")).toBeInTheDocument();
@@ -23,7 +38,7 @@ describe("SelectFilterGrid", () => {
   });
 
   it("renders all filters when expanded", () => {
-    render(<SelectFilterGrid filters={mockFilters} isExpanded={true} />);
+    render(component(true));
 
     mockFilters.forEach((filter) => {
       expect(screen.getByText(filter.name)).toBeInTheDocument();
@@ -31,7 +46,7 @@ describe("SelectFilterGrid", () => {
   });
 
   it("toggles filter expansion correctly", async () => {
-    render(<SelectFilterGrid filters={mockFilters} isExpanded={true} />);
+    render(component(true));
 
     const collectionAccordionButton = screen.getByText("Collection");
     expect(collectionAccordionButton.parentElement).toHaveAttribute(
@@ -47,7 +62,7 @@ describe("SelectFilterGrid", () => {
   });
 
   it("collapses the previous filter when you click a new one", async () => {
-    render(<SelectFilterGrid filters={mockFilters} isExpanded={true} />);
+    render(component(true));
 
     const collectionAccordionButton = screen.getByText("Collection");
 

--- a/app/src/context/SearchProvider.tsx
+++ b/app/src/context/SearchProvider.tsx
@@ -5,33 +5,15 @@ import {
   DEFAULT_SEARCH_SORT,
   DEFAULT_SEARCH_TERM,
 } from "../config/constants";
-import { GeneralSearchManager, SearchManager } from "../utils/searchManager";
-import { Filter } from "../types/FilterType";
+import {
+  GeneralSearchManager,
+  SearchManager,
+  stringToFilter,
+} from "../utils/searchManager";
 
 interface SearchContextType {
   searchManager: SearchManager;
 }
-
-export const stringToFilter = (filtersString: string | null): Filter[] => {
-  if (!filtersString) return [];
-
-  return filtersString
-    .split(",")
-    .map((filterPair) => {
-      const match = filterPair.match(/^\[(\w+)=(.+)\]$/);
-      if (match) {
-        const [, filter, value] = match;
-        return { filter, value };
-      }
-      return null;
-    })
-    .filter((filter): filter is Filter => filter !== null);
-};
-
-export const filterToString = (filters: Filter[]): string => {
-  if (!filters || filters.length === 0) return "";
-  return filters.map(({ filter, value }) => `[${filter}=${value}]`).join("");
-};
 
 const SearchContext = createContext<SearchContextType | undefined>(undefined);
 

--- a/app/src/utils/searchManager.test.tsx
+++ b/app/src/utils/searchManager.test.tsx
@@ -4,7 +4,12 @@ import {
   DEFAULT_SEARCH_SORT,
 } from "../config/constants";
 import { Filter } from "../types/FilterType";
-import { GeneralSearchManager, CollectionSearchManager } from "./searchManager";
+import {
+  GeneralSearchManager,
+  CollectionSearchManager,
+  filterToString,
+  stringToFilter,
+} from "./searchManager";
 
 describe("SearchManager", () => {
   describe("GeneralSearchManager individual params", () => {
@@ -151,6 +156,62 @@ describe("SearchManager", () => {
     it("should handle page change", () => {
       const result = manager.handlePageChange(2);
       expect(result).toBe("q=test&sort=title-asc&page=2");
+    });
+  });
+
+  describe("stringToFilter", () => {
+    it("should return an empty array for null input", () => {
+      expect(stringToFilter(null)).toEqual([]);
+    });
+
+    it("should return an empty array for an empty string", () => {
+      expect(stringToFilter("")).toEqual([]);
+    });
+
+    it("should handle a single filter correctly", () => {
+      expect(stringToFilter("[rights=pd]")).toEqual([
+        { filter: "rights", value: "pd" },
+      ]);
+    });
+
+    it("should handle multiple filters correctly", () => {
+      expect(stringToFilter("[rights=pd][topic=music]")).toEqual([
+        { filter: "rights", value: "pd" },
+        { filter: "topic", value: "music" },
+      ]);
+    });
+
+    it("should handle filters with spaces", () => {
+      expect(stringToFilter("[format=Long Is land]")).toEqual([
+        { filter: "format", value: "Long Is land" },
+      ]);
+    });
+  });
+
+  describe("filterToString", () => {
+    it("should return an empty string for an empty array", () => {
+      expect(filterToString([])).toBe("");
+    });
+
+    it("should convert a single filter to a string", () => {
+      expect(filterToString([{ filter: "rights", value: "pd" }])).toBe(
+        "[rights=pd]"
+      );
+    });
+
+    it("should convert multiple filters to a string", () => {
+      expect(
+        filterToString([
+          { filter: "rights", value: "pd" },
+          { filter: "topic", value: "music" },
+        ])
+      ).toBe("[rights=pd][topic=music]");
+    });
+
+    it("should handle filters with spaces", () => {
+      expect(
+        filterToString([{ filter: "format", value: "Long Is land" }])
+      ).toBe("[format=Long Is land]");
     });
   });
 });

--- a/app/src/utils/searchManager.test.tsx
+++ b/app/src/utils/searchManager.test.tsx
@@ -86,6 +86,14 @@ describe("SearchManager", () => {
       );
     });
 
+    it("should handle removing a filter", () => {
+      const filter1: Filter = { filter: "genre", value: "music" };
+      const result1 = manager.handleRemoveFilter(filter1);
+      expect(result1).toBe(
+        "keywords=test&sort=date-asc&page=2&filters=%5Btopic%3Dart%5D"
+      );
+    });
+
     it("should handle clearing all filters", () => {
       const result = manager.clearAllFilters();
       expect(result).toBe("keywords=test&sort=date-asc");

--- a/app/src/utils/searchManager.tsx
+++ b/app/src/utils/searchManager.tsx
@@ -4,8 +4,20 @@ import {
   DEFAULT_PAGE_NUM,
   DEFAULT_SEARCH_TERM,
 } from "../config/constants";
-import { filterToString } from "../context/SearchProvider";
 import { Filter } from "../types/FilterType";
+
+export const stringToFilter = (filtersString: string | null): Filter[] => {
+  if (!filtersString) return [];
+  return Array.from(filtersString.matchAll(/\[([^\]=]+)=([^\]]+)\]/g)).map(
+    ([, filter, value]) => ({ filter, value })
+  );
+};
+
+export const filterToString = (filters: Filter[]): string => {
+  if (!filters || filters.length === 0) return "";
+  return filters.map(({ filter, value }) => `[${filter}=${value}]`).join("");
+};
+
 export interface SearchManager {
   handleSearchSubmit(): string;
   handleKeywordChange(value: string): void;
@@ -75,7 +87,6 @@ abstract class BaseSearchManager implements SearchManager {
     if (!filterExists) {
       updatedFilters.push(newFilter);
     }
-
     this.currentFilters = updatedFilters;
 
     return this.getQueryString({

--- a/app/src/utils/searchManager.tsx
+++ b/app/src/utils/searchManager.tsx
@@ -6,18 +6,6 @@ import {
 } from "../config/constants";
 import { Filter } from "../types/FilterType";
 
-export const stringToFilter = (filtersString: string | null): Filter[] => {
-  if (!filtersString) return [];
-  return Array.from(filtersString.matchAll(/\[([^\]=]+)=([^\]]+)\]/g)).map(
-    ([, filter, value]) => ({ filter, value })
-  );
-};
-
-export const filterToString = (filters: Filter[]): string => {
-  if (!filters || filters.length === 0) return "";
-  return filters.map(({ filter, value }) => `[${filter}=${value}]`).join("");
-};
-
 export interface SearchManager {
   handleSearchSubmit(): string;
   handleKeywordChange(value: string): void;
@@ -229,4 +217,16 @@ const createQueryStringFromObject = (object: Record<string, string>) => {
     params.set(key, object[key]);
   });
   return params.toString();
+};
+
+export const stringToFilter = (filtersString: string | null): Filter[] => {
+  if (!filtersString) return [];
+  return Array.from(filtersString.matchAll(/\[([^\]=]+)=([^\]]+)\]/g)).map(
+    ([, filter, value]) => ({ filter, value })
+  );
+};
+
+export const filterToString = (filters: Filter[]): string => {
+  if (!filters || filters.length === 0) return "";
+  return filters.map(({ filter, value }) => `[${filter}=${value}]`).join("");
 };

--- a/app/src/utils/searchManager.tsx
+++ b/app/src/utils/searchManager.tsx
@@ -64,13 +64,25 @@ abstract class BaseSearchManager implements SearchManager {
   }
 
   handleAddFilter(newFilter: Filter) {
-    const updatedFilters = [...this.currentFilters, newFilter];
+    const updatedFilters = this.currentFilters.map((filter) =>
+      filter.filter === newFilter.filter ? newFilter : filter
+    );
+
+    const filterExists = this.currentFilters.some(
+      (filter) => filter.filter === newFilter.filter
+    );
+
+    if (!filterExists) {
+      updatedFilters.push(newFilter);
+    }
+
     this.currentFilters = updatedFilters;
+
     return this.getQueryString({
       keywords: this.currentKeywords,
       sort: this.currentSort,
       page: this.currentPage,
-      filters: filterToString(updatedFilters),
+      filters: filterToString(this.currentFilters),
     });
   }
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3367](https://newyorkpubliclibrary.atlassian.net/browse/DR-3367)

## This PR does the following:

- Creates `activeFilters` component with `TagSet` and adds it to `/search` and `/collections/[slug]`
- Adds/updates filter management in `searchManager`

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Add and remove filters etc. Complete filter modal is not in this branch but dropdowns should work enough to show how the `TagSet` / `SearchManager`/ URL communication work

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3367]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ