### PR TITLE
fix: Handle standalone items in breadcrumbs

### DIFF
--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -37,6 +37,28 @@ export async function generateMetadata({
   };
 }
 
+function formatItemBreadcrumbs(item: ItemModel) {
+  const breadcrumbData = item.breadcrumbData;
+  let breadcrumbs = [
+    { text: "Home", url: "/" },
+    {
+      text: `${breadcrumbData.division.text}`,
+      url: `${breadcrumbData.division.path}`,
+    },
+  ];
+  if (breadcrumbData.collection) {
+    breadcrumbs.push({
+      text: breadcrumbData.collection.text,
+      url: breadcrumbData.collection.url,
+    });
+  }
+  breadcrumbs.push({
+    text: `${item.title}`,
+    url: `/items/${item.uuid}`,
+  });
+  return breadcrumbs;
+}
+
 export default async function ItemViewer({ params, searchParams }: ItemProps) {
   revalidatePath("/");
   const manifest = await getItemManifest(params.uuid);
@@ -50,24 +72,10 @@ export default async function ItemViewer({ params, searchParams }: ItemProps) {
   return (
     <PageLayout
       activePage="item"
-      breadcrumbs={[
-        { text: "Home", url: "/" },
-        {
-          text: `${item.breadcrumbData.division.text}`,
-          url: `${item.breadcrumbData.division.path}`,
-        },
-        {
-          text: `${item.breadcrumbData.collection.text}`,
-          url: `${item.breadcrumbData.collection.path}`,
-        },
-        {
-          text: `${item.title}`,
-          url: `/items/${params.uuid}`,
-        },
-      ]}
+      breadcrumbs={formatItemBreadcrumbs(item)}
       adobeAnalyticsPageName={createAdobeAnalyticsPageName("items", item.title)}
       ga4Data={{
-        collection: item.breadcrumbData.collection.title,
+        collection: item.breadcrumbData.collection?.title ?? undefined,
         subcollection: item.subcollectionName ?? undefined,
         division: item.breadcrumbData.division,
       }}

--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -153,12 +153,17 @@ export class ItemModel {
     const collectionLinkObj = extractAllAnchorsFromHTML(
       orderedCollections[0] ?? ""
     )[0];
-    collectionLinkObj["path"] = new URL(collectionLinkObj.href).pathname;
-
-    this.breadcrumbData = {
-      division: divisionLinkObj,
-      collection: collectionLinkObj,
-    };
+    if (collectionLinkObj) {
+      collectionLinkObj["path"] = new URL(collectionLinkObj.href).pathname;
+      this.breadcrumbData = {
+        division: divisionLinkObj,
+        collection: collectionLinkObj,
+      };
+    } else {
+      this.breadcrumbData = {
+        division: divisionLinkObj,
+      };
+    }
 
     this.subcollectionName = null;
     if (orderedCollections.length > 1) {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3755](https://newyorkpubliclibrary.atlassian.net/browse/DR-3755)

## This PR does the following:

Standalone items are not part of a collection, which has been breaking the breadcrumbs on the items page. Simply don't try to include the collection if there isn't one.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

loaded the problematic item https://qa-digitalcollections.nypl.org/manifests/3c070da0-68c2-0135-eea2-6d7976cc435f on localhost:

<img width="1548" alt="Screen Shot 2025-06-25 at 5 15 32 PM" src="https://github.com/user-attachments/assets/66dc88c7-6b10-4dfe-a6b3-d746a812d827" />

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3755]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ