### PR TITLE
DR-3659: Playwright tests to filter search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Playwright tests for navigation menu, what is public domain and search bar, explore further for the home page (DR-3658)
 - Added Playwright test to search for a keyword (DR-3659)
 - Added Playwright test to confirm visibility of search result filters (DR-3659)
+- Added Playwright test to filter search results with dropdowns (DR-3659)
 
 ## [0.4.2] 2025-05-22
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./playwright",
   timeout: 30000, // default timeout for each test
-  expect: { timeout: 5000 }, // default timeout for each expect assertion
+  expect: { timeout: 10000 }, // default timeout for each expect assertion
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./playwright",
   timeout: 30000, // default timeout for each test
+  expect: { timeout: 5000 }, // default timeout for expect assertions
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./playwright",
   timeout: 30000, // default timeout for each test
-  expect: { timeout: 5000 }, // default timeout for expect assertions
+  expect: { timeout: 5000 }, // default timeout for each expect assertion
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -12,12 +12,14 @@ export default class SearchPage {
 
   // search result filters
   readonly topicFilter: Locator;
+  readonly topicOption: Locator;
   readonly nameFilter: Locator;
   readonly collectionFilter: Locator;
   readonly placeFilter: Locator;
   readonly genreFilter: Locator;
   readonly publisherFilter: Locator;
   readonly divisionFilter: Locator;
+  readonly divisionOption: Locator;
   readonly typeFilter: Locator;
   readonly startYear: Locator;
   readonly endYear: Locator;
@@ -27,6 +29,7 @@ export default class SearchPage {
   readonly availableOnsite: Locator;
   readonly showFilters: Locator;
   readonly hideFilters: Locator;
+  readonly applyFilterButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -47,6 +50,9 @@ export default class SearchPage {
 
     // search result filters
     this.topicFilter = this.page.getByRole("button", { name: "Topic" });
+    this.topicOption = this.page
+      .locator("#select-topic")
+      .getByText("Maps in education");
     this.nameFilter = this.page.getByRole("button", { name: "Name" });
     this.collectionFilter = this.page.getByRole("button", {
       name: "Collection",
@@ -55,6 +61,9 @@ export default class SearchPage {
     this.genreFilter = this.page.getByRole("button", { name: "Genre" });
     this.publisherFilter = this.page.getByRole("button", { name: "Publisher" });
     this.divisionFilter = this.page.getByRole("button", { name: "Division" });
+    this.divisionOption = this.page
+      .locator("#select-division")
+      .getByText("Spencer Collection");
     this.typeFilter = this.page.getByRole("button", { name: "Type" });
     this.startYear = this.page.getByRole("textbox", { name: "Start year" });
     this.endYear = this.page.getByRole("textbox", { name: "End year" });
@@ -73,6 +82,10 @@ export default class SearchPage {
     });
     this.hideFilters = this.page.getByRole("button", {
       name: "Less filter options",
+    });
+    this.applyFilterButton = this.page.getByRole("button", {
+      name: "Apply",
+      exact: true,
     });
   }
 

--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -13,13 +13,15 @@ export default class SearchPage {
   // search result filters
   readonly topicFilter: Locator;
   readonly topicOption: Locator;
+  readonly topicSelected: Locator;
   readonly nameFilter: Locator;
   readonly collectionFilter: Locator;
   readonly placeFilter: Locator;
   readonly genreFilter: Locator;
   readonly publisherFilter: Locator;
+  readonly publisherOption: Locator;
+  readonly publisherSelected: Locator;
   readonly divisionFilter: Locator;
-  readonly divisionOption: Locator;
   readonly typeFilter: Locator;
   readonly startYear: Locator;
   readonly endYear: Locator;
@@ -30,7 +32,6 @@ export default class SearchPage {
   readonly showFilters: Locator;
   readonly hideFilters: Locator;
   readonly applyFilterButton: Locator;
-  readonly clearFilter: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -53,7 +54,10 @@ export default class SearchPage {
     this.topicFilter = this.page.getByRole("button", { name: "Topic" });
     this.topicOption = this.page
       .locator("#select-topic")
-      .getByText("Maps in education");
+      .getByText("Maps in education", { exact: true });
+    this.topicSelected = this.page
+      .locator("#select-topic")
+      .getByText("Topic: Maps in education", { exact: true });
     this.nameFilter = this.page.getByRole("button", { name: "Name" });
     this.collectionFilter = this.page.getByRole("button", {
       name: "Collection",
@@ -61,10 +65,13 @@ export default class SearchPage {
     this.placeFilter = this.page.getByRole("button", { name: "Place" });
     this.genreFilter = this.page.getByRole("button", { name: "Genre" });
     this.publisherFilter = this.page.getByRole("button", { name: "Publisher" });
+    this.publisherOption = this.page
+      .locator("#select-publisher")
+      .getByText("Printed at the Theater,", { exact: true });
+    this.publisherSelected = this.page
+      .locator("#select-publisher")
+      .getByText("Publisher: Printed at the Theater,", { exact: true });
     this.divisionFilter = this.page.getByRole("button", { name: "Division" });
-    this.divisionOption = this.page
-      .locator("#select-division")
-      .getByText("Spencer Collection");
     this.typeFilter = this.page.getByRole("button", { name: "Type" });
     this.startYear = this.page.getByRole("textbox", { name: "Start year" });
     this.endYear = this.page.getByRole("textbox", { name: "End year" });
@@ -88,7 +95,6 @@ export default class SearchPage {
       name: "Apply",
       exact: true,
     });
-    this.clearFilter = this.page.getByTestId("filter-close-icon");
   }
 
   static async loadPage(gotoPage: string, page: Page): Promise<SearchPage> {

--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -30,6 +30,7 @@ export default class SearchPage {
   readonly showFilters: Locator;
   readonly hideFilters: Locator;
   readonly applyFilterButton: Locator;
+  readonly clearFilter: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -87,6 +88,7 @@ export default class SearchPage {
       name: "Apply",
       exact: true,
     });
+    this.clearFilter = this.page.getByTestId("filter-close-icon");
   }
 
   static async loadPage(gotoPage: string, page: Page): Promise<SearchPage> {

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "@playwright/test";
 import SearchPage from "../pages/search.page";
+
+test.beforeEach(async ({ page }) => {
+  // move webkit abort here
+  // load pages here
+});
 test("searches for a keyword from homepage", async ({ page }, testInfo) => {
   test.setTimeout(60000); // added extra time to navigate to homepage and load search page
   if (testInfo.project.name === "webkit") {
@@ -83,32 +88,23 @@ test("filters search results", async ({ page }) => {
   );
   await expect(searchPage.refineHeading).toBeVisible();
 
-  // filter a visible filter
+  // filter a first row filter
   await expect(searchPage.topicFilter).toBeVisible();
   await searchPage.topicFilter.click();
   await expect(searchPage.topicOption).toBeVisible();
   await searchPage.topicOption.click();
   await expect(searchPage.applyFilterButton).toBeVisible();
   await searchPage.applyFilterButton.click();
+  await expect(searchPage.topicSelected).toBeVisible();
 
-  // clear filter
-  await expect(searchPage.clearFilter).toBeVisible();
-  await searchPage.clearFilter.click();
-  await expect(searchPage.clearFilter).not.toBeVisible(); // ensure the filter was cleared
-
-  // filter a not visible filter
+  // filter a second row filter
   await expect(searchPage.showFilters).toBeVisible();
   await searchPage.showFilters.click();
-  await expect(searchPage.divisionFilter).toBeVisible();
-  await searchPage.divisionFilter.click();
-  await expect(searchPage.divisionOption).toBeVisible();
-  await searchPage.divisionOption.click();
+  await expect(searchPage.publisherFilter).toBeVisible();
+  await searchPage.publisherFilter.click();
+  await expect(searchPage.publisherOption).toBeVisible();
+  await searchPage.publisherOption.click();
   await expect(searchPage.applyFilterButton).toBeVisible();
   await searchPage.applyFilterButton.click();
-  // expect division filter to be applied
-
-  // clear filter
-  await expect(searchPage.clearFilter).toBeVisible();
-  await searchPage.clearFilter.click();
-  await expect(searchPage.clearFilter).not.toBeVisible(); // ensure the filter was cleared
+  await expect(searchPage.publisherSelected).toBeVisible();
 });

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -86,23 +86,18 @@ test("filters search results", async ({ page }) => {
   // filter a visible filter
   await expect(searchPage.topicFilter).toBeVisible();
   await searchPage.topicFilter.click();
-  const firstTopicOption = page
-    .locator("#select-topic")
-    .getByText("Maps in education");
-  await expect(firstTopicOption).toBeVisible();
-  await firstTopicOption.click();
-  const applyFilterButton = searchPage.page.getByRole("button", {
-    name: "Apply",
-  });
-  await expect(applyFilterButton).toBeVisible();
-  await applyFilterButton.click();
+  await expect(searchPage.topicOption).toBeVisible();
+  await searchPage.topicOption.click();
+  await expect(searchPage.applyFilterButton).toBeVisible();
+  await searchPage.applyFilterButton.click();
 
   // filter a not visible filter
   await expect(searchPage.showFilters).toBeVisible();
   await searchPage.showFilters.click();
   await expect(searchPage.divisionFilter).toBeVisible();
   await searchPage.divisionFilter.click();
-
-  // date range
-  // availability
+  await expect(searchPage.divisionOption).toBeVisible();
+  await searchPage.divisionOption.click();
+  await expect(searchPage.applyFilterButton).toBeVisible();
+  await searchPage.applyFilterButton.click();
 });

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -14,6 +14,7 @@ test.beforeEach(async ({ page }, testInfo) => {
     searchPage = await SearchPage.loadPage(SearchPage.searchResultsUrl, page);
   }
 });
+
 test("searches for a keyword from homepage", async ({ page }, testInfo) => {
   test.setTimeout(60000); // adds extra time to navigate to homepage and load search page
   searchPage = await SearchPage.loadPage("/", page);
@@ -23,35 +24,10 @@ test("searches for a keyword from homepage", async ({ page }, testInfo) => {
   await expect(searchPage.searchBar).toHaveValue(searchPage.searchKeyword);
   await expect(searchPage.searchButton).toBeVisible();
 
-  // option 1
-  // if (testInfo.project.name === "webkit" || testInfo.project.name === "firefox") {
-  //   // Force navigation in WebKit because the button click fails
-  //   console.log("Forcing navigation to:", SearchPage.searchResultsUrl);
-  //   await SearchPage.loadPage(SearchPage.searchResultsUrl, page);
-  // } else {
-  //     // Wait for navigation triggered by the button click
-  //     await Promise.all([
-  //       page.waitForURL(`**${SearchPage.searchResultsUrl}**`, { waitUntil: "load" }),
-  //       searchPage.searchButton.click(),
-  //     ]);
-  // }
-
-  // option 2
-  try {
-    await Promise.all([
-      searchPage.searchButton.click(),
-      page.waitForURL(`**${SearchPage.searchResultsUrl}**`, {
-        waitUntil: "load",
-      }),
-    ]);
-  } catch (error) {
-    // if navigation did not happen and button click failed, then force navigation
-    console.log(
-      "Search button click and navigation failed, forcing navigation to:",
-      SearchPage.searchResultsUrl
-    );
-    await SearchPage.loadPage(SearchPage.searchResultsUrl, page);
-  }
+  await searchPage.searchButton.click();
+  await page.waitForURL("/search/**", {
+    waitUntil: "load",
+  });
 
   await expect(page).toHaveTitle("Search results - NYPL Digital Collections");
 });

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -4,6 +4,7 @@ import SearchPage from "../pages/search.page";
 let searchPage: SearchPage;
 
 test.beforeEach(async ({ page }, testInfo) => {
+  // handles 404 errors for restricted images
   if (testInfo.project.name === "webkit") {
     await page.route("**/*.{png,jpg,jpeg,svg}", (route) => {
       route.abort();

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -1,7 +1,12 @@
 import { test, expect } from "@playwright/test";
 import SearchPage from "../pages/search.page";
-test("searches for a keyword from homepage", async ({ page }) => {
+test("searches for a keyword from homepage", async ({ page }, testInfo) => {
   test.setTimeout(60000); // added extra time to navigate to homepage and load search page
+  if (testInfo.project.name === "webkit") {
+    await page.route("**/*.{png,jpg,jpeg,svg}", (route) => {
+      route.abort();
+    });
+  }
   const searchPage = await SearchPage.loadPage("/", page);
 
   await expect(searchPage.searchBar).toBeVisible();
@@ -24,7 +29,8 @@ test("searches for a keyword from homepage", async ({ page }) => {
   await expect(searchPage.firstResult).toBeVisible();
 });
 
-test("displays search result filters", async ({ page }) => {
+test("displays search result filters", async ({ page }, testInfo) => {
+  test.setTimeout(60000); // added extra time to load all elements
   const searchPage = await SearchPage.loadPage(
     SearchPage.searchResultsUrl,
     page

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -54,10 +54,16 @@ test("searches for a keyword from homepage", async ({ page }, testInfo) => {
   }
 
   await expect(page).toHaveTitle("Search results - NYPL Digital Collections");
+});
 
-  // await expect(searchPage.refineHeading).toBeVisible(); // move to different test "displays search results"
-  // await expect(searchPage.resultsHeading).toBeVisible();
-  // await expect(searchPage.firstResult).toBeVisible();
+test("displays search results", async ({ page }) => {
+  test.setTimeout(60000); // adds extra time to load all elements
+  await expect(searchPage.refineHeading).toBeVisible();
+  await expect(searchPage.resultsHeading).toBeVisible();
+  await expect(searchPage.firstResult).toBeVisible();
+  await expect(searchPage.firstResult).toContainText(searchPage.searchKeyword, {
+    ignoreCase: true,
+  });
 });
 
 test("displays search result filters", async ({ page }) => {
@@ -104,6 +110,7 @@ test("displays search result filters", async ({ page }) => {
 });
 
 test("filters search results", async ({ page }) => {
+  test.setTimeout(60000); // adds extra time to load all elements
   await expect(searchPage.refineHeading).toBeVisible();
 
   // filters a drop-down in the first row

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -91,6 +91,11 @@ test("filters search results", async ({ page }) => {
   await expect(searchPage.applyFilterButton).toBeVisible();
   await searchPage.applyFilterButton.click();
 
+  // clear filter
+  await expect(searchPage.clearFilter).toBeVisible();
+  await searchPage.clearFilter.click();
+  await expect(searchPage.clearFilter).not.toBeVisible(); // ensure the filter was cleared
+
   // filter a not visible filter
   await expect(searchPage.showFilters).toBeVisible();
   await searchPage.showFilters.click();
@@ -100,4 +105,10 @@ test("filters search results", async ({ page }) => {
   await searchPage.divisionOption.click();
   await expect(searchPage.applyFilterButton).toBeVisible();
   await searchPage.applyFilterButton.click();
+  // expect division filter to be applied
+
+  // clear filter
+  await expect(searchPage.clearFilter).toBeVisible();
+  await searchPage.clearFilter.click();
+  await expect(searchPage.clearFilter).not.toBeVisible(); // ensure the filter was cleared
 });

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -75,3 +75,34 @@ test("displays search result filters", async ({ page }, testInfo) => {
   await expect(searchPage.divisionFilter).not.toBeVisible();
   await expect(searchPage.typeFilter).not.toBeVisible();
 });
+
+test("filters search results", async ({ page }) => {
+  const searchPage = await SearchPage.loadPage(
+    SearchPage.searchResultsUrl,
+    page
+  );
+  await expect(searchPage.refineHeading).toBeVisible();
+
+  // filter a visible filter
+  await expect(searchPage.topicFilter).toBeVisible();
+  await searchPage.topicFilter.click();
+  const firstTopicOption = page
+    .locator("#select-topic")
+    .getByText("Maps in education");
+  await expect(firstTopicOption).toBeVisible();
+  await firstTopicOption.click();
+  const applyFilterButton = searchPage.page.getByRole("button", {
+    name: "Apply",
+  });
+  await expect(applyFilterButton).toBeVisible();
+  await applyFilterButton.click();
+
+  // filter a not visible filter
+  await expect(searchPage.showFilters).toBeVisible();
+  await searchPage.showFilters.click();
+  await expect(searchPage.divisionFilter).toBeVisible();
+  await searchPage.divisionFilter.click();
+
+  // date range
+  // availability
+});


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3659](https://newyorkpubliclibrary.atlassian.net/browse/DR-3659)

## This PR does the following:

<!-- What has been updated or added in this PR? -->
- Filters search results by one of the first row drop-down filters and by one of the second row drop-down filters

## Open questions/Notes

<!-- Any questions you want to ask the reviewer? -->
- Confirmed all tests pass on Chromium, but they may be flaky on Firefox and Webkit

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

Run `npm run playwright`

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3659]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ