### PR TITLE
fix: Fix archives ID in ItemMetadata

### DIFF
--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -108,9 +108,9 @@ export class ItemModel {
     // Special NYPL Identifiers for external links
     const identifiers = rawManifestMetadata["Identifiers"];
 
-    const archivesLink = identifiers.find((identifier) => {
-      identifier.includes("Archives ID");
-    });
+    const archivesLink = identifiers.find((identifier) =>
+      identifier.includes("Archives ID")
+    );
 
     const catalogLink = identifiers.find((identifier) =>
       identifier.includes("NYPL Catalog ID (bnumber)")


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3732](https://newyorkpubliclibrary.atlassian.net/browse/DR-3732)

## This PR does the following:

When we grab the archives link from the metadata, we were erroneously searching for an object, not the string itself.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Loaded up item c4b241f0-0ae7-0137-be58-7d8bff779f4d locally, see that it has a finding aid link and that the link takes your to archives portal:
<img width="563" alt="Screen Shot 2025-06-18 at 5 10 51 PM" src="https://github.com/user-attachments/assets/7a16df94-adaa-4eec-bdd3-7c29676a4f0f" />

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3732]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ