### PR TITLE
DR-3609: Adding sequence sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Connects collection landing page (metadata) to API (DR-3362)
+- Added sequence sort option and new default sort functionality to search (DR-3609)
+- Connected collection landing page (metadata) to API (DR-3362)
 
 ### Fixed
 

--- a/app/collections/[uuid]/page.tsx
+++ b/app/collections/[uuid]/page.tsx
@@ -56,7 +56,7 @@ export default async function Collection({
 
   const searchResults = await CollectionsApi.getSearchData({
     keyword: searchParams.q,
-    sort: searchParams.sort,
+    sort: searchParams.sort ? searchParams.sort : "sequence",
     page: searchParams.page,
     filters,
   });

--- a/app/src/components/collectionStructure/collectionStructure.test.tsx
+++ b/app/src/components/collectionStructure/collectionStructure.test.tsx
@@ -16,6 +16,7 @@ import { GeneralSearchManager } from "@/src/utils/searchManager";
 const mockSearchManager = new GeneralSearchManager({
   initialPage: 1,
   initialSort: DEFAULT_SEARCH_SORT,
+  defaultSort: DEFAULT_SEARCH_SORT,
   initialFilters: [],
   initialKeywords: DEFAULT_SEARCH_TERM,
   lastFilterRef: { current: null },

--- a/app/src/components/collectionStructure/collectionStructure.tsx
+++ b/app/src/components/collectionStructure/collectionStructure.tsx
@@ -124,7 +124,6 @@ const toggleItem = async (
 
         // Clear search query
         searchManager.handleKeywordChange("");
-        searchManager.handleSortChange("sequence");
         searchManager.handleSearchSubmit();
         searchManager.setLastFilter(null);
 

--- a/app/src/components/collectionStructure/collectionStructure.tsx
+++ b/app/src/components/collectionStructure/collectionStructure.tsx
@@ -124,6 +124,7 @@ const toggleItem = async (
 
         // Clear search query
         searchManager.handleKeywordChange("");
+        searchManager.handleSortChange("sequence");
         searchManager.handleSearchSubmit();
         searchManager.setLastFilter(null);
 

--- a/app/src/components/pages/collectionPage/collectionPage.tsx
+++ b/app/src/components/pages/collectionPage/collectionPage.tsx
@@ -15,10 +15,9 @@ import { MobileSearchBanner } from "../../mobileSearchBanner/mobileSearchBanner"
 import { displayResults, totalNumPages } from "@/src/utils/utils";
 import {
   CARDS_PER_PAGE,
+  COLLECTION_LANDING_SORT_LABELS,
   DEFAULT_PAGE_NUM,
-  DEFAULT_SEARCH_SORT,
   DEFAULT_SEARCH_TERM,
-  SEARCH_SORT_LABELS,
 } from "@/src/config/constants";
 import SearchCardsGrid from "../../grids/searchCardsGrid";
 import {
@@ -56,7 +55,8 @@ const CollectionPage = ({
 
   const collectionSearchManager = new GeneralSearchManager({
     initialPage: Number(searchParams?.page) || DEFAULT_PAGE_NUM,
-    initialSort: searchParams?.sort || DEFAULT_SEARCH_SORT,
+    initialSort: searchParams.sort || "sequence",
+    defaultSort: "sequence",
     initialFilters: stringToFilter(searchParams?.filters),
     initialKeywords: searchParams?.q || DEFAULT_SEARCH_TERM,
     initialAvailableFilters: searchParams?.availableFilters,
@@ -199,8 +199,9 @@ const CollectionPage = ({
                     collectionSearchManager.page
                   )} results`}</Heading>
                   <SortMenu
-                    options={SEARCH_SORT_LABELS}
+                    options={COLLECTION_LANDING_SORT_LABELS}
                     searchManager={collectionSearchManager}
+                    sort={searchResults.sort}
                     updateURL={updateURL}
                     setFiltersExpanded={setFiltersExpanded}
                   />

--- a/app/src/components/pages/collectionsPage/collectionsPage.tsx
+++ b/app/src/components/pages/collectionsPage/collectionsPage.tsx
@@ -43,7 +43,7 @@ export function CollectionsPage({ data, collectionsSearchParams }) {
   const collectionsSearchManager = new CollectionSearchManager({
     initialPage: Number(collectionsSearchParams?.page) || DEFAULT_PAGE_NUM,
     initialSort: collectionsSearchParams?.sort || DEFAULT_COLLECTION_SORT,
-    defaultSort: DEFAULT_SEARCH_SORT,
+    defaultSort: DEFAULT_COLLECTION_SORT,
     initialKeywords: collectionsSearchParams?.q || DEFAULT_SEARCH_TERM,
     lastFilterRef: useRef<string | null>(null),
   });

--- a/app/src/components/pages/collectionsPage/collectionsPage.tsx
+++ b/app/src/components/pages/collectionsPage/collectionsPage.tsx
@@ -18,6 +18,7 @@ import {
   DEFAULT_COLLECTION_SORT,
   DEFAULT_SEARCH_TERM,
   COLLECTION_SORT_LABELS,
+  DEFAULT_SEARCH_SORT,
 } from "@/src/config/constants";
 import { CollectionSearchManager } from "@/src/utils/searchManager";
 import { headerBreakpoints } from "@/src/utils/breakpoints";
@@ -42,6 +43,7 @@ export function CollectionsPage({ data, collectionsSearchParams }) {
   const collectionsSearchManager = new CollectionSearchManager({
     initialPage: Number(collectionsSearchParams?.page) || DEFAULT_PAGE_NUM,
     initialSort: collectionsSearchParams?.sort || DEFAULT_COLLECTION_SORT,
+    defaultSort: DEFAULT_SEARCH_SORT,
     initialKeywords: collectionsSearchParams?.q || DEFAULT_SEARCH_TERM,
     lastFilterRef: useRef<string | null>(null),
   });
@@ -151,6 +153,7 @@ export function CollectionsPage({ data, collectionsSearchParams }) {
         >
           <SortMenu
             options={COLLECTION_SORT_LABELS}
+            sort={data.sort}
             searchManager={collectionsSearchManager}
             updateURL={updateURL}
           />

--- a/app/src/components/pages/collectionsPage/collectionsPage.tsx
+++ b/app/src/components/pages/collectionsPage/collectionsPage.tsx
@@ -65,9 +65,29 @@ export function CollectionsPage({ data, collectionsSearchParams }) {
 
   useEffect(() => {
     setIsLoaded(true);
-    if (isFirstLoad.current) {
+    let didFocusElement = false;
+    if (
+      collectionsSearchManager.lastFilterRef?.current ||
+      collectionsSearchManager.sort
+    ) {
+      // Search for the button, input, or text element associated with the last used filter/sort
+      const selectors = ["button", "input", "p", "h2"];
+
+      for (const selector of selectors) {
+        const el = document.querySelector(
+          `${selector}[id="${collectionsSearchManager.lastFilterRef.current}"]`
+        );
+        if (el) {
+          (el as HTMLElement).focus();
+          didFocusElement = true;
+          break;
+        }
+      }
+    }
+    if (!didFocusElement && isFirstLoad.current) {
       headingRef.current?.focus();
     }
+
     isFirstLoad.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collections]);
@@ -111,13 +131,14 @@ export function CollectionsPage({ data, collectionsSearchParams }) {
             labelText: "Search by collection title",
             name: "collection_keywords",
             placeholder: "Search by collection title",
-            defaultValue: collectionsSearchManager.keywords,
+            defaultValue: data.keywords,
             onChange: (e) =>
               collectionsSearchManager.handleKeywordChange(
                 (e.target as HTMLInputElement).value
               ),
           }}
           onSubmit={() => {
+            collectionsSearchManager.setLastFilter(null);
             updateURL(collectionsSearchManager.handleSearchSubmit());
           }}
         />
@@ -181,6 +202,7 @@ export function CollectionsPage({ data, collectionsSearchParams }) {
           initialPage={collectionsSearchManager.page}
           pageCount={totalPages}
           onPageChange={(newPage) => {
+            collectionsSearchManager.setLastFilter(null);
             updateURL(collectionsSearchManager.handlePageChange(newPage));
           }}
           sx={{

--- a/app/src/components/pages/searchPage/searchPage.tsx
+++ b/app/src/components/pages/searchPage/searchPage.tsx
@@ -190,6 +190,7 @@ const SearchPage = ({
               )} results`}</Heading>
               <SortMenu
                 options={SEARCH_SORT_LABELS}
+                sort={searchResults.sort}
                 searchManager={searchManager}
                 setFiltersExpanded={setFiltersExpanded}
                 updateURL={updateURL}

--- a/app/src/components/search/collectionSearch.tsx
+++ b/app/src/components/search/collectionSearch.tsx
@@ -70,7 +70,7 @@ export const CollectionSearch = ({ searchManager }: CollectionSearchProps) => {
               { filter: "subcollection", value: "null" },
             ]);
             searchManager.setLastFilter(null);
-            updateURL(searchManager.handleSearchSubmit());
+            updateURL(searchManager.handleSearchSubmit("relevance"));
           }}
           sx={{
             display: "block",

--- a/app/src/components/search/filters/activeFilters.test.tsx
+++ b/app/src/components/search/filters/activeFilters.test.tsx
@@ -62,7 +62,7 @@ describe("ActiveFilters", () => {
     const mockEmptyManager = new GeneralSearchManager({
       initialPage: 1,
       initialSort: DEFAULT_SEARCH_SORT,
-      defaultSort: "relevance",
+      defaultSort: DEFAULT_SEARCH_SORT,
       initialFilters: [],
       initialKeywords: DEFAULT_SEARCH_TERM,
       lastFilterRef: { current: null },

--- a/app/src/components/search/filters/activeFilters.test.tsx
+++ b/app/src/components/search/filters/activeFilters.test.tsx
@@ -22,6 +22,7 @@ describe("ActiveFilters", () => {
     mockManager = new GeneralSearchManager({
       initialPage: 1,
       initialSort: DEFAULT_SEARCH_SORT,
+      defaultSort: DEFAULT_SEARCH_SORT,
       initialFilters: [
         { filter: "topic", value: "art" },
         { filter: "format", value: "book" },
@@ -61,6 +62,7 @@ describe("ActiveFilters", () => {
     const mockEmptyManager = new GeneralSearchManager({
       initialPage: 1,
       initialSort: DEFAULT_SEARCH_SORT,
+      defaultSort: "relevance",
       initialFilters: [],
       initialKeywords: DEFAULT_SEARCH_TERM,
       lastFilterRef: { current: null },

--- a/app/src/components/search/filters/selectFilter.test.tsx
+++ b/app/src/components/search/filters/selectFilter.test.tsx
@@ -35,6 +35,7 @@ jest.mock("next/navigation", () => ({
 let mockManager = new GeneralSearchManager({
   initialPage: 1,
   initialSort: DEFAULT_SEARCH_SORT,
+  defaultSort: DEFAULT_SEARCH_SORT,
   initialFilters: [],
   initialKeywords: DEFAULT_SEARCH_TERM,
   lastFilterRef: { current: null },

--- a/app/src/components/search/filters/selectFilterGrid.test.tsx
+++ b/app/src/components/search/filters/selectFilterGrid.test.tsx
@@ -20,6 +20,7 @@ const manager = new GeneralSearchManager({
   initialPage: 1,
   initialSort: DEFAULT_SEARCH_SORT,
   initialFilters: [],
+  defaultSort: DEFAULT_SEARCH_SORT,
   initialKeywords: DEFAULT_SEARCH_TERM,
   initialAvailableFilters: mockSearchResponse.availableFilters,
 });

--- a/app/src/components/search/filters/selectFilterModal.test.tsx
+++ b/app/src/components/search/filters/selectFilterModal.test.tsx
@@ -48,6 +48,7 @@ describe("SelectFilterModal", () => {
   let mockManager = new GeneralSearchManager({
     initialPage: 1,
     initialSort: DEFAULT_SEARCH_SORT,
+    defaultSort: DEFAULT_SEARCH_SORT,
     initialFilters: [],
     initialKeywords: DEFAULT_SEARCH_TERM,
   });

--- a/app/src/components/sortMenu/sortMenu.test.tsx
+++ b/app/src/components/sortMenu/sortMenu.test.tsx
@@ -19,6 +19,7 @@ describe("SortMenu", () => {
     manager = new GeneralSearchManager({
       initialPage: 1,
       initialSort: DEFAULT_SEARCH_SORT,
+      defaultSort: DEFAULT_SEARCH_SORT,
       initialFilters: [],
       initialKeywords: DEFAULT_SEARCH_TERM,
       lastFilterRef: { current: null },
@@ -29,6 +30,7 @@ describe("SortMenu", () => {
     render(
       <SortMenu
         updateURL={updateURL}
+        sort={manager.sort}
         searchManager={manager}
         options={options}
         setFiltersExpanded={() => {
@@ -43,6 +45,7 @@ describe("SortMenu", () => {
     render(
       <SortMenu
         updateURL={updateURL}
+        sort={manager.sort}
         searchManager={manager}
         options={options}
         setFiltersExpanded={() => {
@@ -63,6 +66,7 @@ describe("SortMenu", () => {
       <SortMenu
         updateURL={updateURL}
         searchManager={manager}
+        sort={manager.sort}
         options={options}
         setFiltersExpanded={() => {
           console.log("expanded");

--- a/app/src/components/sortMenu/sortMenu.tsx
+++ b/app/src/components/sortMenu/sortMenu.tsx
@@ -6,6 +6,7 @@ type SortMenuProps = {
   searchManager: SearchManager;
   options: Record<string, string>;
   setFiltersExpanded?: React.Dispatch<React.SetStateAction<boolean>>;
+  sort: string;
 };
 
 const SortMenu = ({
@@ -13,13 +14,15 @@ const SortMenu = ({
   setFiltersExpanded,
   searchManager,
   options,
+  sort,
 }: SortMenuProps) => {
   return (
     <Menu
+      key={sort}
       id="sort-menu"
       showLabel
-      selectedItem={searchManager.sort}
-      labelText={`Sort by: ${options[searchManager.sort]}`}
+      selectedItem={sort}
+      labelText={`Sort by: ${options[sort]}`}
       listItemsData={Object.entries(options).map(([id, label]) => ({
         id,
         label,

--- a/app/src/config/constants.ts
+++ b/app/src/config/constants.ts
@@ -43,6 +43,15 @@ export const SEARCH_SORT_LABELS = {
   "items-first": "Items first",
 };
 
+export const COLLECTION_LANDING_SORT_LABELS = {
+  sequence: "Sequence",
+  relevance: "Relevance",
+  "date-desc": "Newest to oldest",
+  "date-asc": "Oldest to newest",
+  "title-desc": "Title Z to A",
+  "title-asc": "Title A to Z",
+};
+
 export const ALLOWED_FILTERS = [
   "topic",
   "name",

--- a/app/src/context/SearchProvider.tsx
+++ b/app/src/context/SearchProvider.tsx
@@ -29,6 +29,7 @@ export const SearchProvider = ({
     initialPage: Number(searchParams?.page) || DEFAULT_PAGE_NUM,
     initialSort: searchParams?.sort || DEFAULT_SEARCH_SORT,
     initialFilters: stringToFilter(searchParams?.filters),
+    defaultSort: DEFAULT_SEARCH_SORT,
     initialKeywords: searchParams?.q || DEFAULT_SEARCH_TERM,
     initialAvailableFilters: searchParams?.availableFilters || DEFAULT_FILTERS,
     lastFilterRef: useRef<string | null>(null),

--- a/app/src/utils/searchManager.test.tsx
+++ b/app/src/utils/searchManager.test.tsx
@@ -19,6 +19,7 @@ describe("SearchManager", () => {
       manager = new GeneralSearchManager({
         initialPage: 1,
         initialSort: DEFAULT_SEARCH_SORT,
+        defaultSort: DEFAULT_SEARCH_SORT,
         initialFilters: [],
         initialKeywords: DEFAULT_SEARCH_TERM,
       });
@@ -58,6 +59,7 @@ describe("SearchManager", () => {
     manager = new GeneralSearchManager({
       initialPage: 1,
       initialSort: DEFAULT_SEARCH_SORT,
+      defaultSort: DEFAULT_SEARCH_SORT,
       initialFilters: [],
       initialKeywords: "test",
     });
@@ -120,6 +122,7 @@ describe("SearchManager", () => {
       manager = new CollectionSearchManager({
         initialPage: 1,
         initialSort: DEFAULT_COLLECTION_SORT,
+        defaultSort: "relevance",
         initialFilters: [],
         initialKeywords: DEFAULT_SEARCH_TERM,
       });
@@ -147,6 +150,7 @@ describe("SearchManager", () => {
     manager = new CollectionSearchManager({
       initialPage: 1,
       initialSort: DEFAULT_COLLECTION_SORT,
+      defaultSort: "relevance",
       initialFilters: [],
       initialKeywords: "test",
     });

--- a/app/src/utils/searchManager.tsx
+++ b/app/src/utils/searchManager.tsx
@@ -15,7 +15,7 @@ import { capitalize } from "./utils";
 import { MutableRefObject } from "react";
 
 export interface SearchManager {
-  handleSearchSubmit(): string;
+  handleSearchSubmit(enforceSort?: string): string;
   handleKeywordChange(value: string): void;
   handlePageChange(pageNumber: number): string;
   handleSortChange(id: string): string;
@@ -34,6 +34,7 @@ export interface SearchManager {
 abstract class BaseSearchManager implements SearchManager {
   protected currentPage: number;
   protected currentSort: string;
+  protected defaultSort: string;
   protected currentKeywords: string;
   protected currentFilters: Set<string>;
   protected currentAvailableFilters: AvailableFilter[];
@@ -41,12 +42,13 @@ abstract class BaseSearchManager implements SearchManager {
 
   abstract handlePageChange(pageNumber: number): string;
   abstract handleSortChange(id: string): string;
-  abstract handleSearchSubmit(): string;
+  abstract handleSearchSubmit(enforceSort?: string): string;
   abstract getQueryString(paramsObject: Record<string, any>): string;
 
   constructor(config: {
     initialPage: number;
     initialSort: string;
+    defaultSort: string;
     initialFilters?: Filter[];
     initialKeywords: string;
     initialAvailableFilters?: Record<string, AvailableFilterOption[]>;
@@ -54,6 +56,7 @@ abstract class BaseSearchManager implements SearchManager {
   }) {
     this.currentPage = config.initialPage;
     this.currentSort = config.initialSort;
+    this.defaultSort = config.defaultSort;
     this.currentFilters = new Set(
       (config.initialFilters || []).map((filter) => JSON.stringify(filter))
     );
@@ -149,10 +152,10 @@ abstract class BaseSearchManager implements SearchManager {
 }
 
 export class GeneralSearchManager extends BaseSearchManager {
-  handleSearchSubmit() {
+  handleSearchSubmit(enforceSort?: string) {
     this.currentPage = DEFAULT_PAGE_NUM;
     this.currentFilters.clear();
-    this.currentSort = DEFAULT_SEARCH_SORT;
+    this.currentSort = enforceSort ? enforceSort : this.defaultSort;
     return this.getQueryString({
       q: this.currentKeywords,
       sort: this.currentSort,
@@ -186,7 +189,7 @@ export class GeneralSearchManager extends BaseSearchManager {
     const defaultValues = [
       DEFAULT_SEARCH_TERM,
       DEFAULT_PAGE_NUM,
-      DEFAULT_SEARCH_SORT,
+      this.defaultSort,
       DEFAULT_FILTERS,
     ];
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3609](https://newyorkpubliclibrary.atlassian.net/browse/DR-3609)

## This PR does the following:

- Reworks `searchManager` class so that instances can set their own default sort
- Applies change everywhere `searchManager` is used
- Updates `SortMenu` to take sort from results rather than search manager

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Confirm that "sequence" is the default sort on the collection landing page (except for keyword searches), and that "relevance" is still the default sort for search.

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3609]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ