### PR TITLE
DR-3598: Filter count display bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed filters to be encoded as URI components (DR-3564)
+- Fixed dropdown filters to only display selection (DR-3598)
 
 ## [0.3.6] 2025-04-21
 

--- a/app/src/components/search/filters/selectFilter.tsx
+++ b/app/src/components/search/filters/selectFilter.tsx
@@ -117,7 +117,8 @@ const SelectFilterComponent = ({
     selected && !isModalOpen
       ? [
           selected,
-          ...filter.options.filter((option) => option.name !== selected?.name),
+          // If an option is selected, don't display any others.
+          //...filter.options.filter((option) => option.name !== selected?.name),
         ]
       : filter.options;
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3598](https://newyorkpubliclibrary.atlassian.net/browse/DR-3598)

## This PR does the following:

- If a dropdown filter has a selection, it does not display any of the other options
- This is because those other filter options (and their corresponding counts) are pretty much meaningless in the context of a search query that enforces one value per filter category. To get the filter option counts as if the current filter selection is not applied (an OR filter) we would need to revamp the backend of search which we are not gonna do rn

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3598]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ