### PR TITLE
fix: Add keys to list elements

### DIFF
--- a/app/src/components/items/overview/citations/overview.tsx
+++ b/app/src/components/items/overview/citations/overview.tsx
@@ -1,4 +1,5 @@
 import { Box, Flex, Heading, Text } from "@nypl/design-system-react-components";
+import { Fragment } from "react";
 import parse from "html-react-parser";
 
 // Helper function to parse anchor tag from HTML string
@@ -90,14 +91,12 @@ ${metadata.origin ? "(" + metadata.origin + ")" : ""}${
           const value = citationFormatDummyData[field];
           if (value !== "") {
             return (
-              <>
-                <Text key={index} size="overline1" marginBottom="xs">
+              <Fragment key={`citation-${field}`}>
+                <Text size="overline1" marginBottom="xs">
                   {field}
                 </Text>
-                <Text key={index} marginBottom="m">
-                  {parse(value)}
-                </Text>
-              </>
+                <Text marginBottom="m">{parse(value)}</Text>
+              </Fragment>
             );
           }
         })}

--- a/app/src/components/items/overview/metadata/overview.tsx
+++ b/app/src/components/items/overview/metadata/overview.tsx
@@ -10,6 +10,7 @@ import {
   HorizontalRule,
   Icon,
 } from "@nypl/design-system-react-components";
+import { Fragment } from "react";
 import parse from "html-react-parser";
 
 const metadataFieldToDisplay = {
@@ -54,8 +55,9 @@ const StructuredCollectionsList = (rawCollections) => {
       {rawCollections.map((htmlString, index) => {
         console.log("htmlString is: ", htmlString);
         const { href, text } = parseHtmlString(htmlString);
+        const key = `metadata-collection-${index}`;
         return (
-          <span key={index} style={{ paddingLeft: `${(index - 1) * 1.5}rem` }}>
+          <span key={key} style={{ paddingLeft: `${(index - 1) * 1.5}rem` }}>
             {index !== 0 && (
               <Icon name="navigationSubdirectoryArrowRight" size="large" />
             )}
@@ -88,25 +90,23 @@ const MetadataOverview = ({ metadata }) => {
               const collections = value.split("<br>");
               console.log("collections are: ", collections);
               return (
-                <>
-                  <Text key={index} size="overline1" marginBottom="xs">
+                <Fragment key="metadata-collection">
+                  <Text size="overline1" marginBottom="xs">
                     {metadataFieldToDisplay[field]}
                   </Text>
-                  <Text key={index} marginBottom="m">
+                  <Text marginBottom="m">
                     {StructuredCollectionsList(collections)}
                   </Text>
-                </>
+                </Fragment>
               );
             } else {
               return (
-                <>
-                  <Text key={index} size="overline1" marginBottom="xs">
+                <Fragment key={`"metadata-${field}`}>
+                  <Text size="overline1" marginBottom="xs">
                     {metadataFieldToDisplay[field]}
                   </Text>
-                  <Text key={index} marginBottom="m">
-                    {parse(value)}
-                  </Text>
-                </>
+                  <Text marginBottom="m">{parse(value)}</Text>
+                </Fragment>
               );
             }
           }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-xxxx](url)

## This PR does the following:

Add keys to elements in the metadata and citations that are structured in a list.  Note I had to replace a couple instances of `<>` fragment syntax in favor of the explicit `<Fragment` to pass in a key prop.

This fixes *most* warnings for missing / duplicate keys - there are some edge cases I've seen that are a bit tricky for me, and would have to take more investigation


## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Opened an item page locally and verified the warnings go away
## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
