### PR TITLE
Hot fix: highlight adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] 2025-05-15
 
+### Updated
+
+- HOT FIX: updated search results to use full title instead of just highlights
+
 ### Fixed
 
 - Fixed filters to be encoded as URI components (DR-3564)

--- a/app/src/components/card/searchCard.tsx
+++ b/app/src/components/card/searchCard.tsx
@@ -17,7 +17,7 @@ import { TRUNCATED_SEARCH_CARD_LENGTH } from "@/src/config/constants";
 import {
   capitalize,
   getHighestRankedHighlight,
-  getTitleWithHighlights,
+  highlightTitleWords,
   replaceEmWithMark,
 } from "@/src/utils/utils";
 import parse from "html-react-parser";
@@ -108,10 +108,7 @@ export const SearchCard = ({
 }: SearchCardProps) => {
   const truncatedTitle = result.title.length > TRUNCATED_SEARCH_CARD_LENGTH;
 
-  const highlightedTitle = getTitleWithHighlights(
-    result.highlights,
-    result.title
-  );
+  const highlightedTitle = highlightTitleWords(result.title, result.highlights);
 
   const card = (
     <Card

--- a/app/src/utils/utils.test.tsx
+++ b/app/src/utils/utils.test.tsx
@@ -7,8 +7,8 @@ import {
   filterStringToCollectionApiFilterString,
   getCollectionFilterFromUUID,
   getHighestRankedHighlight,
-  getTitleWithHighlights,
   replaceEmWithMark,
+  highlightTitleWords,
 } from "./utils";
 import { AvailableFilterOption } from "../types/AvailableFilterType";
 
@@ -361,17 +361,24 @@ describe("replaceEmWithMark", () => {
   });
 });
 
-describe("getTitleWithHighlights", () => {
+describe("highlightTitleWords", () => {
   it("returns marked-up highlight if title field exists", () => {
     const highlights = [{ field: "Title", text: "The <em>Great</em> Gatsby" }];
     const title = "The Great Gatsby";
-    const result = getTitleWithHighlights(highlights, title);
+    const result = highlightTitleWords(title, highlights);
     expect(result).toBe("The <mark>Great</mark> Gatsby");
   });
 
   it("returns original title if no title highlight exists", () => {
     const highlights = [{ field: "Topic", text: "Not a title" }];
     const title = "Original Title";
-    expect(getTitleWithHighlights(highlights, title)).toBe(title);
+    expect(highlightTitleWords(title, highlights)).toBe(title);
+  });
+
+  it("uses full title string, not only words from the highlight field", () => {
+    const highlights = [{ field: "Title", text: "The <em>Great</em> Gatsby" }];
+    const title = "The Great Gatsby, 1800, 1900";
+    const result = highlightTitleWords(title, highlights);
+    expect(result).toBe("The <mark>Great</mark> Gatsby, 1800, 1900");
   });
 });

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -220,12 +220,48 @@ export const getHighestRankedHighlight = (highlights: Highlight[]) => {
   return null;
 };
 
+export function highlightTitleWords(title: string, highlights): string {
+  const titleHighlight = highlights.find(
+    (highlight) => highlight.field === "Title"
+  )?.text;
+
+  if (!titleHighlight || titleHighlight.length === 0) {
+    return title;
+  }
+
+  const emWords = new Set<string>();
+  const matches = [...titleHighlight.matchAll(/<em>(.*?)<\/em>/g)];
+  matches.forEach(([, word]) => {
+    word
+      .split(/\s+/)
+      .map((w) => w.replace(/[.,!?;:'"()[\]{}]/g, "").toLowerCase())
+      .forEach((w) => {
+        if (w) emWords.add(w);
+      });
+  });
+
+  return title
+    .split(/\b/)
+    .map((word) => {
+      const clean = word.replace(/[.,!?;:'"()]/g, "").toLowerCase();
+      if (emWords.has(clean)) {
+        return `<mark>${word}</mark>`;
+      }
+      return word;
+    })
+    .join("");
+}
+
+/* Helper for highlighting search result title given that
+   full title appears in the highlight field. 
+   
 export const getTitleWithHighlights = (highlights, title) => {
   const titleHighlight = highlights.find(
     (highlight) => highlight.field === "Title"
   );
   return titleHighlight ? replaceEmWithMark(titleHighlight.text) : title;
 };
+*/
 
 export const deSlugify = (slug: string): string => {
   return slug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());


### PR DESCRIPTION
## Ticket:

## This PR does the following:

- Post search release, realized highlights are not returning full title field
- Updates the construction of the title on the search card to use full title field + highlights instead of just highlights

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.
