### PR TITLE
DR-3659: Playwright tests to filter by date and availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Playwright tests to sort search results (DR-3659)
 - Added Image ID to Items page (DR-3695)
 - Added Playwright test feedback button to the home page (DR-3658)
+- Added Playwright tests to filter by date and availability (DR-3659)
 
 ### Fixed
 - Fixed Order Print button (DR-3486)

--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -102,9 +102,9 @@ export default class SearchPage {
     this.startYear = this.page.getByRole("textbox", { name: "Start year" });
     this.endYear = this.page.getByRole("textbox", { name: "End year" });
     this.applyDates = this.page.getByRole("button", { name: "Apply dates" });
-    this.availablePublicDomain = this.page.getByRole("radio", {
-      name: "Public domain",
-    });
+    this.availablePublicDomain = this.page
+      .locator("label")
+      .filter({ hasText: "Public domain" });
     this.availableOnline = this.page.getByRole("radio", {
       name: "Available online",
     });

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -66,6 +66,8 @@ test.describe("displays search results filters", () => {
   test("displays date range filters", async () => {
     await expect(searchPage.refineHeading).toBeVisible();
 
+    await expect(searchPage.showFilters).toBeVisible();
+    await searchPage.showFilters.click();
     await expect(searchPage.startYear).toBeVisible();
     await expect(searchPage.endYear).toBeVisible();
     await expect(searchPage.applyDates).toBeVisible();
@@ -74,6 +76,8 @@ test.describe("displays search results filters", () => {
   test("displays availability filters", async () => {
     await expect(searchPage.refineHeading).toBeVisible();
 
+    await expect(searchPage.showFilters).toBeVisible();
+    await searchPage.showFilters.click();
     await expect(searchPage.availablePublicDomain).toBeVisible();
     await expect(searchPage.availableOnline).toBeVisible();
     await expect(searchPage.availableOnsite).toBeVisible();

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -105,6 +105,8 @@ test.describe("filters search results", () => {
   test("filters search results by dates", async () => {
     await expect(searchPage.refineHeading).toBeVisible();
 
+    await expect(searchPage.showFilters).toBeVisible();
+    await searchPage.showFilters.click();
     await expect(searchPage.startYear).toBeVisible();
     await expect(searchPage.endYear).toBeVisible();
     await searchPage.startYear.fill("1700");
@@ -118,6 +120,8 @@ test.describe("filters search results", () => {
   test("filters search results by availability", async () => {
     await expect(searchPage.refineHeading).toBeVisible();
 
+    await expect(searchPage.showFilters).toBeVisible();
+    await searchPage.showFilters.click();
     await expect(searchPage.availablePublicDomain).toBeVisible();
     await searchPage.availablePublicDomain.click();
     await expect(searchPage.availablePublicDomain).toBeChecked();

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -33,6 +33,7 @@ test("displays search results", async () => {
   });
 });
 
+// create test.describe to split these tests
 test("displays search result filters", async () => {
   await expect(searchPage.refineHeading).toBeVisible();
 
@@ -75,28 +76,52 @@ test("displays search result filters", async () => {
   await expect(searchPage.typeFilter).not.toBeVisible();
 });
 
-test("filters search results", async () => {
-  await expect(searchPage.refineHeading).toBeVisible();
+test.describe("filters search results", () => {
+  test("filters drop-downs in first row", async () => {
+    await expect(searchPage.refineHeading).toBeVisible();
 
-  // filters a drop-down in the first row
-  await expect(searchPage.topicFilter).toBeVisible();
-  await searchPage.topicFilter.click();
-  await expect(searchPage.topicOption).toBeVisible();
-  await searchPage.topicOption.click();
-  await expect(searchPage.applyFilterButton).toBeVisible();
-  await searchPage.applyFilterButton.click();
-  await expect(searchPage.topicSelected).toBeVisible();
+    await expect(searchPage.topicFilter).toBeVisible();
+    await searchPage.topicFilter.click();
+    await expect(searchPage.topicOption).toBeVisible();
+    await searchPage.topicOption.click();
+    await expect(searchPage.applyFilterButton).toBeVisible();
+    await searchPage.applyFilterButton.click();
+    await expect(searchPage.topicSelected).toBeVisible();
+  });
+  test("filters drop-downs in second row", async () => {
+    await expect(searchPage.refineHeading).toBeVisible();
 
-  // filters a drop-down in the second row
-  await expect(searchPage.showFilters).toBeVisible();
-  await searchPage.showFilters.click();
-  await expect(searchPage.publisherFilter).toBeVisible();
-  await searchPage.publisherFilter.click();
-  await expect(searchPage.publisherOption).toBeVisible();
-  await searchPage.publisherOption.click();
-  await expect(searchPage.applyFilterButton).toBeVisible();
-  await searchPage.applyFilterButton.click();
-  await expect(searchPage.publisherSelected).toBeVisible();
+    await expect(searchPage.showFilters).toBeVisible();
+    await searchPage.showFilters.click();
+    await expect(searchPage.publisherFilter).toBeVisible();
+    await searchPage.publisherFilter.click();
+    await expect(searchPage.publisherOption).toBeVisible();
+    await searchPage.publisherOption.click();
+    await expect(searchPage.applyFilterButton).toBeVisible();
+    await searchPage.applyFilterButton.click();
+    await expect(searchPage.publisherSelected).toBeVisible();
+  });
+
+  test("filters search results by dates", async () => {
+    await expect(searchPage.refineHeading).toBeVisible();
+
+    await expect(searchPage.startYear).toBeVisible();
+    await expect(searchPage.endYear).toBeVisible();
+    await searchPage.startYear.fill("1700");
+    await searchPage.endYear.fill("1800");
+    await expect(searchPage.applyDates).toBeVisible();
+    await searchPage.applyDates.click();
+    await expect(searchPage.startYear).toHaveValue("1700");
+    await expect(searchPage.endYear).toHaveValue("1800");
+  });
+
+  test("filters search results by availability", async () => {
+    await expect(searchPage.refineHeading).toBeVisible();
+
+    await expect(searchPage.availablePublicDomain).toBeVisible();
+    await searchPage.availablePublicDomain.click();
+    await expect(searchPage.availablePublicDomain).toBeChecked();
+  });
 });
 
 test.describe("clears search results filters", () => {
@@ -111,7 +136,7 @@ test.describe("clears search results filters", () => {
     await expect(searchPage.publisherSelected).not.toBeVisible();
   });
 
-  test("clears dropdown filter", async () => {
+  test("clears drop-down filter", async () => {
     await expect(searchPage.refineHeading).toBeVisible();
 
     await searchPage.filterSearchResults(); // reset filters to topic and publisher

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -33,47 +33,62 @@ test("displays search results", async () => {
   });
 });
 
-// create test.describe to split these tests
-test("displays search result filters", async () => {
-  await expect(searchPage.refineHeading).toBeVisible();
+test.describe("displays search results filters", () => {
+  test("displays first row of drop-down filters", async () => {
+    await expect(searchPage.refineHeading).toBeVisible();
 
-  // displays first row of filters
-  await expect(searchPage.topicFilter).toBeVisible();
-  await expect(searchPage.nameFilter).toBeVisible();
-  await expect(searchPage.collectionFilter).toBeVisible();
-  await expect(searchPage.placeFilter).toBeVisible();
+    await expect(searchPage.topicFilter).toBeVisible();
+    await expect(searchPage.nameFilter).toBeVisible();
+    await expect(searchPage.collectionFilter).toBeVisible();
+    await expect(searchPage.placeFilter).toBeVisible();
+  });
 
-  // does not yet display second row of filters
-  await expect(searchPage.genreFilter).not.toBeVisible();
-  await expect(searchPage.publisherFilter).not.toBeVisible();
-  await expect(searchPage.divisionFilter).not.toBeVisible();
-  await expect(searchPage.typeFilter).not.toBeVisible();
+  test("does not yet display second row of drop-down filters", async () => {
+    await expect(searchPage.refineHeading).toBeVisible();
 
-  // displays second row of filters
-  await expect(searchPage.showFilters).toBeVisible();
-  await searchPage.showFilters.click();
-  await expect(searchPage.genreFilter).toBeVisible();
-  await expect(searchPage.publisherFilter).toBeVisible();
-  await expect(searchPage.divisionFilter).toBeVisible();
-  await expect(searchPage.typeFilter).toBeVisible();
+    await expect(searchPage.genreFilter).not.toBeVisible();
+    await expect(searchPage.publisherFilter).not.toBeVisible();
+    await expect(searchPage.divisionFilter).not.toBeVisible();
+    await expect(searchPage.typeFilter).not.toBeVisible();
+  });
 
-  // displays date range filters
-  await expect(searchPage.startYear).toBeVisible();
-  await expect(searchPage.endYear).toBeVisible();
-  await expect(searchPage.applyDates).toBeVisible();
+  test("displays second row of drop-down filters", async () => {
+    await expect(searchPage.refineHeading).toBeVisible();
 
-  // displays availability filters
-  await expect(searchPage.availablePublicDomain).toBeVisible();
-  await expect(searchPage.availableOnline).toBeVisible();
-  await expect(searchPage.availableOnsite).toBeVisible();
+    await expect(searchPage.showFilters).toBeVisible();
+    await searchPage.showFilters.click();
+    await expect(searchPage.genreFilter).toBeVisible();
+    await expect(searchPage.publisherFilter).toBeVisible();
+    await expect(searchPage.divisionFilter).toBeVisible();
+    await expect(searchPage.typeFilter).toBeVisible();
+  });
 
-  // hides second row of filters
-  await expect(searchPage.hideFilters).toBeVisible();
-  await searchPage.hideFilters.click();
-  await expect(searchPage.genreFilter).not.toBeVisible();
-  await expect(searchPage.publisherFilter).not.toBeVisible();
-  await expect(searchPage.divisionFilter).not.toBeVisible();
-  await expect(searchPage.typeFilter).not.toBeVisible();
+  test("displays date range filters", async () => {
+    await expect(searchPage.refineHeading).toBeVisible();
+
+    await expect(searchPage.startYear).toBeVisible();
+    await expect(searchPage.endYear).toBeVisible();
+    await expect(searchPage.applyDates).toBeVisible();
+  });
+
+  test("displays availability filters", async () => {
+    await expect(searchPage.refineHeading).toBeVisible();
+
+    await expect(searchPage.availablePublicDomain).toBeVisible();
+    await expect(searchPage.availableOnline).toBeVisible();
+    await expect(searchPage.availableOnsite).toBeVisible();
+  });
+
+  test("hides second row of drop-down filters", async () => {
+    await expect(searchPage.refineHeading).toBeVisible();
+
+    await expect(searchPage.hideFilters).toBeVisible();
+    await searchPage.hideFilters.click();
+    await expect(searchPage.genreFilter).not.toBeVisible();
+    await expect(searchPage.publisherFilter).not.toBeVisible();
+    await expect(searchPage.divisionFilter).not.toBeVisible();
+    await expect(searchPage.typeFilter).not.toBeVisible();
+  });
 });
 
 test.describe("filters search results", () => {

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -86,6 +86,8 @@ test.describe("displays search results filters", () => {
   test("hides second row of drop-down filters", async () => {
     await expect(searchPage.refineHeading).toBeVisible();
 
+    await expect(searchPage.showFilters).toBeVisible();
+    await searchPage.showFilters.click();
     await expect(searchPage.hideFilters).toBeVisible();
     await searchPage.hideFilters.click();
     await expect(searchPage.genreFilter).not.toBeVisible();


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3659](https://newyorkpubliclibrary.atlassian.net/browse/DR-3659)

## This PR does the following:
- Adds tests to filter search results by date and availability
- Reorganizes previous tests

## Open questions

N/A

## How has this been tested? How should a reviewer test this?

Run `npm run playwright` or observe Playwright Tests check in PR

## Accessibility concerns or updates

N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3659]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ