### PR TITLE
fix: Point Archives link at specific component

### DIFF
--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -110,7 +110,7 @@ export class ItemModel {
     const identifiers = rawManifestMetadata["Identifiers"];
 
     const archivesLink = identifiers.find((identifier) =>
-      identifier.includes("Archives ID")
+      identifier.includes("Archives EAD ID")
     );
 
     const catalogLink = identifiers.find((identifier) =>


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3732](https://newyorkpubliclibrary.atlassian.net/browse/DR-3732)

## This PR does the following:

Use the EAD link instead of the archives collection link

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Load an item with an archive link on localhost (eg, http://localhost:3000/items/c4b241f0-0ae7-0137-be58-7d8bff779f4d)

See the button is still there:
![Screen Shot 2025-06-24 at 9 35 58 AM](https://github.com/user-attachments/assets/64ccc5f5-f0a4-49ea-9172-ef87988d1bf6)

Click it and see it takes us to the specific component:

![Screen Shot 2025-06-24 at 9 36 04 AM](https://github.com/user-attachments/assets/87bba236-1de3-499a-a85c-c29c33e04803)

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3732]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ