### PR TITLE
pass api url to docker build

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -38,9 +38,10 @@ jobs:
           API_URL: ${{ secrets.API_URL }}
           AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
           COLLECTIONS_API_AUTH_TOKEN: ${{ secrets.COLLECTIONS_API_AUTH_TOKEN }}
+          COLLECTIONS_API_URL: ${{ secrets.COLLECTIONS_API_URL }}
           ECR_URL: 557492996044.dkr.ecr.us-east-1.amazonaws.com/dc-frontend:latest
         run: |
-          docker build --build-arg APP_ENV=$APP_ENV --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY --build-arg API_URL=$API_URL --build-arg AUTH_TOKEN=$AUTH_TOKEN --build-arg COLLECTIONS_API_AUTH_TOKEN=$COLLECTIONS_API_AUTH_TOKEN --tag $LOCAL_TAG_NAME .
+          docker build --build-arg APP_ENV=$APP_ENV --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY --build-arg API_URL=$API_URL --build-arg AUTH_TOKEN=$AUTH_TOKEN --build-arg COLLECTIONS_API_AUTH_TOKEN=$COLLECTIONS_API_AUTH_TOKEN COLLECTIONS_API_AUTH_TOKEN=$COLLECTIONS_API_URL--tag $LOCAL_TAG_NAME .
           docker tag $LOCAL_TAG_NAME $ECR_URL
           docker push $ECR_URL
 

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -38,9 +38,10 @@ jobs:
           API_URL: ${{ secrets.API_URL }}
           AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
           COLLECTIONS_API_AUTH_TOKEN: ${{ secrets.QA_COLLECTIONS_API_AUTH_TOKEN }}
+          COLLECTIONS_API_URL: ${{ secrets.QA_COLLECTIONS_API_URL }}
           ECR_URL: 685731035297.dkr.ecr.us-east-1.amazonaws.com/dc-frontend:qa-latest
         run: |
-          docker build --build-arg APP_ENV=$APP_ENV --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY --build-arg API_URL=$API_URL --build-arg AUTH_TOKEN=$AUTH_TOKEN --build-arg COLLECTIONS_API_AUTH_TOKEN=$COLLECTIONS_API_AUTH_TOKEN --tag $LOCAL_TAG_NAME .
+          docker build --build-arg APP_ENV=$APP_ENV --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY --build-arg API_URL=$API_URL --build-arg AUTH_TOKEN=$AUTH_TOKEN --build-arg COLLECTIONS_API_AUTH_TOKEN=$COLLECTIONS_API_AUTH_TOKEN COLLECTIONS_API_URL=$COLLECTIONS_API_URL--tag $LOCAL_TAG_NAME .
           docker tag $LOCAL_TAG_NAME $ECR_URL
           docker push $ECR_URL
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG NEW_RELIC_LICENSE_KEY
 ARG AUTH_TOKEN
 ARG API_URL
 ARG COLLECTIONS_API_AUTH_TOKEN
+ARG COLLECTIONS_API_URL
 
 WORKDIR /app
 
@@ -25,6 +26,7 @@ ENV NEW_RELIC_APP_NAME="Facelift ${APP_ENV}"
 ENV API_URL=${API_URL}
 ENV AUTH_TOKEN=${AUTH_TOKEN}
 ENV COLLECTIONS_API_AUTH_TOKEN=${COLLECTIONS_API_AUTH_TOKEN}
+ENV COLLECTIONS_API_URL=${COLLECTIONS_API_URL}
 
 # Create a `.env.prod` file with the environment variables
 # This is a workaround to use environment variables in the `newrelic.js` file


### PR DESCRIPTION
I think this _should_ fix the issue with the manifests loading in the viewer. 

Why? because Next.js has a really weird way of handling env variables. We have a whole section on this in the README https://github.com/NYPL/digital-collections?tab=readme-ov-file#environment-variables that probably needs to be updated. 

Tl;dr: anything defined in the `env` of `next.config.js` needs to be defined as a repository secret in github actions and passed to the docker image at build time

