### PR TITLE
DR-3550: add logs to 404 to New Relic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated DS to v3.6.0 (DR-3470)
 
 ### Added
-- log path in notFoundPage.tsx to new relic. (DR-3550)
+
 - Added Collections API authentication tokens (DR-3535)
 - Added search query redirects (DR-3529)
 - Connected search page to API (DR-3416)
+- Log path in notFoundPage.tsx to New Relic. (DR-3550)
 
 ## [0.3.5] 2025-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve layout shift on header focus (DR-3523)
 
 ### Added
-
+- log path in notFoundPage.tsx to new relic. (DR-3550)
 - Added Collections API authentication tokens (DR-3535)
 - Added search query redirects (DR-3529)
 - Connect search page to API (DR-3416)

--- a/__tests__/pages/notfoundpage.test.tsx
+++ b/__tests__/pages/notfoundpage.test.tsx
@@ -5,6 +5,7 @@ import React from "react";
 
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn(),
+  usePathname: jest.fn(),
 }));
 
 describe("Not found page", () => {

--- a/app/src/components/pages/notFoundPage/notFoundPage.tsx
+++ b/app/src/components/pages/notFoundPage/notFoundPage.tsx
@@ -13,15 +13,16 @@ import { usePathname } from "next/navigation";
 
 export default function NotFoundPage() {
   const pathname = usePathname();
+
   useEffect(() => {
-    const errorMessage = `${pathname} not found`;
-    console.error(pathname);
+    const errorMessage = `DCF: ${pathname} not found`;
+    console.error(errorMessage);
 
     // Send message to New Relic
     if ((window as any).newrelic) {
       (window as any).newrelic.noticeError(errorMessage);
     }
-  }, ["error"]);
+  }, [pathname]);
 
   return (
     <PageLayout

--- a/app/src/components/pages/notFoundPage/notFoundPage.tsx
+++ b/app/src/components/pages/notFoundPage/notFoundPage.tsx
@@ -8,8 +8,21 @@ import {
 import PageLayout from "../../pageLayout/pageLayout";
 import Image from "next/image";
 import { createAdobeAnalyticsPageName } from "@/src/utils/utils";
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 
 export default function NotFoundPage() {
+  const pathname = usePathname();
+  useEffect(() => {
+    const errorMessage = `${pathname} not found`;
+    console.error(pathname);
+
+    // Send message to New Relic
+    if ((window as any).newrelic) {
+      (window as any).newrelic.noticeError(errorMessage);
+    }
+  }, ["error"]);
+
   return (
     <PageLayout
       activePage="notFound"

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
-- Resolve layout shift on header focus (DR-3523)
+- Resolved layout shift on header focus (DR-3523)
+- Updated DS to v3.6.0 (DR-3470)
 
 ### Added
 - log path in notFoundPage.tsx to new relic. (DR-3550)
 - Added Collections API authentication tokens (DR-3535)
 - Added search query redirects (DR-3529)
-- Connect search page to API (DR-3416)
+- Connected search page to API (DR-3416)
 
 ## [0.3.5] 2025-03-27
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -13,10 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated DS to v3.6.0 (DR-3470)
 
 ### Added
-- log path in notFoundPage.tsx to new relic. (DR-3550)
+
 - Added Collections API authentication tokens (DR-3535)
 - Added search query redirects (DR-3529)
 - Connected search page to API (DR-3416)
+- Log path in notFoundPage.tsx to New Relic. (DR-3550)
 
 ## [0.3.5] 2025-03-27
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Updated
+
+- Resolve layout shift on header focus (DR-3523)
+
+### Added
+- log path in notFoundPage.tsx to new relic. (DR-3550)
+- Added Collections API authentication tokens (DR-3535)
+- Added search query redirects (DR-3529)
+- Connect search page to API (DR-3416)
+
 ## [0.3.5] 2025-03-27
 
 ### Added


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3550](https://newyorkpubliclibrary.atlassian.net/browse/DR-3550)

## This PR does the following:

- Adds client-side logs to see the path that resulted in the 404 not found page.
- Logs this to New Relic.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- N/A

## How has this been tested? How should a reviewer test this?

Will test on QA NR.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3550]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ