### PR TITLE
Fall back to finding aid when component missing

### DIFF
--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -110,17 +110,25 @@ export class ItemModel {
     // Special NYPL Identifiers for external links
     const identifiers = rawManifestMetadata["Identifiers"];
 
-    const archivesLink = identifiers.find((identifier) =>
+    const archivesComponentLink = identifiers.find((identifier) =>
       identifier.includes("Archives EAD ID")
     );
+    this.archivesLink = archivesComponentLink
+      ? extractFirstHrefFromHTML(archivesComponentLink)
+      : null;
+
+    if (!this.archivesLink) {
+      const archivesFindingAidLink = identifiers.find((identifier) =>
+        identifier.includes("Archives ID")
+      );
+      this.archivesLink = archivesFindingAidLink
+        ? extractFirstHrefFromHTML(archivesFindingAidLink)
+        : null;
+    }
 
     const catalogLink = identifiers.find((identifier) =>
       identifier.includes("NYPL Catalog ID (bnumber)")
     );
-
-    this.archivesLink = archivesLink
-      ? extractFirstHrefFromHTML(archivesLink)
-      : null;
 
     this.catalogLink = catalogLink
       ? extractFirstHrefFromHTML(catalogLink)


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3732](https://newyorkpubliclibrary.atlassian.net/browse/DR-3732)

## This PR does the following:

If there is no link to a specific component, but there is a finding aid, make sure to link to it.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Open https://qa-digitalcollections.nypl.org/items/227b1250-13df-0133-a97c-60f81dd2b63c on localhost, see the finding aid link now renders:

<img width="1417" alt="Screen Shot 2025-06-25 at 5 33 28 PM" src="https://github.com/user-attachments/assets/c70eba01-73b9-4b32-abfa-da035489c8db" />

And that it links to the finding aid:

<img width="1234" alt="Screen Shot 2025-06-25 at 5 33 35 PM" src="https://github.com/user-attachments/assets/5a6694b4-1934-4548-9b05-4cfc6c3b15b9" />

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3732]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ