### PR TITLE
Redirect items/{captureuuid} to item url with idx

### DIFF
--- a/app/src/utils/apiClients/apiClients.tsx
+++ b/app/src/utils/apiClients/apiClients.tsx
@@ -168,6 +168,14 @@ export class RepoApi {
 }
 
 export class CollectionsApi {
+  static async getCaptureMetadata(uuid: string) {
+    const apiUrl = `${process.env.COLLECTIONS_API_URL}/captures/${uuid}/metadata`;
+    return await fetchApi({
+      apiUrl: apiUrl,
+      options: { isRepoApi: false },
+    });
+  }
+
   static async getCollectionsData({
     keyword = DEFAULT_SEARCH_TERM,
     sort = DEFAULT_COLLECTION_SORT,


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3715](https://newyorkpubliclibrary.atlassian.net/browse/DR-3715)

## This PR does the following:

OG DC supports passing in a capture uuid to the items endpoint, displaying the specific capture on the items page.  On facelift, we currently also support this type of url, but don't link to the specific capture, just the item.

To support old links, check if the given uuid is a capture, and if so, redirect to the url for its parent item uuid, passing in the canvasIndex corresponding to the specific capture.

Note - this doesn't cover the other type of capture url OG DC supports - /items/{uuid}#/?uuid={captureuuid}. Those urls will need to be handled differently, since everything after the `#` is chopped off before sending off to the server, so we'll need a client side solution in a followup PR

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Open http://localhost:3000/items/e36b2b90-740d-0136-0517-476ebf952da4, see it redirects to http://localhost:3000/items/7cd3acc0-5d7f-0134-12ab-00505686a51c?canvasIndex=2
(you can try the same ids on vercel)
## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3715]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ