### PR TITLE
DR-3523: Correct header shift on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Updated
+
+- Resolve layout shift on header focus (DR-3523)
+
 ## [0.3.5] 2025-03-27
 
 ### Added

--- a/app/src/components/header/header.tsx
+++ b/app/src/components/header/header.tsx
@@ -1,12 +1,10 @@
+import React, { useLayoutEffect, useRef, useState } from "react";
 import {
   Box,
   HStack,
   VStack,
   HorizontalRule,
 } from "@nypl/design-system-react-components";
-import React from "react";
-import { useScrolled } from "../../hooks/useScrolled";
-import { useStickyMargin } from "../../hooks/useStickyMargin";
 import Search from "../search/search";
 import DCLogo from "../logo/logo";
 import NavMenu from "../navMenu/navMenu";
@@ -15,123 +13,147 @@ import { headerBreakpoints } from "../../utils/breakpoints";
 import useScrollDirection from "../../hooks/useScrollDirection";
 
 const Header = () => {
-  useStickyMargin();
-  const isScrolled = useScrolled("header");
+  const headerRef = useRef<HTMLDivElement>(null);
+  const [headerHeight, setHeaderHeight] = useState<number>(150);
+  const [isFocused, setIsFocused] = useState(false);
   const isScrollingUp = useScrollDirection();
 
+  useLayoutEffect(() => {
+    const updateHeight = () => {
+      if (headerRef.current) {
+        const newHeight = headerRef.current.offsetHeight;
+        setHeaderHeight((prev) => (prev !== newHeight ? newHeight : prev));
+      }
+    };
+    updateHeight();
+    window.addEventListener("resize", updateHeight);
+    return () => {
+      window.removeEventListener("resize", updateHeight);
+    };
+  }, [isScrollingUp]);
+
   return (
-    <Box
-      data-sticky-header
-      data-sticky-offset="10"
-      position="sticky"
-      id="header"
-      top={0}
-      zIndex={99999}
-      bgColor="ui.white"
-      sx={{
-        [`@media screen and (min-width: ${headerBreakpoints.smTablet}px)`]: {
-          pt: "xs",
-        },
-        alignItems: "center",
-      }}
-    >
+    <>
+      {/* Placeholder to avoid layout shift */}
+      {isFocused && <Box height={`${headerHeight}px`} />}
       <Box
-        maxWidth="1280px"
-        mx="auto"
-        padding="0 16px !important"
+        ref={headerRef}
+        data-sticky-header
+        data-sticky-offset="10"
+        position={isFocused ? "fixed" : "sticky"}
+        top="0px"
+        left="0"
+        right="0"
+        zIndex={99999}
+        bgColor="ui.white"
         sx={{
-          [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]: {
-            display: "flex",
-            justifyContent: "space-between",
+          [`@media screen and (min-width: ${headerBreakpoints.smTablet}px)`]: {
+            pt: "xs",
           },
+          alignItems: "center",
         }}
+        onFocusCapture={() => setIsFocused(true)}
+        onBlurCapture={() => setIsFocused(false)}
       >
-        <HStack
-          justify="space-between"
+        <Box
+          maxWidth="1280px"
+          mx="auto"
+          padding="0 16px !important"
           sx={{
-            display: "none",
-            [`@media screen and (min-width: ${headerBreakpoints.smTablet}px)`]:
+            [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]:
               {
                 display: "flex",
-                pt: "2px",
+                justifyContent: "space-between",
               },
-            pb: "xs",
           }}
         >
-          <DCLogo isMobile={false} />
-          <Box
+          <HStack
+            justify="space-between"
             sx={{
-              display: "block",
-              [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]:
+              display: "none",
+              [`@media screen and (min-width: ${headerBreakpoints.smTablet}px)`]:
+                {
+                  display: "flex",
+                  pt: "2px",
+                },
+              pb: "xs",
+            }}
+          >
+            <DCLogo isMobile={false} />
+            <Box
+              sx={{
+                display: "block",
+                [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]:
+                  {
+                    display: "none",
+                  },
+              }}
+            >
+              <NavMenu render={0} />
+            </Box>
+          </HStack>
+          <HStack
+            sx={{
+              display: isScrollingUp ? "flex" : "none",
+              [`@media screen and (min-width: ${headerBreakpoints.smTablet}px)`]:
+                {
+                  display: "none",
+                },
+              justifyContent: "space-between",
+              paddingTop: "xs",
+              paddingBottom: "xs",
+            }}
+          >
+            <DCLogo isMobile={true} />
+            <MobileNavMenu />
+          </HStack>
+          <HorizontalRule
+            height="1px"
+            width="auto"
+            sx={{
+              borderColor: "var(--nypl-colors-ui-border-default)",
+              margin: "0 -15px",
+              [`@media screen and (min-width: ${headerBreakpoints.smTablet}px)`]:
                 {
                   display: "none",
                 },
             }}
+          />
+          <VStack
+            align="end"
+            sx={{
+              [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]:
+                {
+                  width: "36%",
+                },
+              paddingTop: "xs",
+            }}
           >
-            <NavMenu render={0} />
-          </Box>
-        </HStack>
-        <HStack
-          sx={{
-            display: isScrollingUp ? "flex" : "none",
-            [`@media screen and (min-width: ${headerBreakpoints.smTablet}px)`]:
-              {
+            <Box
+              sx={{
                 display: "none",
-              },
-            justifyContent: "space-between",
-            paddingTop: "xs",
-            paddingBottom: "xs",
-          }}
-        >
-          <DCLogo isMobile={true} />
-          <MobileNavMenu />
-        </HStack>
+                [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]:
+                  {
+                    display: isScrollingUp ? "block" : "none",
+                  },
+              }}
+            >
+              <NavMenu render={1} />
+            </Box>
+            <Search />
+          </VStack>
+        </Box>
         <HorizontalRule
           height="1px"
           width="auto"
           sx={{
             borderColor: "var(--nypl-colors-ui-border-default)",
-            margin: "0 -15px",
-            [`@media screen and (min-width: ${headerBreakpoints.smTablet}px)`]:
-              {
-                display: "none",
-              },
+            margin: "0px",
+            display: "block",
           }}
         />
-        <VStack
-          align="end"
-          sx={{
-            [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]:
-              {
-                width: "36%",
-              },
-            paddingTop: "xs",
-          }}
-        >
-          <Box
-            sx={{
-              display: "none",
-              [`@media screen and (min-width: ${headerBreakpoints.lgTablet}px)`]:
-                {
-                  display: isScrollingUp ? "block" : "none",
-                },
-            }}
-          >
-            <NavMenu render={1} />
-          </Box>
-          <Search />
-        </VStack>
       </Box>
-      <HorizontalRule
-        height="1px"
-        width="auto"
-        sx={{
-          borderColor: "var(--nypl-colors-ui-border-default)",
-          margin: "0px",
-          display: "block",
-        }}
-      />
-    </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3523](https://newyorkpubliclibrary.atlassian.net/browse/DR-3523)

## This PR does the following:

- Adds `position: fixed` and space to header when there's focus within (to prevent layout shift when user types in search bar)


## Open Questions

<!-- Any questions you want to ask the reviewer? -->

I think this introduces a flicker when there's focus in the header and the user scrolls up, which would make sense (it's `fixed` but needs to behave stickily). Is this flicker super noticeable and any ideas on how to get rid of it?

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.
