### PR TITLE
Parse collection `containsOnsiteMaterials` as bool

### DIFF
--- a/app/src/components/card/card.tsx
+++ b/app/src/components/card/card.tsx
@@ -41,6 +41,12 @@ export const Card = forwardRef<HTMLDivElement, DCCardProps>(
       ? `${slug}-${id}`
       : `${stringToSlug(record.title)}-${id}`; // should probably truncate
 
+    if (isCollection) {
+      console.log(record.title);
+      console.log(record.containsOnSiteMaterials);
+      console.log(typeof record.containsOnSiteMaterials);
+    }
+
     const card = (
       <ChakraCard
         ref={ref}

--- a/app/src/models/collectionCard.ts
+++ b/app/src/models/collectionCard.ts
@@ -1,4 +1,5 @@
 import { imageURL } from "../utils/utils";
+import { parseBoolean } from "../utils/utils";
 
 export class CollectionCardModel {
   uuid: string;
@@ -17,6 +18,7 @@ export class CollectionCardModel {
     this.imageURL = imageURL(data.imageID, "square", "!288,288", "0");
     this.numberOfDigitizedItems =
       data.numberOfDigitizedItems || data.numItems || 0;
-    this.containsOnSiteMaterials = data.containsOnSiteMaterials;
+    this.containsOnSiteMaterials =
+      parseBoolean(data.containsOnSiteMaterials) || false;
   }
 }

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -270,3 +270,7 @@ export const isDCUuid = (identifier) => {
 export const deSlugify = (slug: string): string => {
   return slug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 };
+
+export const parseBoolean = (value: string): boolean => {
+  return value == "true" ? true : false;
+};


### PR DESCRIPTION
Looks like this got dropped in an earlier refactor - make sure we convert this booly string to bool - I just copied and pasted how this was before.

I wonder if there's a better way, like JSON parsing

## Ticket:

- JIRA ticket [DR-3724](https://newyorkpubliclibrary.atlassian.net/browse/DR-3724)

## This PR does the following:

Fixes divisions page onsite materials

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<img width="907" alt="Screen Shot 2025-06-12 at 4 41 34 PM" src="https://github.com/user-attachments/assets/202156b8-83f7-42f2-b3a7-21abb34f36d0" />

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
