### PR TITLE
fix: Separate notes with line breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix date formatting in citations (DR-3734)
+- Separate notes by line breaks (DR-3785)
 
 ## [0.4.4] 2025-07-01
 ### Added

--- a/app/src/utils/metadata/normalizeItemMetdata.ts
+++ b/app/src/utils/metadata/normalizeItemMetdata.ts
@@ -18,7 +18,7 @@ export function normalizeItemMetadataFromManifest(
     locations: joinWithBr(raw["Library Locations"]),
     subjects: joinWithBr(raw["Subjects"]),
     genres: joinWithBr(raw["Genres"]),
-    notes: raw["Notes"]?.join("") || "",
+    notes: joinWithBr(raw["Notes"]),
     physicalDescription: joinWithBr(raw["Physical Description"]),
     typeOfResource: joinWithBr(raw["Resource Type"]),
     abstract: raw["Abstract"]?.[0] || "",


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3785](https://newyorkpubliclibrary.atlassian.net/browse/DR-3785)

## This PR does the following:

An easy one that I noticed that was bugging me, that I think I broke in https://github.com/NYPL/collections-api/pull/164

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Run this, load http://localhost:3000/items/27e2abb0-81b7-0134-dafd-00505686a51c?canvasIndex=0:

<img width="1204" height="727" alt="Screen Shot 2025-07-10 at 4 38 21 PM" src="https://github.com/user-attachments/assets/0ff8d714-460b-4bbd-8c67-11ae77f429a7" />

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3785]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ