### PR TITLE
DR-3564: Encode filter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed filters to be encoded as URI components (DR-3564)
+
 ## [0.3.6] 2025-04-21
 
 ### Updated

--- a/app/src/utils/utils.test.tsx
+++ b/app/src/utils/utils.test.tsx
@@ -298,7 +298,7 @@ describe("filterStringToCollectionApiFilterString", () => {
   test("generates the correct filter syntax for a single filter", () => {
     expect(
       filterStringToCollectionApiFilterString("[Name=Swope, Martha]")
-    ).toBe("name=Swope, Martha");
+    ).toBe("name=Swope%2C%20Martha");
     expect(
       filterStringToCollectionApiFilterString(
         "[Collection=Print Collection portrait file||16ad5350-c52e-012f-aecf-58d385a7bc34]"
@@ -314,7 +314,7 @@ describe("filterStringToCollectionApiFilterString", () => {
         "[name=Swope, Martha][collection=Print Collection portrait file||16ad5350-c52e-012f-aecf-58d385a7bc34]"
       )
     ).toBe(
-      "name=Swope, Martha&collection=Print Collection portrait file||16ad5350-c52e-012f-aecf-58d385a7bc34"
+      "name=Swope%2C%20Martha&collection=Print%20Collection%20portrait%20file%7C%7C16ad5350-c52e-012f-aecf-58d385a7bc34"
     );
   });
 

--- a/app/src/utils/utils.test.tsx
+++ b/app/src/utils/utils.test.tsx
@@ -304,7 +304,7 @@ describe("filterStringToCollectionApiFilterString", () => {
         "[Collection=Print Collection portrait file||16ad5350-c52e-012f-aecf-58d385a7bc34]"
       )
     ).toBe(
-      "collection=Print Collection portrait file||16ad5350-c52e-012f-aecf-58d385a7bc34"
+      "collection=Print%20Collection%20portrait%20file%7C%7C16ad5350-c52e-012f-aecf-58d385a7bc34"
     );
   });
 

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -177,7 +177,7 @@ export const filterStringToCollectionApiFilterString = (filters: string) => {
         if (!isValidFilter(name)) {
           return null;
         }
-        return `${name}=${value}`;
+        return `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
       })
       .filter(Boolean);
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3564](https://newyorkpubliclibrary.atlassian.net/browse/DR-3564)

## This PR does the following:

- Encodes the search query filters, so that any and all special characters are encoded by the time they hit Solr
** Keyword was recently encoded in a previous PR
- Resolves bug we were noticing where filters with values containing ampersands would return no results: try `q=maps` and then selecting "G.W. Bromley & Co" under the "Name" filter. Previously, this returned 0 results, now it should correctly return ~2551

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3564]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ