### PR TITLE
return structured list of collections with arrows

### DIFF
--- a/app/src/components/items/overview/metadata/overview.tsx
+++ b/app/src/components/items/overview/metadata/overview.tsx
@@ -8,6 +8,7 @@ import {
   ButtonGroup,
   TagSet,
   HorizontalRule,
+  Icon,
 } from "@nypl/design-system-react-components";
 import parse from "html-react-parser";
 
@@ -33,9 +34,41 @@ const metadataFieldToDisplay = {
   dateIssued: "Date Issued",
 };
 
-const metadataFieldRender = (field, value) => {
-  if (field === "name") {
-  }
+// Helper function to parse anchor tag from HTML string
+// annoyingly redundant
+const parseHtmlString = (html) => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+  const anchor = doc.querySelector("a");
+  return {
+    href: anchor?.getAttribute("href"),
+    text: anchor?.textContent,
+  };
+};
+
+// Designs use DS Link component but I wonder if we can get away with not using them for the
+// Items page since the manifests are returning the links
+const StructuredCollectionsList = (rawCollections) => {
+  return (
+    <>
+      {rawCollections.map((htmlString, index) => {
+        console.log("htmlString is: ", htmlString);
+        const { href, text } = parseHtmlString(htmlString);
+        return (
+          <span key={index} style={{ paddingLeft: `${(index - 1) * 1.5}rem` }}>
+            {index !== 0 && (
+              <Icon name="navigationSubdirectoryArrowRight" size="large" />
+            )}
+            {parse(htmlString)}
+            {/* <Link href={href}>
+              {text}
+            </Link> */}
+            <br></br>
+          </span>
+        );
+      })}
+    </>
+  );
 };
 
 const MetadataOverview = ({ metadata }) => {
@@ -50,16 +83,31 @@ const MetadataOverview = ({ metadata }) => {
         {Object.keys(metadata)?.map((field, index) => {
           const value = metadata[field];
           if (value !== "" && metadataFieldToDisplay[field] !== "") {
-            return (
-              <>
-                <Text key={index} size="overline1" marginBottom="xs">
-                  {metadataFieldToDisplay[field]}
-                </Text>
-                <Text key={index} marginBottom="m">
-                  {parse(value)}
-                </Text>
-              </>
-            );
+            if (field === "collection") {
+              const collections = value.split("<br>");
+              console.log("collections are: ", collections);
+              return (
+                <>
+                  <Text key={index} size="overline1" marginBottom="xs">
+                    {metadataFieldToDisplay[field]}
+                  </Text>
+                  <Text key={index} marginBottom="m">
+                    {StructuredCollectionsList(collections)}
+                  </Text>
+                </>
+              );
+            } else {
+              return (
+                <>
+                  <Text key={index} size="overline1" marginBottom="xs">
+                    {metadataFieldToDisplay[field]}
+                  </Text>
+                  <Text key={index} marginBottom="m">
+                    {parse(value)}
+                  </Text>
+                </>
+              );
+            }
           }
         })}
       </Box>


### PR DESCRIPTION
## Ticket:

- JIRA ticket [render collections and subcollections on FE](https://newyorkpubliclibrary.atlassian.net/browse/DR-3663)

## This PR does the following:

- renders a structured list of Collections links according to the [designs](https://www.figma.com/design/GlPdMuVtoP1LjdqsU0KM0p/DC-Facelift--Item-page?node-id=15992-29010&m=dev) 

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- This required an annoying amount of string and html manipulation. Open question about if we need to the use the DS Link component or not. I think this is okay for now, just so we can get things off to QA but lmk what you think.

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->
locally with any item.


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
