### PR TITLE
DR-3586 (continued): `geographic_mtxt_s` redirect to `topic`

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,7 @@ const filterMap = {
   publisher_mtxt_s: "publisher",
   namePart_mtxt_s: "name",
   topic_mtxt_s: "topic",
+  geographic_mtxt_s: "topic",
   languageTerm_mtxt_s: "language",
   form_mtxt_s: "form",
 };


### PR DESCRIPTION
## Ticket:

[DR-3586](https://newyorkpubliclibrary.atlassian.net/browse/DR-3586)

## This PR does the following:

- Adds `geographic_mtxt_s` to list of filter redirects

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3586]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ