### PR TITLE
DR-3780 Fix some item pages not loading

### DIFF
--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -50,14 +50,15 @@ export async function generateMetadata({
 
 function formatItemBreadcrumbs(item: ItemModel) {
   const breadcrumbData = item.breadcrumbData;
-  let breadcrumbs = [
-    { text: "Home", url: "/" },
-    {
-      text: `${breadcrumbData.division.text}`,
-      url: `${breadcrumbData.division.path}`,
-    },
-  ];
-  if (breadcrumbData.collection) {
+  let breadcrumbs = [{ text: "Home", url: "/" }];
+  if (breadcrumbData?.division) {
+    breadcrumbs.push({
+      text: breadcrumbData?.division.text,
+      url: breadcrumbData?.division.path,
+    });
+  }
+  if (breadcrumbData?.collection) {
+    console.log(breadcrumbData.collection);
     breadcrumbs.push({
       text: breadcrumbData.collection.text,
       url: breadcrumbData.collection.path,

--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -85,7 +85,7 @@ export class ItemModel {
     this.divisionLink =
       this.isRestricted && rawManifestMetadata["Division"]
         ? rawManifestMetadata["Division"].toString()
-        : rawManifestMetadata["Library Locations"][0] || "";
+        : rawManifestMetadata["Library Locations"]?.[0] || "";
 
     this.permittedLocationText =
       this.isRestricted && rawManifestMetadata["Permitted Locations"]
@@ -147,11 +147,11 @@ export class ItemModel {
       location:
         extractAllAnchorsFromHTML(
           this.metadata?.locations?.split("<br>")[0] ?? ""
-        )[0].text ?? "",
+        )[0]?.text ?? "",
       resource:
         extractAllAnchorsFromHTML(
           this.metadata?.typeOfResource?.split("<br>")[0] ?? ""
-        )[0].text ?? "",
+        )[0]?.text ?? "",
       origin: this.metadata?.origin,
       dateIssued: this.metadata?.dateIssued,
     });
@@ -160,20 +160,27 @@ export class ItemModel {
     const divisionLinkObj = extractAllAnchorsFromHTML(
       this.metadata?.locations?.split("<br>")[0] ?? ""
     )[0];
-    divisionLinkObj["path"] = new URL(divisionLinkObj.href).pathname;
+    if (divisionLinkObj) {
+      divisionLinkObj["path"] = new URL(divisionLinkObj.href).pathname;
+    }
 
     const orderedCollections = this.metadata?.collection?.split("<br>") ?? [];
     // note: this points to the top level collection, not the immediate parent collection or subcollection
     const collectionLinkObj = extractAllAnchorsFromHTML(
       orderedCollections[0] ?? ""
     )[0];
-    if (collectionLinkObj) {
+    if (collectionLinkObj && divisionLinkObj) {
       collectionLinkObj["path"] = new URL(collectionLinkObj.href).pathname;
       this.breadcrumbData = {
         division: divisionLinkObj,
         collection: collectionLinkObj,
       };
-    } else {
+    } else if (collectionLinkObj) {
+      collectionLinkObj["path"] = new URL(collectionLinkObj.href).pathname;
+      this.breadcrumbData = {
+        collection: collectionLinkObj,
+      };
+    } else if (divisionLinkObj) {
       this.breadcrumbData = {
         division: divisionLinkObj,
       };


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3760](https://newyorkpubliclibrary.atlassian.net/browse/DR-3760)

## This PR does the following:

<!-- What has been updated or added in this PR? -->
Fixes some item pages not loading when missing fields.

## Open questions

<!-- Any questions you want to ask the reviewer? -->
I also added the collection as a breadcrumb, but I'm a little confused about how the breadcrumbs currently work.

For [this item](https://dcfl-digitalcollections.nypl.org/items/52e80000-c53c-012f-75fa-58d385a7bc34?canvasIndex=0) when I run this locally I see `Home/Wallach Division Picture Collection/Rhea - Rhea americana`, but when I view this in dcfl-digitalcollections I see `Home/The Miriam and Ira D. Wallach Division.../Wallach Division Picture Collection/Rhea - Rhea americana`. So it looks like it's already pulling in the collection as the breadcrumb and this could duplicate it?

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->
Tested locally, items now load from the links in the ticket.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3760]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ