### PR TITLE
create component for available on site materials

### DIFF
--- a/app/src/components/items/item.tsx
+++ b/app/src/components/items/item.tsx
@@ -12,6 +12,7 @@ import {
   Box,
   Link,
   Icon,
+  Text,
 } from "@nypl/design-system-react-components";
 
 interface ItemProps {
@@ -28,25 +29,24 @@ const Item = ({ item, type }: ItemProps) => {
   return (
     <>
       <Box marginTop="-3em">
-        <Heading level="h2">{item.title}</Heading>
         {renderViewer(item) ? (
-          <ItemMediaViewer item={item} />
+          <>
+            <Heading level="h2">{item.title}</Heading>
+            <ItemMediaViewer item={item} />
+          </>
         ) : (
-          <ItemMediaViewerFallback item={item} />
+          <>
+            <ItemMediaViewerFallback item={item} />
+            <Heading level="h2">{item.title}</Heading>
+          </>
         )}
-        <Banner
-          marginTop="m"
-          content={
-            <>
-              Our collections include some content that may be harmful or
-              dificult to view.{" "}
-              <Link href="https://digitalcollections.nypl.org/about#nypl_harmful_content_statement">
-                Learn more.
-              </Link>{" "}
-            </>
-          }
-          type="neutral"
-        ></Banner>
+        <Text marginTop="m">
+          <Icon name="errorOutline" size="medium" /> Our collections include
+          some content that may be harmful or dificult to view.{" "}
+          <Link href="https://digitalcollections.nypl.org/about#nypl_harmful_content_statement">
+            Learn more.
+          </Link>{" "}
+        </Text>
         <ItemOverview item={item} />
       </Box>
     </>

--- a/app/src/components/items/item.tsx
+++ b/app/src/components/items/item.tsx
@@ -3,7 +3,9 @@
 import { ItemModel } from "../../models/item";
 import React from "react";
 import ItemMediaViewer from "./viewer/viewer";
+import ItemMediaViewerFallback from "./viewer/fallback";
 import ItemOverview from "./overview/overview";
+
 import {
   Heading,
   Banner,
@@ -30,24 +32,7 @@ const Item = ({ item, type }: ItemProps) => {
         {renderViewer(item) ? (
           <ItemMediaViewer item={item} />
         ) : (
-          <Banner
-            marginTop="m"
-            content={
-              <>
-                This item either has no media to return or is restricted. Help
-                us resolve this by submitting feedback with the feedback form.
-              </>
-            }
-            icon={
-              <Icon
-                name="alertWarningOutline"
-                title="Banner with custom icon"
-                size="large"
-                marginTop="xxxs"
-              />
-            }
-            type="negative"
-          />
+          <ItemMediaViewerFallback item={item} />
         )}
         <Banner
           marginTop="m"

--- a/app/src/components/items/overview/metadata/overview.tsx
+++ b/app/src/components/items/overview/metadata/overview.tsx
@@ -39,7 +39,6 @@ const metadataFieldRender = (field, value) => {
 };
 
 const MetadataOverview = ({ metadata }) => {
-  console.log("metadata is: ", metadata);
   return (
     <>
       <Box>
@@ -49,11 +48,6 @@ const MetadataOverview = ({ metadata }) => {
         </Heading>
 
         {Object.keys(metadata)?.map((field, index) => {
-          console.log(
-            " metadataFieldToDisplay[field] is: ",
-            metadataFieldToDisplay[field]
-          );
-
           const value = metadata[field];
           if (value !== "" && metadataFieldToDisplay[field] !== "") {
             return (

--- a/app/src/components/items/viewer/fallback.tsx
+++ b/app/src/components/items/viewer/fallback.tsx
@@ -16,6 +16,8 @@ interface ItemProps {
 }
 
 const ItemMediaViewerFallback = ({ item }: ItemProps) => {
+  // hacky way to generate the link
+  // this assumes that the first location in the array is the Division link
   const divisionLink = item?.metadata?.locations?.split("<br>")[0];
   return (
     <>

--- a/app/src/components/items/viewer/fallback.tsx
+++ b/app/src/components/items/viewer/fallback.tsx
@@ -15,7 +15,7 @@ interface ItemProps {
 }
 
 const ItemMediaViewerFallback = ({ item }: ItemProps) => {
-  const divisionLink = item.metadata.locations.split("<br>")[0];
+  const divisionLink = item?.metadata?.locations?.split("<br>")[0];
   return (
     <>
       {item.isRestricted ? (

--- a/app/src/components/items/viewer/fallback.tsx
+++ b/app/src/components/items/viewer/fallback.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { ItemModel } from "../../../models/item";
+import React from "react";
+import {
+  Heading,
+  Banner,
+  Box,
+  Link,
+  Icon,
+} from "@nypl/design-system-react-components";
+
+interface ItemProps {
+  item: ItemModel;
+}
+
+const ItemMediaViewerFallback = ({ item }: ItemProps) => {
+  const divisionLink = item.metadata.locations.split("<br>")[0];
+  return (
+    <>
+      {item.isRestricted ? (
+        <Banner
+          marginTop="m"
+          heading={
+            <Heading level="h5">Available to view on-site at NYPL</Heading>
+          }
+          content={
+            <>
+              We invite you to visit one of our reading rooms at {divisionLink}{" "}
+              to view this item. Due to copyright restrictions, it is available
+              for on-site access only. For directions, opening hours, and
+              additional information about the research libraries, please visit
+              the {divisionLink} page on <Link href="nypl.org">nypl.org</Link>.
+            </>
+          }
+          type="warning"
+        />
+      ) : (
+        <Banner
+          marginTop="m"
+          content={
+            <>
+              This item has no media to return. Help us resolve this by
+              submitting feedback with the feedback form.
+            </>
+          }
+          icon={
+            <Icon
+              name="alertWarningOutline"
+              title="Banner with custom icon"
+              size="large"
+              marginTop="xxxs"
+            />
+          }
+          type="negative"
+        />
+      )}
+    </>
+  );
+};
+
+export default ItemMediaViewerFallback;

--- a/app/src/components/items/viewer/fallback.tsx
+++ b/app/src/components/items/viewer/fallback.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import {
   Heading,
   Banner,
+  Notification,
   Box,
   Link,
   Icon,
@@ -19,12 +20,13 @@ const ItemMediaViewerFallback = ({ item }: ItemProps) => {
   return (
     <>
       {item.isRestricted ? (
-        <Banner
+        <Notification
           marginTop="m"
-          heading={
-            <Heading level="h5">Available to view on-site at NYPL</Heading>
-          }
-          content={
+          marginBottom="m"
+          marginLeft="0"
+          marginRight="0"
+          notificationHeading="Available to view on-site at NYPL"
+          notificationContent={
             <>
               We invite you to visit one of our reading rooms at {divisionLink}{" "}
               to view this item. Due to copyright restrictions, it is available
@@ -33,7 +35,6 @@ const ItemMediaViewerFallback = ({ item }: ItemProps) => {
               the {divisionLink} page on <Link href="nypl.org">nypl.org</Link>.
             </>
           }
-          type="warning"
         />
       ) : (
         <Banner

--- a/app/src/components/items/viewer/fallback.tsx
+++ b/app/src/components/items/viewer/fallback.tsx
@@ -17,7 +17,7 @@ interface ItemProps {
 
 const ItemMediaViewerFallback = ({ item }: ItemProps) => {
   // hacky way to generate the link
-  // this assumes that the first location in the array is the Division link
+  // this assumes that the first Library Location in the array is the Division link
   // TODO: map DCFL Division link to nypl.org Division link
   const divisionLink = item?.metadata?.locations?.split("<br>")[0];
   return (

--- a/app/src/components/items/viewer/fallback.tsx
+++ b/app/src/components/items/viewer/fallback.tsx
@@ -18,6 +18,7 @@ interface ItemProps {
 const ItemMediaViewerFallback = ({ item }: ItemProps) => {
   // hacky way to generate the link
   // this assumes that the first location in the array is the Division link
+  // TODO: map DCFL Division link to nypl.org Division link
   const divisionLink = item?.metadata?.locations?.split("<br>")[0];
   return (
     <>

--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -20,6 +20,7 @@ export class ItemModel {
   manifestURL: string;
   link: string;
   isRestricted: boolean;
+  location: string;
   metadata?: {
     title: string;
     names?: string;
@@ -49,6 +50,7 @@ export class ItemModel {
 
     // const label = parser?.getManifestLabelByLanguage("en");
     const metadata = Array.from(parser.iterateManifestMetadata());
+    // console.log("metadata is: ", manifest.metadata)
     const manifestMetadataHash = {};
 
     if (metadata) {
@@ -74,19 +76,8 @@ export class ItemModel {
         ? manifestMetadataHash["Is Restricted"].toString().toLowerCase() ===
           "true"
         : true),
-      // (this.contentType = getContentType(
-      //   manifestMetadataHash["Content Type"].length > 0
-      //     ? manifestMetadataHash["Content Type"][0]
-      //     : manifestMetadataHash["Content Type"]
-      // ));
-      // TO DO: change this to QA
       (this.manifestURL = `${process.env.COLLECTIONS_API_URL}/manifests/${uuid}`);
-    // `http://localhost:8000/manifests/${uuid}`;
 
-    // `${process.env.collectionS_API_URL}/manifests/${uuid}`
-    // `http://localhost:8000/manifests/${uuid}`;
-    // //`https://qa-api-collections.nypl.org/manifests/${uuid}`;
-    // TO DO: use ENV var ie. `${process.env.collectionS_API_URL}/manifests/${uuid}`
     // TO DO: add _isCartographic for map stuff
     this.metadata = {
       title: manifestMetadataHash["Title"]

--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -50,7 +50,6 @@ export class ItemModel {
 
     // const label = parser?.getManifestLabelByLanguage("en");
     const metadata = Array.from(parser.iterateManifestMetadata());
-    // console.log("metadata is: ", manifest.metadata)
     const manifestMetadataHash = {};
 
     if (metadata) {

--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -20,7 +20,6 @@ export class ItemModel {
   manifestURL: string;
   link: string;
   isRestricted: boolean;
-  location: string;
   metadata?: {
     title: string;
     names?: string;


### PR DESCRIPTION
## Ticket:

- JIRA ticket [Conditionally render media viewer based on rights logic](https://newyorkpubliclibrary.atlassian.net/browse/DR-3645)

## This PR does the following:

- builds a new component `ItemMediaViewerFallback` to handle what should render in place of the Universal Viewer when an Item is restricted OR when a manifest has metadata and no items in the items array.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- divisions links.... currently I'm using the division information returned in the metadata under Library Locations but I'm pretty sure this links to a division in DCFL and not the division link on nypl.org.... Lana wants the banner to include the link to the division on the nypl.org site. I didn't include this logic in this PR but think I'll need to make an object in DCFL that maps DCFL slugs to NYPL Division urls.

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->
locally with this uuid: 33e3aab0-16fc-013d-c413-0242ac110002

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
