### PR TITLE
No ref: Search filter redirects

### DIFF
--- a/__tests__/middleware/collectionRedirects.test.tsx
+++ b/__tests__/middleware/collectionRedirects.test.tsx
@@ -13,11 +13,11 @@ jest.mock("next/server", () => {
 
 let request: NextRequest;
 
-it("redirects collection_keywords to q", () => {
+it("redirects collection_keywords to q", async () => {
   const request = {
     nextUrl: new URL("http://localhost/collections?collection_keywords=test"),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/collections?q=test",
@@ -26,13 +26,13 @@ it("redirects collection_keywords to q", () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms collection_keywords to q and maintains other parameters", () => {
+it("transforms collection_keywords to q and maintains other parameters", async () => {
   const request = {
     nextUrl: new URL(
       "http://localhost/collections?collection_keywords=test&sort=title-asc&page=23"
     ),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/collections?sort=title-asc&page=23&q=test",
@@ -41,23 +41,23 @@ it("transforms collection_keywords to q and maintains other parameters", () => {
   expect(response).toBe("redirect response");
 });
 
-it("goes through unchanged if no collection_keywords= param", () => {
+it("goes through unchanged if no collection_keywords= param", async () => {
   request = {
     nextUrl: new URL("http://localhost/collections?sort=title-asc"),
   } as NextRequest;
 
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.next).toHaveBeenCalled();
   expect(response).toBe("next response");
 });
 
-it("redirects existing collection slug to uuid", () => {
+it("redirects existing collection slug to uuid", async () => {
   request = {
     nextUrl: new URL("http://localhost/collections/script-b"),
   } as NextRequest;
 
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/collections/5af6c940-c45b-013c-85aa-0242ac110005",
@@ -66,12 +66,12 @@ it("redirects existing collection slug to uuid", () => {
   expect(response).toBe("redirect response");
 });
 
-it("redirects non-existent collection slug to title search", () => {
+it("redirects non-existent collection slug to title search", async () => {
   request = {
     nextUrl: new URL("http://localhost/collections/hello-im-not-a-real-slug"),
   } as NextRequest;
 
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?q=Hello+Im+Not+A+Real+Slug",
@@ -80,14 +80,14 @@ it("redirects non-existent collection slug to title search", () => {
   expect(response).toBe("redirect response");
 });
 
-it("passes a collection uuid through", () => {
+it("passes a collection uuid through", async () => {
   request = {
     nextUrl: new URL(
       "http://localhost/collections/bc920670-c5f9-012f-63ad-58d385a7bc34"
     ),
   } as NextRequest;
 
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.next).toHaveBeenCalled();
   expect(response).toBe("next response");

--- a/__tests__/middleware/searchRedirects.test.tsx
+++ b/__tests__/middleware/searchRedirects.test.tsx
@@ -1,5 +1,16 @@
 import { middleware } from "middleware";
 import { NextRequest, NextResponse } from "next/server";
+import { CollectionsApi } from "../../app/src/utils/apiClients";
+
+jest.mock("../../app/src/utils/apiClients", () => {
+  return {
+    CollectionsApi: {
+      getCollectionData: jest
+        .fn()
+        .mockResolvedValue({ title: "Mocked Collection Title" }),
+    },
+  };
+});
 
 jest.mock("next/server", () => {
   return {
@@ -13,11 +24,11 @@ jest.mock("next/server", () => {
 
 let request: NextRequest;
 
-it("transforms keywords to q", () => {
+it("transforms keywords to q", async () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?keywords=test"),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?q=test",
@@ -26,11 +37,11 @@ it("transforms keywords to q", () => {
   expect(response).toBe("redirect response");
 });
 
-it("drops ascending/descending relevance sort (default sort)", () => {
+it("drops ascending/descending relevance sort (default sort)", async () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?sort=score+desc"),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?",
@@ -39,11 +50,11 @@ it("drops ascending/descending relevance sort (default sort)", () => {
   expect(response).toBe("redirect response");
 });
 
-it("drops sequence sort", () => {
+it("drops sequence sort", async () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?sort=sortString+desc"),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?",
@@ -52,11 +63,11 @@ it("drops sequence sort", () => {
   expect(response).toBe("redirect response");
 });
 
-it("drops date created sort", () => {
+it("drops date created sort", async () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?sort=keyDate_st+asc"),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?",
@@ -65,11 +76,11 @@ it("drops date created sort", () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms date digitized ascending/descending sort", () => {
+it("transforms date digitized ascending/descending sort", async () => {
   const request1 = {
     nextUrl: new URL("http://localhost/search/index?sort=dateDigitized_dt+asc"),
   } as NextRequest;
-  const response1 = middleware(request1);
+  const response1 = await middleware(request1);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?sort=date-asc",
@@ -82,7 +93,7 @@ it("transforms date digitized ascending/descending sort", () => {
       "http://localhost/search/index?sort=dateDigitized_dt+desc"
     ),
   } as NextRequest;
-  const response2 = middleware(request2);
+  const response2 = await middleware(request2);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?sort=date-desc",
@@ -91,11 +102,11 @@ it("transforms date digitized ascending/descending sort", () => {
   expect(response2).toBe("redirect response");
 });
 
-it("transforms title alphabetical ascending/descending sort", () => {
+it("transforms title alphabetical ascending/descending sort", async () => {
   const request1 = {
     nextUrl: new URL("http://localhost/search/index?sort=mainTitle_ns+asc"),
   } as NextRequest;
-  const response1 = middleware(request1);
+  const response1 = await middleware(request1);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?sort=title-asc",
@@ -106,7 +117,7 @@ it("transforms title alphabetical ascending/descending sort", () => {
   const request2 = {
     nextUrl: new URL("http://localhost/search/index?sort=mainTitle_ns+desc"),
   } as NextRequest;
-  const response2 = middleware(request2);
+  const response2 = await middleware(request2);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?sort=title-desc",
@@ -115,11 +126,11 @@ it("transforms title alphabetical ascending/descending sort", () => {
   expect(response2).toBe("redirect response");
 });
 
-it("drops scroll", () => {
+it("drops scroll", async () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?keywords=#/?scroll=136"),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?",
@@ -128,23 +139,23 @@ it("drops scroll", () => {
   expect(response).toBe("redirect response");
 });
 
-it("maintains page", () => {
+it("maintains page", async () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?page=2"),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.next).toHaveBeenCalled();
   expect(response).toBe("next response");
 });
 
-it("transforms a filter", () => {
+it("transforms a filter", async () => {
   const request = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bname%5D=Swope%2C+Martha"
     ),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Bname%3DSwope%2C+Martha%5D",
@@ -153,13 +164,13 @@ it("transforms a filter", () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms multiple filters", () => {
+it("transforms multiple filters", async () => {
   const request = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bgenre%5D=Photographs&filters%5Bname%5D%5B%5D=Swope%2C+Martha"
     ),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Bgenre%3DPhotographs%5D%5Bname%3DSwope%2C+Martha%5D",
@@ -168,11 +179,11 @@ it("transforms multiple filters", () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms rights filter", () => {
+it("transforms rights filter", async () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?filters%5Brights%5D=pd"),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Brights%3DpublicDomain%5D",
@@ -181,13 +192,13 @@ it("transforms rights filter", () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms year_begin and year_end filters", () => {
+it("transforms year_begin and year_end filters", async () => {
   const request = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bgenre%5D%5B%5D=Cards&keywords=&&&&year_begin=1900&year_end=1905&"
     ),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Bgenre%3DCards%5D%5BdateStart%3D1900%5D%5BdateEnd%3D1905%5D",
@@ -196,13 +207,13 @@ it("transforms year_begin and year_end filters", () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms date filter", () => {
+it("transforms date filter", async () => {
   const requestWithOnlyDate = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bdate%5D%5B%5D=1900-1905"
     ),
   } as NextRequest;
-  const response = middleware(requestWithOnlyDate);
+  const response = await middleware(requestWithOnlyDate);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5BdateStart%3D1900%5D%5BdateEnd%3D1905%5D",
@@ -211,13 +222,13 @@ it("transforms date filter", () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms date and one year filter", () => {
+it("transforms date and one year filter", async () => {
   const requestWithDateAndYear = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bdate%5D%5B%5D=-9999-1903&filters%5Bgenre%5D=Scores&keywords=hello"
     ),
   } as NextRequest;
-  const response = middleware(requestWithDateAndYear);
+  const response = await middleware(requestWithDateAndYear);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?q=hello&filters=%5BdateEnd%3D1903%5D%5Bgenre%3DScores%5D",
@@ -227,13 +238,13 @@ it("transforms date and one year filter", () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms date and both year filters", () => {
+it("transforms date and both year filters", async () => {
   const requestWithDateAndYears = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bdate%5D%5B%5D=1900-1905&keywords=hello&year_begin=1901&year_end=1905&"
     ),
   } as NextRequest;
-  const response = middleware(requestWithDateAndYears);
+  const response = await middleware(requestWithDateAndYears);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?q=hello&filters=%5BdateStart%3D1901%5D%5BdateEnd%3D1905%5D",
@@ -242,13 +253,13 @@ it("transforms date and both year filters", () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms filter titles where necessary", () => {
+it("transforms filter titles where necessary", async () => {
   const requestWithDateAndYears = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bform_mtxt_s%5D%5B%5D=Photocopies&filters%5Bpublisher%5D=The+Division&keywords="
     ),
   } as NextRequest;
-  const response = middleware(requestWithDateAndYears);
+  const response = await middleware(requestWithDateAndYears);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Bform%3DPhotocopies%5D%5Bpublisher%3DThe+Division%5D",
@@ -257,13 +268,28 @@ it("transforms filter titles where necessary", () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms many params", () => {
+it("transforms root-collection and fetches collection title", async () => {
+  const requestWithRootCollection = {
+    nextUrl: new URL(
+      "http://localhost/search/index?filters%5Broot-collection%5D=16ad5350-c52e-012f-aecf-58d385a7bc34&keywords="
+    ),
+  } as NextRequest;
+  const response = await middleware(requestWithRootCollection);
+
+  expect(NextResponse.redirect).toHaveBeenCalledWith(
+    "http://localhost/search/index?filters=%5Bcollection%3DMocked+Collection+Title%7C%7C16ad5350-c52e-012f-aecf-58d385a7bc34%5D",
+    301
+  );
+  expect(response).toBe("redirect response");
+});
+
+it("transforms many params", async () => {
   const request = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bdate%5D%5B%5D=1900-9999&filters%5Bgenre%5D%5B%5D=Cards&filters%5Bname%5D%5B%5D=Ogden%27s+Cigarettes&filters%5Brights%5D=pd&keywords="
     ),
   } as NextRequest;
-  const response = middleware(request);
+  const response = await middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5BdateStart%3D1900%5D%5Bgenre%3DCards%5D%5Bname%3DOgden%27s+Cigarettes%5D%5Brights%3DpublicDomain%5D",

--- a/__tests__/middleware/searchRedirects.test.tsx
+++ b/__tests__/middleware/searchRedirects.test.tsx
@@ -1,16 +1,11 @@
 import { middleware } from "middleware";
 import { NextRequest, NextResponse } from "next/server";
-import { CollectionsApi } from "../../app/src/utils/apiClients";
 
-jest.mock("../../app/src/utils/apiClients", () => {
-  return {
-    CollectionsApi: {
-      getCollectionData: jest
-        .fn()
-        .mockResolvedValue({ title: "Mocked Collection Title" }),
-    },
-  };
-});
+(global as any).fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve({ title: "Mocked Collection Title" }),
+  })
+);
 
 jest.mock("next/server", () => {
   return {

--- a/__tests__/middleware/searchRedirects.test.tsx
+++ b/__tests__/middleware/searchRedirects.test.tsx
@@ -248,7 +248,7 @@ it("transforms date and both year filters", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms filter titles where necessary", async () => {
+it("transforms filter titles where necessary (form)", async () => {
   const requestWithDateAndYears = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bform_mtxt_s%5D%5B%5D=Photocopies&filters%5Bpublisher%5D=The+Division&keywords="
@@ -258,6 +258,21 @@ it("transforms filter titles where necessary", async () => {
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Bform%3DPhotocopies%5D%5Bpublisher%3DThe+Division%5D",
+    301
+  );
+  expect(response).toBe("redirect response");
+});
+
+it("transforms filter titles (place)", async () => {
+  const requestWithDateAndYears = {
+    nextUrl: new URL(
+      "http://localhost/search/index?filters%5BplaceTerm_mtxt_s%5D%5B%5D=Photocopies&filters%5Bpublisher%5D=The+Division&keywords="
+    ),
+  } as NextRequest;
+  const response = await middleware(requestWithDateAndYears);
+
+  expect(NextResponse.redirect).toHaveBeenCalledWith(
+    "http://localhost/search/index?filters=%5Bplace%3DPhotocopies%5D%5Bpublisher%3DThe+Division%5D",
     301
   );
   expect(response).toBe("redirect response");

--- a/__tests__/middleware/searchRedirects.test.tsx
+++ b/__tests__/middleware/searchRedirects.test.tsx
@@ -242,6 +242,21 @@ it("transforms date and both year filters", () => {
   expect(response).toBe("redirect response");
 });
 
+it("transforms filter titles where necessary", () => {
+  const requestWithDateAndYears = {
+    nextUrl: new URL(
+      "http://localhost/search/index?filters%5Bform_mtxt_s%5D%5B%5D=Photocopies&filters%5Bpublisher%5D=The+Division&keywords="
+    ),
+  } as NextRequest;
+  const response = middleware(requestWithDateAndYears);
+
+  expect(NextResponse.redirect).toHaveBeenCalledWith(
+    "http://localhost/search/index?filters=%5Bform%3DPhotocopies%5D%5Bpublisher%3DThe+Division%5D",
+    301
+  );
+  expect(response).toBe("redirect response");
+});
+
 it("transforms many params", () => {
   const request = {
     nextUrl: new URL(

--- a/app/src/config/constants.ts
+++ b/app/src/config/constants.ts
@@ -47,7 +47,6 @@ export const ALLOWED_FILTERS = [
   "topic",
   "name",
   "collection",
-  // To do: subcollection?
   "place",
   "format",
   "name",
@@ -59,5 +58,8 @@ export const ALLOWED_FILTERS = [
   "dateEnd",
   "rightsFilter",
   "rights",
+  "form",
+  "language",
+  "subcollection",
   "materialType",
 ];

--- a/app/src/utils/fetchApi.ts
+++ b/app/src/utils/fetchApi.ts
@@ -63,7 +63,7 @@ export const fetchApi = async ({
     })) as Response;
 
     if (response.status === 422) {
-      //logger.error(`Invalid parameter value: ${apiUrl}`);
+      logger.error(`Invalid parameter value: ${apiUrl}`);
     } else if (!response.ok) {
       throw new Error(
         `fetchApi: ${response.status} ${
@@ -73,7 +73,7 @@ export const fetchApi = async ({
     }
     return await response.json();
   } catch (error) {
-    //logger.error(error);
+    logger.error(error);
     throw new Error(error.message);
   }
 };

--- a/app/src/utils/fetchApi.ts
+++ b/app/src/utils/fetchApi.ts
@@ -63,7 +63,7 @@ export const fetchApi = async ({
     })) as Response;
 
     if (response.status === 422) {
-      logger.error(`Invalid parameter value: ${apiUrl}`);
+      //logger.error(`Invalid parameter value: ${apiUrl}`);
     } else if (!response.ok) {
       throw new Error(
         `fetchApi: ${response.status} ${
@@ -73,7 +73,7 @@ export const fetchApi = async ({
     }
     return await response.json();
   } catch (error) {
-    logger.error(error);
+    //logger.error(error);
     throw new Error(error.message);
   }
 };

--- a/app/src/utils/searchManager.tsx
+++ b/app/src/utils/searchManager.tsx
@@ -265,7 +265,9 @@ export const transformToAvailableFilters = (
   availableFilters: Record<string, AvailableFilterOption[]>
 ): AvailableFilter[] => {
   return Object.entries(availableFilters)
-    .filter(([key]) => key !== "subcollection")
+    .filter(
+      ([key]) => key !== "subcollection" && key !== "language" && key !== "form"
+    )
     .map(([key, options]) => ({
       name: key,
       options,

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,17 @@ import collectionSlugToUuidMapping from "@/src/data/collectionSlugUuidMapping";
 import { deSlugify } from "@/src/utils/utils";
 import { NextRequest, NextResponse } from "next/server";
 
+const filterMap = {
+  placeTerm_mtxt_s: "place",
+  genre_mtxt_s: "genre",
+  typeOfResource_mtxt_s: "type",
+  publisher_mtxt_s: "publisher",
+  namePart_mtxt_s: "name",
+  topic_mtxt_s: "topic",
+  languageTerm_mtxt_s: "language",
+  form_mtxt_s: "form",
+};
+
 async function getCollectionTitle(uuid): Promise<string> {
   try {
     const response = await fetch(
@@ -119,43 +130,11 @@ export async function middleware(req: NextRequest) {
       let filterValue = decodeURIComponent(value);
       if (filterKey === "rights" && filterValue === "pd") {
         filterValue = "publicDomain";
-      }
-      switch (filterKey) {
-        case "rights":
-          if (filterValue === "pd") {
-            filterValue = "publicDomain";
-          }
-          break;
-        case "placeTerm_mtxt_s":
-          filterKey = "place";
-          break;
-        case "genre_mtxt_s":
-          filterKey = "genre";
-          break;
-        case "typeOfResource_mtxt_s":
-          filterKey = "type";
-          break;
-        case "publisher_mtxt_s":
-          filterKey = "publisher";
-          break;
-        case "namePart_mtxt_s":
-          filterKey = "name";
-          break;
-        case "topic_mtxt_s":
-          filterKey = "topic";
-          break;
-        case "languageTerm_mtxt_s":
-          filterKey = "language";
-          break;
-        case "form_mtxt_s":
-          filterKey = "form";
-          break;
-        case "root-collection":
-          filterKey = "collection";
-          filterValue = await getCollectionTitle(filterValue);
-          break;
-        default:
-          break;
+      } else if (filterKey === "root-collection") {
+        filterKey = "collection";
+        filterValue = await getCollectionTitle(filterValue);
+      } else if (filterMap[filterKey]) {
+        filterKey = filterMap[filterKey];
       }
       if (filterKey === "date") {
         // Regular expression to match end date x-9999, start date -9999-x, or x-x (both)

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,13 +11,12 @@ async function getCollectionTitle(uuid): Promise<string> {
         headers: {
           "x-nypl-collections-api-key": `${process.env.COLLECTIONS_API_AUTH_TOKEN}`,
         },
-        body: undefined,
       }
     );
     const collectionData = await response.json();
     return `${collectionData.title}||${uuid}`;
-  } catch (err) {
-    console.error("Error fetching root collection:", err);
+  } catch (error) {
+    console.error("Error fetching root collection:", error);
     return "";
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,11 +5,12 @@ import { NextRequest, NextResponse } from "next/server";
 async function getCollectionTitle(uuid): Promise<string> {
   try {
     const response = await fetch(
-      `${process.env.COLLECTIONS_API_URL}/collections/${uuid}`,
+      `${process.env.COLLECTIONS_API_URL}/collections/${uuid}}`,
       {
         method: "GET",
         headers: {
           "x-nypl-collections-api-key": `${process.env.COLLECTIONS_API_AUTH_TOKEN}`,
+          "Cache-Control": "no-cache",
         },
       }
     );
@@ -150,7 +151,6 @@ export async function middleware(req: NextRequest) {
           filterKey = "form";
           break;
         case "root-collection":
-          console.log("this is happening");
           filterKey = "collection";
           filterValue = await getCollectionTitle(filterValue);
           break;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,26 @@
 import collectionSlugToUuidMapping from "@/src/data/collectionSlugUuidMapping";
-import { CollectionsApi } from "@/src/utils/apiClients";
 import { deSlugify } from "@/src/utils/utils";
 import { NextRequest, NextResponse } from "next/server";
+
+async function getCollectionTitle(uuid): Promise<string> {
+  try {
+    const response = await fetch(
+      `${process.env.COLLECTIONS_API_URL}/collections/${uuid}`,
+      {
+        method: "GET",
+        headers: {
+          "x-nypl-collections-api-key": `${process.env.COLLECTIONS_API_AUTH_TOKEN}`,
+        },
+        body: undefined,
+      }
+    );
+    const collectionData = await response.json();
+    return `${collectionData.title}||${uuid}`;
+  } catch (err) {
+    console.error("Error fetching root collection:", err);
+    return "";
+  }
+}
 
 export async function middleware(req: NextRequest) {
   const url = req.nextUrl;
@@ -132,14 +151,9 @@ export async function middleware(req: NextRequest) {
           filterKey = "form";
           break;
         case "root-collection":
+          console.log("this is happening");
           filterKey = "collection";
-          try {
-            const collectionData =
-              await CollectionsApi.getCollectionData(filterValue);
-            filterValue = `${collectionData.title}||${filterValue}`;
-          } catch (err) {
-            console.error("Error fetching root collection:", err);
-          }
+          filterValue = await getCollectionTitle(filterValue);
           break;
         default:
           break;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Ticket:

## This PR does the following:

- Handles _filter_ redirects within the search query, so that links to filters from the item page (ex. [item with physical description link](https://digitalcollections.nypl.org/items/c7438e90-ebed-013d-3ecf-0242ac110002)) as well as bookmarked filters on a search query will work
- See [this doc](https://docs.google.com/document/d/1_HDSzW5ToWf6ariAm7G0VWoUTvPBCqbq7q-9gInqQiM/edit?tab=t.0#heading=h.1ku3d96grql6) again for all the expected redirects and example URLs
- Lana has confirmed that for filters that do not appear as dropdowns on our new search page (namely physical description/form and language) the tag appearing in the "Applied filters:" is sufficient to indicate that you are filtering with that value, even if the dropdown isn't visible/selected
- Similar work will need to be done with `subcollection` but I'm considering that part of the collection landing page work.. I think (`collections/[someCollectionSlug]/?tab=navigation&roots=[someSubcollectionUuid]` needs to go to `collections/[someCollectionUuid]?filters=[subcollection=someSubcollectionTitle||Uuid]`)

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- In order to transform `root-collection = uuid` to a Collections API-acceptable `collection = title || uuid`, we have to request the collection title, making this middleware async. The `collections/:uuid` endpoint is so fast that I think this is worth it... what do you guys think


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
