### PR TITLE
Add item google analytics pageview events

### DIFF
--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -66,6 +66,11 @@ export default async function ItemViewer({ params, searchParams }: ItemProps) {
         },
       ]}
       adobeAnalyticsPageName={createAdobeAnalyticsPageName("items", item.title)}
+      ga4Data={{
+        collection: item.breadcrumbData.collection.title,
+        subcollection: item.subcollectionName ?? undefined,
+        division: item.breadcrumbData.division,
+      }}
     >
       <ItemPage
         manifest={manifest}

--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -39,6 +39,7 @@ export class ItemModel {
   catalogLink: string | null;
   citationData: CitationOutput;
   breadcrumbData: any;
+  subcollectionName: string | null;
 
   constructor(uuid: string, manifest: any) {
     const parser = new Maniiifest(manifest);
@@ -146,9 +147,10 @@ export class ItemModel {
     )[0];
     divisionLinkObj["path"] = new URL(divisionLinkObj.href).pathname;
 
+    const orderedCollections = this.metadata?.collection?.split("<br>") ?? [];
     // note: this points to the top level collection, not the immediate parent collection or subcollection
     const collectionLinkObj = extractAllAnchorsFromHTML(
-      this.metadata?.collection?.split("<br>")[0] ?? ""
+      orderedCollections[0] ?? ""
     )[0];
     collectionLinkObj["path"] = new URL(collectionLinkObj.href).pathname;
 
@@ -156,5 +158,11 @@ export class ItemModel {
       division: divisionLinkObj,
       collection: collectionLinkObj,
     };
+    this.subcollectionName = null;
+    if (orderedCollections.length > 1) {
+      const subcollection = orderedCollections[orderedCollections.length - 1];
+      this.subcollectionName =
+        extractAllAnchorsFromHTML(subcollection)[0]?.text;
+    }
   }
 }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3587](https://newyorkpubliclibrary.atlassian.net/browse/DR-3587)

## This PR does the following:

Simply add the ga4 data to the PageLayout for the items page. Note, I added some extra logic to extract the subcollection name, using the last collection in the collection list, as that will be the 'immediate' parent

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3587]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ