### PR TITLE
Division slug redirects

### DIFF
--- a/__tests__/middleware/collectionRedirects.test.tsx
+++ b/__tests__/middleware/collectionRedirects.test.tsx
@@ -80,6 +80,49 @@ it("redirects non-existent collection slug to title search", async () => {
   expect(response).toBe("redirect response");
 });
 
+it("redirects a deprecated division slug to correct slug", async () => {
+  request = {
+    nextUrl: new URL(
+      "http://localhost/divisions/schomburg-center-for-research-in-black-culture-jean-blackwell-hutson-research-and-reference-division"
+    ),
+  } as NextRequest;
+
+  const response = await middleware(request);
+
+  expect(NextResponse.redirect).toHaveBeenCalledWith(
+    "http://localhost/divisions/schomburg-center-for-research-in-black-culture-jean-blackwell-hutson-research",
+    301
+  );
+  expect(response).toBe("redirect response");
+});
+
+it("redirects another deprecated division slug to correct slug", async () => {
+  request = {
+    nextUrl: new URL(
+      "http://localhost/divisions/the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-picture-collection"
+    ),
+  } as NextRequest;
+
+  const response = await middleware(request);
+
+  expect(NextResponse.redirect).toHaveBeenCalledWith(
+    "http://localhost/divisions/the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-picture",
+    301
+  );
+  expect(response).toBe("redirect response");
+});
+
+it("does not redirect a current division slug", async () => {
+  request = {
+    nextUrl: new URL("http://localhost/divisions/billy-rose-theatre-division"),
+  } as NextRequest;
+
+  const response = await middleware(request);
+
+  expect(NextResponse.next).toHaveBeenCalled();
+  expect(response).toBe("next response");
+});
+
 it("passes a collection uuid through", async () => {
   request = {
     nextUrl: new URL(

--- a/app/src/data/divisionSlugMapping.ts
+++ b/app/src/data/divisionSlugMapping.ts
@@ -1,0 +1,18 @@
+export const divisionSlugMapping = {
+  "the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-photography-collection":
+    "the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-photography",
+  "the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-print-collection":
+    "the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-print",
+  "schomburg-center-for-research-in-black-culture-manuscripts-archives-and-rare-books-division":
+    "schomburg-center-for-research-in-black-culture-manuscripts-archives-and-rare",
+  "irma-and-paul-milstein-division-of-united-states-history-local-history-and-genealogy":
+    "irma-and-paul-milstein-division-of-united-states-history-local-history",
+  "schomburg-center-for-research-in-black-culture-jean-blackwell-hutson-research-and-reference-division":
+    "schomburg-center-for-research-in-black-culture-jean-blackwell-hutson-research",
+  "schomburg-center-for-research-in-black-culture-moving-image-and-recorded-sound-division":
+    "schomburg-center-for-research-in-black-culture-moving-image-and-recorded-sound",
+  "the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-art-architecture-collection":
+    "the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-art",
+  "the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-picture-collection":
+    "the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-picture",
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,5 @@
 import collectionSlugToUuidMapping from "@/src/data/collectionSlugUuidMapping";
+import { divisionSlugMapping } from "@/src/data/divisionSlugMapping";
 import { deSlugify } from "@/src/utils/utils";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -64,6 +65,20 @@ export async function middleware(req: NextRequest) {
     }
 
     return NextResponse.redirect(newUrl.toString(), 301);
+  }
+
+  const divisionMatch = pathname.match(/^\/divisions\/([^\/?#]+)/);
+  if (divisionMatch) {
+    const slug = divisionMatch[1];
+    const correctSlug = divisionSlugMapping[slug];
+
+    if (correctSlug && slug !== correctSlug) {
+      const newUrl = new URL(req.nextUrl);
+      newUrl.pathname = `/divisions/${correctSlug}`;
+      return NextResponse.redirect(newUrl.toString(), 301);
+    }
+
+    return NextResponse.next();
   }
 
   const searchParams = url.searchParams;


### PR DESCRIPTION
## Ticket:

- From testing of JIRA ticket [DR-3362](https://newyorkpubliclibrary.atlassian.net/browse/DR-3362)

## This PR does the following:

- Adds redirects for the deprecated division slugs 

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

Hit some of the division links ("Library locations") from the collection landing pages

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.
