### PR TITLE
remove download option

### DIFF
--- a/app/src/components/items/react/player.tsx
+++ b/app/src/components/items/react/player.tsx
@@ -1,8 +1,12 @@
+import { useEffect } from "react";
+
 import dynamic from "next/dynamic";
 
 const Player = dynamic(() => import("react-player/lazy"), { ssr: false });
 
 export default function ReactPlayer({ src, type }) {
+  useEffect(() => {});
+
   return (
     <div>
       <Player

--- a/app/src/components/items/react/player.tsx
+++ b/app/src/components/items/react/player.tsx
@@ -7,7 +7,7 @@ const Player = dynamic(() => import("react-player/lazy"), { ssr: false });
 export default function ReactPlayer({ src, type }) {
   useEffect(() => {
     // disable download
-    const player = document.querySelector("video");
+    const player = document.querySelector("video") as any;
     player?.controls; // true
     player?.controlsList == "nodownload";
   });

--- a/app/src/components/items/react/player.tsx
+++ b/app/src/components/items/react/player.tsx
@@ -5,7 +5,12 @@ import dynamic from "next/dynamic";
 const Player = dynamic(() => import("react-player/lazy"), { ssr: false });
 
 export default function ReactPlayer({ src, type }) {
-  useEffect(() => {});
+  useEffect(() => {
+    // disable download
+    const player = document.querySelector("video");
+    player?.controls; // true
+    player?.controlsList == "nodownload";
+  });
 
   return (
     <div>


### PR DESCRIPTION
disable download options for all AV

this uses the HTMLMediaElement `controlsList` feature which is partially supported across browsers: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList
thus, might want a better solution for this

additionally, Clare flagged this viewer behaving inconsistently across browsers and recommended a different viewer. contemplating spending time implementing that before diving deeper into this. 

open to thoughts and suggestions :)