### PR TITLE
Dr 3681/collections relevance sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Playwright test for Name filter for search-results page (DR-3796)
 - Added Playwright test for George Arents Division's landing page (DR-3716)
 - Added Playwright tests for the About page (DR-3762)
+- Added relevance to the Collections page (DR-3681)
+
 ## [0.4.6] 2025-07-15
 ### Updated
 - Updated IIIF image urls to use v3 instead of v2

--- a/app/src/config/constants.ts
+++ b/app/src/config/constants.ts
@@ -16,19 +16,21 @@ export const TRUNCATED_SEARCH_CARD_LENGTH = 140;
 export const CARDS_PER_PAGE = 48;
 
 export const DEFAULT_PAGE_NUM = 1;
-export const DEFAULT_COLLECTION_SORT = "date-desc";
+export const DEFAULT_COLLECTION_SORT = "relevance";
 export const DEFAULT_SEARCH_SORT = "relevance";
 export const DEFAULT_SEARCH_TERM = "";
 export const DEFAULT_FILTERS = [];
 // export const DEFAULT_SORT = [];
 
 export const COLLECTION_SORT_OPTIONS = {
+  relevance: "relevance",
   "date-desc": "date DESC",
   "date-asc": "date ASC",
   "title-desc": "title DESC",
   "title-asc": "title ASC",
 };
 export const COLLECTION_SORT_LABELS = {
+  relevance: "Relevance",
   "date-desc": "Newest to oldest",
   "date-asc": "Oldest to newest",
   "title-desc": "Title Z to A",

--- a/app/src/utils/apiClients/collectionsApiClient.test.tsx
+++ b/app/src/utils/apiClients/collectionsApiClient.test.tsx
@@ -36,7 +36,7 @@ describe("Collections API methods", () => {
       const collections = await CollectionsApi.getCollectionsData();
 
       expect(fetchApi).toHaveBeenCalledWith({
-        apiUrl: `${process.env.COLLECTIONS_API_URL}/collections?page=1&perPage=48&sort=date-desc&keyword=`,
+        apiUrl: `${process.env.COLLECTIONS_API_URL}/collections?page=1&perPage=48&sort=relevance&keyword=`,
         options: { isRepoApi: false },
       });
 


### PR DESCRIPTION
## Ticket:

- [DR-3681](https://newyorkpubliclibrary.atlassian.net/browse/DR-3681)

## This PR does the following:

<!-- What has been updated or added in this PR? -->
Adds the relevance sorting option to the Collections page and makes it the default sort option.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?
<!--- Please describe in detail how you tested your changes. -->
Updated test. Also tested locally

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.


[DR-3681]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ