### PR TITLE
Forward client IP through fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 - Updated breadcrumb to include Division and Collection information (DR-3701)
 - Updated Collections page to bolden the Polonsky note (DR-3705)
+- Updated `fetch` calls to include original client IP (DR-3754)
 
 ## [0.4.3] 2025-06-17
 ### Added

--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Metadata } from "next";
+import { headers } from "next/headers";
 import PageLayout from "../../src/components/pageLayout/pageLayout";
 import { createAdobeAnalyticsPageName } from "../../src/utils/utils";
 import { ItemModel } from "../../src/models/item";
@@ -18,8 +19,18 @@ type ItemProps = {
 let item;
 
 const getItemManifest = async (uuid: string) => {
-  const data = await CollectionsApi.getManifestForItemUUID(uuid);
+  const clientIP = await getClientIP();
+  const data = await CollectionsApi.getManifestForItemUUID(uuid, clientIP);
   return data;
+};
+
+const getClientIP = async () => {
+  const clientHeaders = await headers();
+  const forwardedFor = clientHeaders.get("x-forwarded-for");
+  if (forwardedFor) {
+    return forwardedFor.split(",")[0];
+  }
+  return clientHeaders.get("x-real-ip");
 };
 
 export async function generateMetadata({

--- a/app/src/utils/apiClients/apiClients.tsx
+++ b/app/src/utils/apiClients/apiClients.tsx
@@ -249,11 +249,11 @@ export class CollectionsApi {
     return response;
   }
 
-  static async getManifestForItemUUID(uuid: string) {
+  static async getManifestForItemUUID(uuid: string, clientIP: string | null) {
     let apiUrl = `${process.env.COLLECTIONS_API_URL}/manifests/${uuid}`;
     const response = await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false },
+      options: { isRepoApi: false, clientIP: clientIP },
     });
     return response;
   }

--- a/app/src/utils/fetchApi/fetchApi.ts
+++ b/app/src/utils/fetchApi/fetchApi.ts
@@ -8,6 +8,7 @@ import logger from "logger";
  *   - method: "GET" or "POST" (default is "GET").
  *   - params: URL parameters for GET requests.
  *   - body: Body data for POST requests.
+ *   - clientIP: IP address of the requester
  *   - isRepoApi: Boolean flag to determine if Repo API or Collections API authorization should be included.
  *   - next: Next.js-specific options (revalidate, tags)
  * @returns {Promise<any>} - The API response.
@@ -21,11 +22,19 @@ export const fetchApi = async ({
     method?: "GET" | "POST";
     params?: { [key: string]: any };
     body?: any;
+    clientIP?: string | null;
     isRepoApi?: boolean;
     next?;
   };
 }) => {
-  const { method = "GET", params, body, isRepoApi = true, next } = options;
+  const {
+    method = "GET",
+    params,
+    body,
+    clientIP = null,
+    isRepoApi = true,
+    next,
+  } = options;
 
   const headers: Record<string, string> = {};
 
@@ -41,6 +50,9 @@ export const fetchApi = async ({
   if (method === "GET" && params) {
     const queryString = "?" + new URLSearchParams(params).toString();
     apiUrl += queryString;
+  }
+  if (clientIP) {
+    headers["X-Forwarded-For"] = clientIP;
   }
 
   console.log("apiUrl is: ", apiUrl);
@@ -62,7 +74,7 @@ export const fetchApi = async ({
   try {
     const response = (await fetchWithTimeout(apiUrl, {
       method,
-      headers,
+      headers: headers,
       body: method === "POST" ? JSON.stringify(body) : undefined,
       next,
     })) as Response;


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3754](https://newyorkpubliclibrary.atlassian.net/browse/DR-3754)

## This PR does the following:

Currently, our server looks for the IP of the user in various headers to determine rights for the user. However, since our fetch requests are all placed on the nextJS server, living in EC2, the IPs for all the requests end up being EC2 IPs, so our rights logic fails.

To fix this, use `next/headers` to inspect the headers of the incoming request and forward the origin IP to the API. I used the following nextJS doc as a guide for this:
https://nextjs.org/docs/14/app/api-reference/functions/headers#ip-address

I kinda need to see what this looks like when it goes through the reverse proxy, so once this is in, I'll inspect the logs and patch on the server side.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3754]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ