### PR TITLE
DR-3616: Replace collection `title||uuid` and subcollection redirect

### DIFF
--- a/__tests__/middleware/collectionRedirects.test.tsx
+++ b/__tests__/middleware/collectionRedirects.test.tsx
@@ -13,11 +13,11 @@ jest.mock("next/server", () => {
 
 let request: NextRequest;
 
-it("redirects collection_keywords to q", async () => {
+it("redirects collection_keywords to q", () => {
   const request = {
     nextUrl: new URL("http://localhost/collections?collection_keywords=test"),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/collections?q=test",
@@ -26,13 +26,13 @@ it("redirects collection_keywords to q", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms collection_keywords to q and maintains other parameters", async () => {
+it("transforms collection_keywords to q and maintains other parameters", () => {
   const request = {
     nextUrl: new URL(
       "http://localhost/collections?collection_keywords=test&sort=title-asc&page=23"
     ),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/collections?sort=title-asc&page=23&q=test",
@@ -41,23 +41,23 @@ it("transforms collection_keywords to q and maintains other parameters", async (
   expect(response).toBe("redirect response");
 });
 
-it("goes through unchanged if no collection_keywords= param", async () => {
+it("goes through unchanged if no collection_keywords= param", () => {
   request = {
     nextUrl: new URL("http://localhost/collections?sort=title-asc"),
   } as NextRequest;
 
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.next).toHaveBeenCalled();
   expect(response).toBe("next response");
 });
 
-it("redirects existing collection slug to uuid", async () => {
+it("redirects existing collection slug to uuid", () => {
   request = {
     nextUrl: new URL("http://localhost/collections/script-b"),
   } as NextRequest;
 
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/collections/5af6c940-c45b-013c-85aa-0242ac110005",
@@ -66,12 +66,12 @@ it("redirects existing collection slug to uuid", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("redirects non-existent collection slug to title search", async () => {
+it("redirects non-existent collection slug to title search", () => {
   request = {
     nextUrl: new URL("http://localhost/collections/hello-im-not-a-real-slug"),
   } as NextRequest;
 
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?q=Hello+Im+Not+A+Real+Slug",
@@ -80,14 +80,14 @@ it("redirects non-existent collection slug to title search", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("redirects a deprecated division slug to correct slug", async () => {
+it("redirects a deprecated division slug to correct slug", () => {
   request = {
     nextUrl: new URL(
       "http://localhost/divisions/schomburg-center-for-research-in-black-culture-jean-blackwell-hutson-research-and-reference-division"
     ),
   } as NextRequest;
 
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/divisions/schomburg-center-for-research-in-black-culture-jean-blackwell-hutson-research",
@@ -96,14 +96,14 @@ it("redirects a deprecated division slug to correct slug", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("redirects another deprecated division slug to correct slug", async () => {
+it("redirects another deprecated division slug to correct slug", () => {
   request = {
     nextUrl: new URL(
       "http://localhost/divisions/the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-picture-collection"
     ),
   } as NextRequest;
 
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/divisions/the-miriam-and-ira-d-wallach-division-of-art-prints-and-photographs-picture",
@@ -112,25 +112,25 @@ it("redirects another deprecated division slug to correct slug", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("does not redirect a current division slug", async () => {
+it("does not redirect a current division slug", () => {
   request = {
     nextUrl: new URL("http://localhost/divisions/billy-rose-theatre-division"),
   } as NextRequest;
 
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.next).toHaveBeenCalled();
   expect(response).toBe("next response");
 });
 
-it("passes a collection uuid through", async () => {
+it("passes a collection uuid through", () => {
   request = {
     nextUrl: new URL(
       "http://localhost/collections/bc920670-c5f9-012f-63ad-58d385a7bc34"
     ),
   } as NextRequest;
 
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.next).toHaveBeenCalled();
   expect(response).toBe("next response");

--- a/__tests__/middleware/searchRedirects.test.tsx
+++ b/__tests__/middleware/searchRedirects.test.tsx
@@ -1,12 +1,6 @@
 import { middleware } from "middleware";
 import { NextRequest, NextResponse } from "next/server";
 
-(global as any).fetch = jest.fn(() =>
-  Promise.resolve({
-    json: () => Promise.resolve({ title: "Mocked Collection Title" }),
-  })
-);
-
 jest.mock("next/server", () => {
   return {
     NextRequest: jest.fn(),
@@ -19,11 +13,11 @@ jest.mock("next/server", () => {
 
 let request: NextRequest;
 
-it("transforms keywords to q", async () => {
+it("transforms keywords to q", () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?keywords=test"),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?q=test",
@@ -32,11 +26,11 @@ it("transforms keywords to q", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("drops ascending/descending relevance sort (default sort)", async () => {
+it("drops ascending/descending relevance sort (default sort)", () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?sort=score+desc"),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?",
@@ -45,11 +39,11 @@ it("drops ascending/descending relevance sort (default sort)", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("drops sequence sort", async () => {
+it("drops sequence sort", () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?sort=sortString+desc"),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?",
@@ -58,11 +52,11 @@ it("drops sequence sort", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("drops date created sort", async () => {
+it("drops date created sort", () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?sort=keyDate_st+asc"),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?",
@@ -71,11 +65,11 @@ it("drops date created sort", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms date digitized ascending/descending sort", async () => {
+it("transforms date digitized ascending/descending sort", () => {
   const request1 = {
     nextUrl: new URL("http://localhost/search/index?sort=dateDigitized_dt+asc"),
   } as NextRequest;
-  const response1 = await middleware(request1);
+  const response1 = middleware(request1);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?sort=date-asc",
@@ -88,7 +82,7 @@ it("transforms date digitized ascending/descending sort", async () => {
       "http://localhost/search/index?sort=dateDigitized_dt+desc"
     ),
   } as NextRequest;
-  const response2 = await middleware(request2);
+  const response2 = middleware(request2);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?sort=date-desc",
@@ -97,11 +91,11 @@ it("transforms date digitized ascending/descending sort", async () => {
   expect(response2).toBe("redirect response");
 });
 
-it("transforms title alphabetical ascending/descending sort", async () => {
+it("transforms title alphabetical ascending/descending sort", () => {
   const request1 = {
     nextUrl: new URL("http://localhost/search/index?sort=mainTitle_ns+asc"),
   } as NextRequest;
-  const response1 = await middleware(request1);
+  const response1 = middleware(request1);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?sort=title-asc",
@@ -112,7 +106,7 @@ it("transforms title alphabetical ascending/descending sort", async () => {
   const request2 = {
     nextUrl: new URL("http://localhost/search/index?sort=mainTitle_ns+desc"),
   } as NextRequest;
-  const response2 = await middleware(request2);
+  const response2 = middleware(request2);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?sort=title-desc",
@@ -121,11 +115,11 @@ it("transforms title alphabetical ascending/descending sort", async () => {
   expect(response2).toBe("redirect response");
 });
 
-it("drops scroll", async () => {
+it("drops scroll", () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?keywords=#/?scroll=136"),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?",
@@ -134,23 +128,23 @@ it("drops scroll", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("maintains page", async () => {
+it("maintains page", () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?page=2"),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.next).toHaveBeenCalled();
   expect(response).toBe("next response");
 });
 
-it("transforms a filter", async () => {
+it("transforms a filter", () => {
   const request = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bname%5D=Swope%2C+Martha"
     ),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Bname%3DSwope%2C+Martha%5D",
@@ -159,13 +153,13 @@ it("transforms a filter", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms multiple filters", async () => {
+it("transforms multiple filters", () => {
   const request = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bgenre%5D=Photographs&filters%5Bname%5D%5B%5D=Swope%2C+Martha"
     ),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Bgenre%3DPhotographs%5D%5Bname%3DSwope%2C+Martha%5D",
@@ -174,11 +168,11 @@ it("transforms multiple filters", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms rights filter", async () => {
+it("transforms rights filter", () => {
   const request = {
     nextUrl: new URL("http://localhost/search/index?filters%5Brights%5D=pd"),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Brights%3DpublicDomain%5D",
@@ -187,13 +181,13 @@ it("transforms rights filter", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms year_begin and year_end filters", async () => {
+it("transforms year_begin and year_end filters", () => {
   const request = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bgenre%5D%5B%5D=Cards&keywords=&&&&year_begin=1900&year_end=1905&"
     ),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Bgenre%3DCards%5D%5BdateStart%3D1900%5D%5BdateEnd%3D1905%5D",
@@ -202,13 +196,13 @@ it("transforms year_begin and year_end filters", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms date filter", async () => {
+it("transforms date filter", () => {
   const requestWithOnlyDate = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bdate%5D%5B%5D=1900-1905"
     ),
   } as NextRequest;
-  const response = await middleware(requestWithOnlyDate);
+  const response = middleware(requestWithOnlyDate);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5BdateStart%3D1900%5D%5BdateEnd%3D1905%5D",
@@ -217,13 +211,13 @@ it("transforms date filter", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms date and one year filter", async () => {
+it("transforms date and one year filter", () => {
   const requestWithDateAndYear = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bdate%5D%5B%5D=-9999-1903&filters%5Bgenre%5D=Scores&keywords=hello"
     ),
   } as NextRequest;
-  const response = await middleware(requestWithDateAndYear);
+  const response = middleware(requestWithDateAndYear);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?q=hello&filters=%5BdateEnd%3D1903%5D%5Bgenre%3DScores%5D",
@@ -248,13 +242,13 @@ it("transforms date and both year filters", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms filter titles where necessary (form)", async () => {
+it("transforms filter titles where necessary (form)", () => {
   const requestWithDateAndYears = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bform_mtxt_s%5D%5B%5D=Photocopies&filters%5Bpublisher%5D=The+Division&keywords="
     ),
   } as NextRequest;
-  const response = await middleware(requestWithDateAndYears);
+  const response = middleware(requestWithDateAndYears);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Bform%3DPhotocopies%5D%5Bpublisher%3DThe+Division%5D",
@@ -263,13 +257,13 @@ it("transforms filter titles where necessary (form)", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms filter titles (place)", async () => {
+it("transforms filter titles (place)", () => {
   const requestWithDateAndYears = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5BplaceTerm_mtxt_s%5D%5B%5D=Photocopies&filters%5Bpublisher%5D=The+Division&keywords="
     ),
   } as NextRequest;
-  const response = await middleware(requestWithDateAndYears);
+  const response = middleware(requestWithDateAndYears);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5Bplace%3DPhotocopies%5D%5Bpublisher%3DThe+Division%5D",
@@ -278,28 +272,28 @@ it("transforms filter titles (place)", async () => {
   expect(response).toBe("redirect response");
 });
 
-it("transforms root-collection and fetches collection title", async () => {
+it("transforms root-collection", () => {
   const requestWithRootCollection = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Broot-collection%5D=16ad5350-c52e-012f-aecf-58d385a7bc34&keywords="
     ),
   } as NextRequest;
-  const response = await middleware(requestWithRootCollection);
+  const response = middleware(requestWithRootCollection);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
-    "http://localhost/search/index?filters=%5Bcollection%3DMocked+Collection+Title%7C%7C16ad5350-c52e-012f-aecf-58d385a7bc34%5D",
+    "http://localhost/search/index?filters=%5Bcollection%3D16ad5350-c52e-012f-aecf-58d385a7bc34%5D",
     301
   );
   expect(response).toBe("redirect response");
 });
 
-it("transforms many params", async () => {
+it("transforms many params", () => {
   const request = {
     nextUrl: new URL(
       "http://localhost/search/index?filters%5Bdate%5D%5B%5D=1900-9999&filters%5Bgenre%5D%5B%5D=Cards&filters%5Bname%5D%5B%5D=Ogden%27s+Cigarettes&filters%5Brights%5D=pd&keywords="
     ),
   } as NextRequest;
-  const response = await middleware(request);
+  const response = middleware(request);
 
   expect(NextResponse.redirect).toHaveBeenCalledWith(
     "http://localhost/search/index?filters=%5BdateStart%3D1900%5D%5Bgenre%3DCards%5D%5Bname%3DOgden%27s+Cigarettes%5D%5Brights%3DpublicDomain%5D",

--- a/app/collections/[uuid]/page.tsx
+++ b/app/collections/[uuid]/page.tsx
@@ -45,13 +45,9 @@ export default async function Collection({
   if (searchParams.filters) {
     filters = `${
       searchParams?.filters ? searchParams?.filters : ""
-    }[collection=${encodeURIComponent(collectionData.title)}||${
-      collectionData.uuid
-    }]`;
+    }[collection=${collectionData.uuid}]`;
   } else {
-    filters = `[collection=${encodeURIComponent(collectionData.title)}||${
-      collectionData.uuid
-    }]`;
+    filters = `[collection=${collectionData.uuid}]`;
   }
 
   const searchResults = await CollectionsApi.getSearchData({

--- a/app/src/components/collectionStructure/collectionStructure.tsx
+++ b/app/src/components/collectionStructure/collectionStructure.tsx
@@ -74,11 +74,8 @@ const applyNodeFilter = async (
 ) => {
   const filter = {
     filter: "subcollection",
-    value: `${encodeURIComponent(node.title)}||${encodeURIComponent(
-      node.uuid
-    )}`,
+    value: node.uuid,
   };
-
   // Clear search query
   searchManager.handleKeywordChange("");
   searchManager.handleSearchSubmit();
@@ -95,9 +92,7 @@ const applyNodeFilter = async (
       ? searchManager.handleAddFilter([
           {
             filter: "subcollection",
-            value: `${encodeURIComponent(
-              parentNode.title
-            )}||${encodeURIComponent(parentNode.uuid)}`,
+            value: parentNode.uuid,
           },
         ])
       : searchManager.handleRemoveFilter([filter])
@@ -199,7 +194,7 @@ const CollectionStructure = ({
   const subCollectionFilter = searchManager.filters.find(
     (filter) => filter.filter === "subcollection"
   );
-  const targetUuid = subCollectionFilter?.value?.split("||")[1];
+  const targetUuid = subCollectionFilter?.value;
 
   const buildTreeWithPathToUuid = async (
     parentUuid: string,

--- a/app/src/components/pages/collectionPage/collectionPage.tsx
+++ b/app/src/components/pages/collectionPage/collectionPage.tsx
@@ -37,6 +37,7 @@ import CollectionMetadata, {
 import CollectionSearchParamsType from "@/src/types/CollectionSearchParams";
 import { SearchResultsType } from "@/src/types/SearchResultsType";
 import { CollectionModel } from "@/src/models/collection";
+import { useSubcollectionRedirect } from "@/src/hooks/useSubcollectionRedirect";
 
 type CollectionPageProps = {
   searchResults: SearchResultsType;
@@ -75,6 +76,8 @@ const CollectionPage = ({
     push(`${pathname}?${queryString}`, { scroll: false });
   };
   const [isLoaded, setIsLoaded] = useState(false);
+
+  useSubcollectionRedirect();
 
   useEffect(() => {
     setIsLoaded(true);

--- a/app/src/components/pages/searchPage/searchPage.tsx
+++ b/app/src/components/pages/searchPage/searchPage.tsx
@@ -22,6 +22,7 @@ import NoResultsFound from "../../results/noResultsFound";
 import SearchCardGridLoading from "../../grids/searchCardGridLoading";
 import BackToTopLink from "../../backToTopLink/backToTopLink";
 import { SearchResultsType } from "@/src/types/SearchResultsType";
+import { useSubcollectionRedirect } from "@/src/hooks/useSubcollectionRedirect";
 
 const SearchPage = ({
   searchResults,
@@ -76,6 +77,8 @@ const SearchPage = ({
     isFirstLoad.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchResults]);
+
+  useSubcollectionRedirect();
 
   return (
     <Box id="mainContent">

--- a/app/src/components/search/filters/selectFilter.tsx
+++ b/app/src/components/search/filters/selectFilter.tsx
@@ -153,29 +153,15 @@ const SelectFilterComponent = ({
           accordionButtonRef.current?.focus();
           searchManager.setLastFilter(`accordion-button-select-${filter.name}`);
           // Push the current filter selection to URL.
-          if (filter.name === "collection") {
-            const [collectionTitle, collectionUuid] =
-              current?.name!.split("||") ?? [];
-            updateURL(
-              searchManager.handleAddFilter([
-                {
-                  filter: filter.name,
-                  value: `${encodeURIComponent(
-                    collectionTitle
-                  )}||${encodeURIComponent(collectionUuid)}`,
-                },
-              ])
-            );
-          } else {
-            updateURL(
-              searchManager.handleAddFilter([
-                {
-                  filter: filter.name,
-                  value: current?.name!,
-                },
-              ])
-            );
-          }
+          updateURL(
+            searchManager.handleAddFilter([
+              {
+                filter: filter.name,
+                value: current?.name!,
+              },
+            ])
+          );
+
           setUserClickedOutside(true);
         }}
       >

--- a/app/src/components/search/filters/selectFilterModal.tsx
+++ b/app/src/components/search/filters/selectFilterModal.tsx
@@ -25,7 +25,6 @@ import {
   AvailableFilterOption,
 } from "@/src/types/AvailableFilterType";
 import { capitalize } from "@/src/utils/utils";
-import { useSearchContext } from "@/src/context/SearchProvider";
 
 type SelectFilterModalProps = {
   filter: AvailableFilter;
@@ -290,29 +289,14 @@ const SelectFilterModal = forwardRef<HTMLButtonElement, SelectFilterModalProps>(
                     searchManager.setLastFilter(
                       `accordion-button-select-${filter.name}`
                     );
-                    if (filter.name === "collection") {
-                      const [collectionTitle, collectionUuid] =
-                        modalCurrent?.name!.split("||") ?? [];
-                      updateURL(
-                        searchManager.handleAddFilter([
-                          {
-                            filter: filter.name,
-                            value: `${encodeURIComponent(
-                              collectionTitle
-                            )}||${encodeURIComponent(collectionUuid)}`,
-                          },
-                        ])
-                      );
-                    } else {
-                      updateURL(
-                        searchManager.handleAddFilter([
-                          {
-                            filter: filter.name,
-                            value: modalCurrent?.name!,
-                          },
-                        ])
-                      );
-                    }
+                    updateURL(
+                      searchManager.handleAddFilter([
+                        {
+                          filter: filter.name,
+                          value: modalCurrent?.name!,
+                        },
+                      ])
+                    );
                     setModalCurrent(current);
                   }}
                 >

--- a/app/src/hooks/useSubcollectionRedirect.ts
+++ b/app/src/hooks/useSubcollectionRedirect.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+
+export function useSubcollectionRedirect() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const { pathname, hash, origin, search } = window.location;
+
+    const collectionMatch = pathname.match(
+      /^\/collections\/([0-9a-fA-F-]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})$/
+    );
+    if (!collectionMatch || !hash.includes("roots=")) return;
+
+    const rootsParamMatch = hash.match(/roots=([^&#]*)/);
+    if (!rootsParamMatch) return;
+
+    const rootsPath = decodeURIComponent(rootsParamMatch[1]);
+    const uuidMatches = [...rootsPath.matchAll(/:\s*([0-9a-fA-F-]{36})/g)];
+    console.log(uuidMatches);
+
+    const uuids = uuidMatches.map((m) => m[1]);
+
+    const lastUuid = uuids[uuids.length - 1];
+
+    if (!lastUuid) return;
+
+    const fetchAndRedirect = async () => {
+      try {
+        const newUrl = new URL(origin + pathname + search);
+        newUrl.hash = "";
+        newUrl.searchParams.set("filters", `[subcollection=${lastUuid}]`);
+        window.location.replace(newUrl.toString());
+      } catch (err) {
+        console.error("Redirect error:", err);
+      }
+    };
+
+    fetchAndRedirect();
+  }, []);
+}

--- a/app/src/utils/utils.test.tsx
+++ b/app/src/utils/utils.test.tsx
@@ -301,23 +301,13 @@ describe("filterStringToCollectionApiFilterString", () => {
     ).toBe("name=Swope%2C%20Martha");
   });
 
-  test("does not encode collection/subcollection filters", () => {
-    expect(
-      filterStringToCollectionApiFilterString(
-        "[Collection=Print Collection portrait file||16ad5350-c52e-012f-aecf-58d385a7bc34]"
-      )
-    ).toBe(
-      "collection=Print Collection portrait file||16ad5350-c52e-012f-aecf-58d385a7bc34"
-    );
-  });
-
   test("generates the correct filter syntax for multiple filter", () => {
     expect(
       filterStringToCollectionApiFilterString(
-        "[name=Swope, Martha][collection=Print Collection portrait file||16ad5350-c52e-012f-aecf-58d385a7bc34]"
+        "[name=Swope, Martha][collection=16ad5350-c52e-012f-aecf-58d385a7bc34]"
       )
     ).toBe(
-      "name=Swope%2C%20Martha&collection=Print Collection portrait file||16ad5350-c52e-012f-aecf-58d385a7bc34"
+      "name=Swope%2C%20Martha&collection=16ad5350-c52e-012f-aecf-58d385a7bc34"
     );
   });
 

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -176,9 +176,6 @@ export const filterStringToCollectionApiFilterString = (filters: string) => {
         if (!isValidFilter(name)) {
           return null;
         }
-        if (name === "subcollection" || name === "collection") {
-          return `${name}=${value}`;
-        }
         return `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
       })
       .filter(Boolean);

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,27 +16,7 @@ const filterMap = {
   divisionFullname_mtxt_s: "division",
 };
 
-async function getCollectionTitle(uuid): Promise<string> {
-  try {
-    const response = await fetch(
-      `${process.env.COLLECTIONS_API_URL}/collections/${uuid}}`,
-      {
-        method: "GET",
-        headers: {
-          "x-nypl-collections-api-key": `${process.env.COLLECTIONS_API_AUTH_TOKEN}`,
-          "Cache-Control": "no-cache",
-        },
-      }
-    );
-    const collectionData = await response.json();
-    return `${collectionData.title}||${uuid}`;
-  } catch (error) {
-    console.error("Error fetching root collection:", error);
-    return "";
-  }
-}
-
-export async function middleware(req: NextRequest) {
+export function middleware(req: NextRequest) {
   const url = req.nextUrl;
   const pathname = url.pathname;
 
@@ -149,7 +129,6 @@ export async function middleware(req: NextRequest) {
         filterValue = "publicDomain";
       } else if (filterKey === "root-collection") {
         filterKey = "collection";
-        filterValue = await getCollectionTitle(filterValue);
       } else if (filterMap[filterKey]) {
         filterKey = filterMap[filterKey];
       }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3616](https://newyorkpubliclibrary.atlassian.net/browse/DR-3616) and [DR-3615](https://newyorkpubliclibrary.atlassian.net/browse/DR-3615)

## This PR does the following:

- Removes all usage of the `title||uuid` format for collection and subcollection filters
- Adds `useSubcollectionRedirect`, a clientside redirect for OG DC subcollection links, to `/search` and `/collections/[uuid]` pages

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
