### PR TITLE
Use citations endpoint for citations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Added redirects for OG direct capture links
+- Added redirects for OG direct capture links (DR-3715)
+- Added Playwright test to verify two collection's on home page(DR-3658)
+
+### Fixed
+- Fix date formatting in citations (DR-3734)
 
 ## [0.4.4] 2025-07-01
 ### Added

--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -82,7 +82,8 @@ function formatItemBreadcrumbs(item: ItemModel) {
 
 export default async function ItemViewer({ params, searchParams }: ItemProps) {
   revalidatePath("/");
-  const [itemData, manifest] = await Promise.all([
+  const [citationsData, itemData, manifest] = await Promise.all([
+    CollectionsApi.getCitationsData(params.uuid),
     getItemData(params.uuid),
     getItemManifest(params.uuid),
   ]);
@@ -112,6 +113,7 @@ export default async function ItemViewer({ params, searchParams }: ItemProps) {
       }}
     >
       <ItemPage
+        citationsData={citationsData}
         manifest={manifest}
         uuid={params.uuid}
         captures={itemData.captures}

--- a/app/src/components/pages/itemPage/itemPage.tsx
+++ b/app/src/components/pages/itemPage/itemPage.tsx
@@ -4,7 +4,13 @@ import Item from "../../items/item";
 
 import { ItemModel } from "@/src/models/item";
 
-export function ItemPage({ manifest, uuid, captures, canvasIndex }) {
-  const item = new ItemModel(uuid, manifest, captures);
+export function ItemPage({
+  manifest,
+  uuid,
+  captures,
+  canvasIndex,
+  citationsData,
+}) {
+  const item = new ItemModel(uuid, manifest, captures, citationsData);
   return <Item manifest={manifest} item={item} canvasIndex={canvasIndex} />;
 }

--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -44,14 +44,19 @@ export class ItemModel {
   isImage: boolean;
   archivesLink: string | null;
   catalogLink: string | null;
-  citationData: CitationOutput;
+  citationData: CitationOutput | null;
   breadcrumbData: any;
   mediaFiles: string[];
   subcollectionName: string | null;
   permittedLocationText: string;
   captures: CaptureModel[];
 
-  constructor(uuid: string, manifest: any, captures?: CaptureModel[]) {
+  constructor(
+    uuid: string,
+    manifest: any,
+    captures?: CaptureModel[],
+    citationData?: any
+  ) {
     const parser = new Maniiifest(manifest);
     // Non-Manifest/Metadata related fields
     this.uuid = uuid;
@@ -154,20 +159,18 @@ export class ItemModel {
       : null;
 
     // Citation Data
-    this.citationData = generateCitations({
-      title: this.title,
-      link: this.link,
-      location:
-        extractAllAnchorsFromHTML(
-          this.metadata?.locations?.split("<br>")[0] ?? ""
-        )[0]?.text ?? "",
-      resource:
-        extractAllAnchorsFromHTML(
-          this.metadata?.typeOfResource?.split("<br>")[0] ?? ""
-        )[0]?.text ?? "",
-      origin: this.metadata?.origin,
-      dateIssued: this.metadata?.dateIssued,
-    });
+    this.citationData = null;
+    if (citationData) {
+      this.citationData = generateCitations({
+        title: citationData.title,
+        link: citationData.shareURL,
+        location: citationData.division,
+        resource: citationData.type,
+        dateIssued: citationData.year_end
+          ? `${citationData.year_start} - ${citationData.year_end}`
+          : citationData.year_start,
+      });
+    }
 
     // Breadcrumb Data
     const divisionLinkObj = extractAllAnchorsFromHTML(

--- a/app/src/utils/apiClients/apiClients.tsx
+++ b/app/src/utils/apiClients/apiClients.tsx
@@ -176,6 +176,14 @@ export class CollectionsApi {
     });
   }
 
+  static async getCitationsData(uuid: string) {
+    const apiUrl = `${process.env.COLLECTIONS_API_URL}/items/${uuid}/citations`;
+    return await fetchApi({
+      apiUrl: apiUrl,
+      options: { isRepoApi: false },
+    });
+  }
+
   static async getCollectionsData({
     keyword = DEFAULT_SEARCH_TERM,
     sort = DEFAULT_COLLECTION_SORT,

--- a/app/src/utils/metadata/generateCitations.test.tsx
+++ b/app/src/utils/metadata/generateCitations.test.tsx
@@ -6,7 +6,6 @@ describe("generateCitations", () => {
     link: "https://nypl.org/item/abc",
     location: "Main Branch",
     resource: "Text",
-    origin: "1901",
     dateIssued: "1902",
   };
 

--- a/app/src/utils/metadata/generateCitations.ts
+++ b/app/src/utils/metadata/generateCitations.ts
@@ -10,7 +10,6 @@ export interface CitationInput {
   link: string;
   location?: string;
   resource?: string;
-  origin?: string;
   dateIssued?: string;
 }
 
@@ -23,18 +22,18 @@ export function generateCitations(data: CitationInput): CitationOutput {
     year: "numeric",
   });
 
-  const { title, link, location, origin, dateIssued, resource } = data;
+  const { title, link, location, dateIssued, resource } = data;
 
   const MLA = `<p>${
     location ? location + ", " : ""
   }The New York Public Library. "${title}" <em>The New York Public Library Digital Collections</em>. ${
-    origin ? origin + "." : ""
-  } ${dateIssued ? dateIssued + "." : ""} ${link}</p>`;
+    dateIssued ? dateIssued + "." : ""
+  } ${link}</p>`;
 
   const APA = `<p>${
     location ? location + ", " : ""
-  }The New York Public Library. ${origin ? origin + "." : ""} ${
-    dateIssued ? dateIssued + "." : ""
+  }The New York Public Library. ${
+    dateIssued ? `(${dateIssued})` + "." : ""
   } <em>${title}</em> Retrieved from ${link}</p>`;
 
   const CHICAGO = `<p>${
@@ -42,8 +41,8 @@ export function generateCitations(data: CitationInput): CitationOutput {
   }The New York Public Library. "${title}" New York Public Library Digital Collections. Accessed ${today}. ${link}</p>`;
 
   const WIKI = `<p>&lt;ref name=NYPL&gt;{{cite web | url=${link} | title=${
-    resource ? "(" + resource + ")" : ""
-  }${title}${origin ? " (" + origin + ")" : ""}${
+    resource ? " (" + resource + ") " : ""
+  }${title}${
     dateIssued ? " (" + dateIssued + ")" : ""
   } | author=Digital Collections, The New York Public Library | accessdate=${today} | publisher=The New York Public Library, Astor, Lenox, and Tilden Foundations}}&lt;/ref&gt;</p>`;
 

--- a/playwright/pages/dc_homepage.ts
+++ b/playwright/pages/dc_homepage.ts
@@ -26,6 +26,14 @@ export class DCHomepage {
   readonly booksAndPeriodicalsSeeMoreLink: Locator;
   readonly fliersAndEphemeraSeeMoreLink: Locator;
 
+  //collections on homepage
+  readonly posadaCollection: Locator;
+  readonly farmSecurityAdministrationPhotographsCollection: Locator;
+
+  //collections' items count
+  readonly posadaCollectionItems: Locator;
+  readonly farmSecurityAdministrationPhotographsCollectionItems: Locator;
+
   //featured section
   readonly featuredSectionHeading: Locator;
   readonly featuredDigitalCollectionsPrintStore: Locator;
@@ -90,6 +98,25 @@ export class DCHomepage {
     this.whatIsPublicDomainLink = this.page.getByRole("link", {
       name: "What is public domain?",
     });
+
+    //collections
+    this.posadaCollection = this.page.getByRole("link", {
+      name: "Posada Collection",
+      exact: true,
+    });
+    this.farmSecurityAdministrationPhotographsCollection = this.page.locator(
+      "#row-card-heading-farm-security-administration-photographs-1"
+    );
+
+    //collections' items total count
+    //these locators are used to verify that the collections have items
+    this.posadaCollectionItems = this.page.locator(
+      "#item-count-posada-collection-0"
+    );
+    this.farmSecurityAdministrationPhotographsCollectionItems =
+      this.page.locator(
+        "#item-count-farm-security-administration-photographs-1"
+      );
 
     //featured section
 

--- a/playwright/tests/dc_homepage.spec.ts
+++ b/playwright/tests/dc_homepage.spec.ts
@@ -26,6 +26,22 @@ test("verify public domain link is visible", async ({ page }) => {
   await expect(dchomepage.whatIsPublicDomainLink).toBeVisible();
 });
 
+test("verify collections and item count", async ({ page }) => {
+  const dchomepage = new DCHomepage(page);
+  await expect(dchomepage.posadaCollection).toBeVisible();
+  await expect(dchomepage.posadaCollectionItems).not.toHaveText("0 items");
+  await expect(
+    dchomepage.farmSecurityAdministrationPhotographsCollection
+  ).toBeVisible();
+  await expect(
+    dchomepage.farmSecurityAdministrationPhotographsCollectionItems
+  ).not.toHaveText("0 items");
+  await expect(dchomepage.posadaCollectionItems).not.toHaveText("NaN items");
+  await expect(
+    dchomepage.farmSecurityAdministrationPhotographsCollectionItems
+  ).not.toHaveText("NaN items");
+});
+
 test("verify featured section is visible", async ({ page }) => {
   const dchomepage = new DCHomepage(page);
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3734](https://newyorkpubliclibrary.atlassian.net/browse/DR-3734)

## This PR does the following:

Fetch citations data when rendering the item page and pass it through to the item model for rendering out citations

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Load up an item locally, eg http://localhost:3000/items/7cd3acc0-5d7f-0134-12ab-00505686a51c?canvasIndex=0, see the citations now don't display formatted links / origins:

<img width="712" alt="Screen Shot 2025-07-09 at 11 46 54 AM" src="https://github.com/user-attachments/assets/b98b8e9a-d738-4372-bc77-cbec1ebd4f19" />

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3734]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ