### PR TITLE
DR-3523: Header shift bug (pt 2)

### DIFF
--- a/app/src/components/publicDomainFilter/publicDomainFilter.tsx
+++ b/app/src/components/publicDomainFilter/publicDomainFilter.tsx
@@ -43,7 +43,7 @@ const PublicDomainFilter = ({ onCheckChange }: PublicDomainFilterProps) => {
         id="pd-checkbox"
         data-testid="pd-checkbox"
         name="pd_filter"
-        labelText=""
+        labelText="Search only public domain"
         showLabel={false}
         isChecked={isChecked}
         {...{ onClick: handleClick }}

--- a/app/src/components/publicDomainFilter/publicDomainFilter.tsx
+++ b/app/src/components/publicDomainFilter/publicDomainFilter.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useRef } from "react";
-import { Box, Checkbox, Link } from "@nypl/design-system-react-components";
+import {
+  Box,
+  Checkbox,
+  Link,
+  Text,
+} from "@nypl/design-system-react-components";
 import { PublicDomainFilterProps } from "../../types/props/PublicDomainFilterProps";
 
 const PublicDomainFilter = ({ onCheckChange }: PublicDomainFilterProps) => {
@@ -9,7 +14,9 @@ const PublicDomainFilter = ({ onCheckChange }: PublicDomainFilterProps) => {
   const text = (
     <>
       Search only public domain.{" "}
-      <Link href="/about#public_domain">What is public domain?</Link>
+      <Link hasVisitedState={false} href="/about#public_domain">
+        What is public domain?
+      </Link>
     </>
   );
 
@@ -23,16 +30,28 @@ const PublicDomainFilter = ({ onCheckChange }: PublicDomainFilterProps) => {
   };
 
   return (
-    <Box sx={{ pt: "15px", pb: "15px" }}>
+    <Box
+      sx={{
+        pt: "15px",
+        pb: "15px",
+        display: "flex",
+        gap: "xs",
+        justifyItems: "center",
+      }}
+    >
       <Checkbox
         id="pd-checkbox"
         data-testid="pd-checkbox"
-        labelText={text}
         name="pd_filter"
+        labelText=""
+        showLabel={false}
         isChecked={isChecked}
         {...{ onClick: handleClick }}
         ref={checkboxRef}
       />
+      <Text fontSize="14px" marginBottom="0">
+        {text}
+      </Text>
     </Box>
   );
 };


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3523](https://newyorkpubliclibrary.atlassian.net/browse/DR-3523)

## This PR does the following:

- Separates the public domain checkbox label from the `Checkbox` into its own element so that the click behavior can be overridden so that the layout doesn't shift on click so that the header doesn't jump :)

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3523]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ