### PR TITLE
Add title filter to collections api

### DIFF
--- a/app/src/config/constants.ts
+++ b/app/src/config/constants.ts
@@ -73,6 +73,7 @@ export const ALLOWED_FILTERS = [
   "language",
   "subcollection",
   "materialType",
+  "title",
 ];
 
 export const METADATA_FIELDS = [

--- a/app/src/utils/searchManager/searchManager.tsx
+++ b/app/src/utils/searchManager/searchManager.tsx
@@ -278,10 +278,9 @@ export const filterToString = (filters: Filter[]): string => {
 export const transformToDisplayAvailableFilters = (
   availableFilters: Record<string, AvailableFilterOption[]>
 ): AvailableFilter[] => {
+  const nonSelectableFilters = ["form", "language", "subcollection", "title"];
   return Object.entries(availableFilters)
-    .filter(
-      ([key]) => key !== "subcollection" && key !== "language" && key !== "form"
-    )
+    .filter(([key]) => !nonSelectableFilters.includes(key))
     .map(([key, options]) => ({
       name: key,
       options,


### PR DESCRIPTION
Looks like if this isn't set, the filter will not be included in the API request.  Also, made sure to exclude it from the selectable options, so it doesn't appear as a selectable filter (or should we just include it?)

## Ticket:

- JIRA ticket [DR-3640](https://newyorkpubliclibrary.atlassian.net/browse/DR-3640)

## This PR does the following:

Looks like if this isn't set, the filter will not be included in the API
request.  Also, made sure to exclude it from the selectable options, so
it doesn't appear as a selectable filter (or should we just include it?)

This is needed to support https://github.com/NYPL/collections-api/pull/137
## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Ran this locally against the aforementioned backend PR, searched for 'Much Ado About Nothing', clicked on the subject corresponding to the title:
<img width="633" alt="Screen Shot 2025-06-11 at 11 58 27 AM" src="https://github.com/user-attachments/assets/d5e0f9e1-0367-4fb0-91b8-bb9bf4a908be" />

See that it goes to a search with matching results:
<img width="1411" alt="Screen Shot 2025-06-11 at 11 59 42 AM" src="https://github.com/user-attachments/assets/8b5503a8-85e4-42d6-91e0-fd845f10137f" />

(though it looks like the search could be refined on the server)

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3640]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ