### PR TITLE
Dr 3214 Update Divisions endpoints to use CollectionsAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Updated Divisions endpoints to use CollectionsAPI (DR-3214)
+
 ## [0.4.6] 2025-07-15
 ### Updated
 - Updated IIIF image urls to use v3 instead of v2

--- a/__tests__/__mocks__/data/mockCollections.ts
+++ b/__tests__/__mocks__/data/mockCollections.ts
@@ -7,7 +7,7 @@ export const mockCollections: CollectionDataType[] = [
     url: "https://digitalcollections.nypl.org/collections/posada-collection#/?tab=navigation",
     imageID: "58270299",
     numberOfDigitizedItems: 34,
-    containsOnSiteMaterials: true,
+    containsOnSiteMaterial: true,
     containsAVMaterial: false,
   },
   {
@@ -16,7 +16,7 @@ export const mockCollections: CollectionDataType[] = [
     url: "https://digitalcollections.nypl.org/collections/mavo#/?tab=navigation",
     imageID: null,
     numberOfDigitizedItems: 35,
-    containsOnSiteMaterials: true,
+    containsOnSiteMaterial: true,
     containsAVMaterial: false,
   },
   {
@@ -25,7 +25,7 @@ export const mockCollections: CollectionDataType[] = [
     url: "https://digitalcollections.nypl.org/collections/austin-hansen-photograph-collection#/?tab=navigation",
     imageID: "58300996",
     numberOfDigitizedItems: 65,
-    containsOnSiteMaterials: true,
+    containsOnSiteMaterial: true,
     containsAVMaterial: false,
   },
   {
@@ -35,7 +35,7 @@ export const mockCollections: CollectionDataType[] = [
     url: "https://digitalcollections.nypl.org/collections/arthur-alfonso-schomburg-papers#/?tab=navigation",
     imageID: null,
     numberOfDigitizedItems: 55,
-    containsOnSiteMaterials: true,
+    containsOnSiteMaterial: true,
     containsAVMaterial: false,
   },
   {
@@ -44,7 +44,7 @@ export const mockCollections: CollectionDataType[] = [
     url: "https://digitalcollections.nypl.org/collections/friedman-abeles-photographs#/?tab=navigation",
     imageID: "58498722",
     numberOfDigitizedItems: 35,
-    containsOnSiteMaterials: false,
+    containsOnSiteMaterial: false,
     containsAVMaterial: false,
   },
   {
@@ -53,7 +53,7 @@ export const mockCollections: CollectionDataType[] = [
     url: "https://digitalcollections.nypl.org/collections/farm-security-administration-photographs#/?tab=navigation",
     imageID: "1952272",
     numberOfDigitizedItems: 36,
-    containsOnSiteMaterials: false,
+    containsOnSiteMaterial: false,
     containsAVMaterial: false,
   },
   {
@@ -62,7 +62,7 @@ export const mockCollections: CollectionDataType[] = [
     url: "https://digitalcollections.nypl.org/collections/changing-new-york#/?tab=navigation",
     imageID: "58447105",
     numberOfDigitizedItems: 37,
-    containsOnSiteMaterials: false,
+    containsOnSiteMaterial: false,
     containsAVMaterial: false,
   },
   {
@@ -72,7 +72,7 @@ export const mockCollections: CollectionDataType[] = [
     url: "https://digitalcollections.nypl.org/collections/the-black-experience-in-childrens-books-selections-from-augusta-bakers#/?tab=about",
     imageID: "56958645",
     numberOfDigitizedItems: 153,
-    containsOnSiteMaterials: false,
+    containsOnSiteMaterial: false,
     containsAVMaterial: false,
   },
 ];

--- a/__tests__/__mocks__/data/repoApi/mockCollectionLaneResponse.ts
+++ b/__tests__/__mocks__/data/repoApi/mockCollectionLaneResponse.ts
@@ -17,7 +17,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/6681fc20-c52b-012f-4eb1-58d385a7bc34",
         imageID: "wf39_171707",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "177198",
         numberOfDigitizedItems: "177198",
       },
@@ -28,7 +28,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/16ad5350-c52e-012f-aecf-58d385a7bc34",
         imageID: "494030",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "71626",
         numberOfDigitizedItems: "71626",
       },
@@ -39,7 +39,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/2589a880-c52c-012f-2cb4-58d385a7bc34",
         imageID: "TH-15522",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "57361",
         numberOfDigitizedItems: "57361",
       },
@@ -50,7 +50,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/0146e060-c530-012f-1e6f-58d385a7bc34",
         imageID: "swope_631929",
-        containsOnSiteMaterials: "true",
+        containsOnSiteMaterial: "true",
         numItems: "50860",
         numberOfDigitizedItems: "50860",
       },
@@ -61,7 +61,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/5261fd50-c52e-012f-85ec-58d385a7bc34",
         imageID: "G90F173_009F",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "42204",
         numberOfDigitizedItems: "42204",
       },
@@ -72,7 +72,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/7a830280-c542-012f-b87c-58d385a7bc34",
         imageID: "4063867",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "39827",
         numberOfDigitizedItems: "39827",
       },
@@ -84,7 +84,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/a301da20-c52e-012f-cc55-58d385a7bc34",
         imageID: "708126F",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "34742",
         numberOfDigitizedItems: "34742",
       },
@@ -95,7 +95,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/79d4a650-c52e-012f-67ad-58d385a7bc34",
         imageID: "820781",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "34311",
         numberOfDigitizedItems: "34311",
       },
@@ -106,7 +106,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/e5462600-c5d9-012f-a6a3-58d385a7bc34",
         imageID: "58215588",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "27827",
         numberOfDigitizedItems: "27827",
       },
@@ -118,7 +118,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/80fa1460-c52f-012f-be77-58d385a7bc34",
         imageID: "506894",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "25428",
         numberOfDigitizedItems: "25428",
       },
@@ -129,7 +129,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/d3802d10-f49a-0139-3bff-0242ac110002",
         imageID: "58424723",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "24855",
         numberOfDigitizedItems: "24855",
       },
@@ -140,7 +140,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/cd0fd890-b0de-0133-ad22-00505686d14e",
         imageID: "5706845",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "15771",
         numberOfDigitizedItems: "15771",
       },
@@ -151,7 +151,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/1e6dd2f0-c530-012f-c1f8-58d385a7bc34",
         imageID: "2011162",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "13637",
         numberOfDigitizedItems: "13637",
       },
@@ -162,7 +162,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/1a0528c0-0d47-0133-a1f0-58d385a7b928",
         imageID: "5381653",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "9247",
         numberOfDigitizedItems: "9247",
       },
@@ -173,7 +173,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/26818d00-c611-012f-a212-58d385a7bc34",
         imageID: "92304",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "7085",
         numberOfDigitizedItems: "7085",
       },
@@ -184,7 +184,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/d5e04a00-c61a-012f-127f-58d385a7bc34",
         imageID: "2029425",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "7041",
         numberOfDigitizedItems: "7041",
       },
@@ -195,7 +195,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/f7ffc990-c5ae-012f-eb75-58d385a7bc34",
         imageID: "58086787",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "3845",
         numberOfDigitizedItems: "3845",
       },
@@ -206,7 +206,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/0e023030-c5ab-012f-a4c2-58d385a7bc34",
         imageID: "485174",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "3727",
         numberOfDigitizedItems: "3727",
       },
@@ -217,7 +217,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/8d08f9f0-c60b-012f-0c69-58d385a7bc34",
         imageID: "1150535",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "3343",
         numberOfDigitizedItems: "3343",
       },
@@ -229,7 +229,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/531a8850-c607-012f-0a5d-58d385a7bc34",
         imageID: "58767265",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "3321",
         numberOfDigitizedItems: "3321",
       },
@@ -240,7 +240,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/530a11c0-c8b6-0131-2d6e-58d385a7b928",
         imageID: "5242169",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "3129",
         numberOfDigitizedItems: "3129",
       },
@@ -251,7 +251,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/0f38cb80-c5ae-012f-b01b-58d385a7bc34",
         imageID: "colmer_164_2041",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "3122",
         numberOfDigitizedItems: "3122",
       },
@@ -262,7 +262,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/de8b3b60-c284-0135-01bc-33751ccfcc26",
         imageID: "57484879",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "2844",
         numberOfDigitizedItems: "2844",
       },
@@ -273,7 +273,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/f5301480-9c31-0131-7b95-58d385a7bbd0",
         imageID: "5212943",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "2598",
         numberOfDigitizedItems: "2598",
       },
@@ -284,7 +284,7 @@ export const mockCollectionLaneResponse = {
         apiUri:
           "https://api.repo.nypl.org/api/v2/collections/274b79c0-c5b6-012f-1730-58d385a7bc34",
         imageID: "1103827",
-        containsOnSiteMaterials: "false",
+        containsOnSiteMaterial: "false",
         numItems: "2505",
         numberOfDigitizedItems: "2505",
       },

--- a/__tests__/__mocks__/data/repoApi/mockCollectionsResponse.ts
+++ b/__tests__/__mocks__/data/repoApi/mockCollectionsResponse.ts
@@ -11,7 +11,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/6681fc20-c52b-012f-4eb1-58d385a7bc34",
       imageID: "wf39_171707",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "177198",
       numberOfDigitizedItems: "177198",
     },
@@ -22,7 +22,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/16ad5350-c52e-012f-aecf-58d385a7bc34",
       imageID: "1103512",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "71626",
       numberOfDigitizedItems: "71626",
     },
@@ -33,7 +33,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/2589a880-c52c-012f-2cb4-58d385a7bc34",
       imageID: "TH-15522",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "57361",
       numberOfDigitizedItems: "57361",
     },
@@ -44,7 +44,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/0146e060-c530-012f-1e6f-58d385a7bc34",
       imageID: "swope_631929",
-      containsOnSiteMaterials: "true",
+      containsOnSiteMaterial: "true",
       numItems: "50859",
       numberOfDigitizedItems: "50859",
     },
@@ -55,7 +55,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/b50ab6f0-c52b-012f-5986-58d385a7bc34",
       imageID: "1116456",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "49721",
       numberOfDigitizedItems: "49721",
     },
@@ -66,7 +66,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/5261fd50-c52e-012f-85ec-58d385a7bc34",
       imageID: "G90F173_009F",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "42204",
       numberOfDigitizedItems: "42204",
     },
@@ -77,7 +77,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/7a830280-c542-012f-b87c-58d385a7bc34",
       imageID: "4063867",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "39827",
       numberOfDigitizedItems: "39827",
     },
@@ -89,7 +89,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/a301da20-c52e-012f-cc55-58d385a7bc34",
       imageID: "708126F",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "34742",
       numberOfDigitizedItems: "34742",
     },
@@ -100,7 +100,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/79d4a650-c52e-012f-67ad-58d385a7bc34",
       imageID: "820781",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "34311",
       numberOfDigitizedItems: "34311",
     },
@@ -111,7 +111,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/51894d20-c52f-012f-657d-58d385a7bc34",
       imageID: "1637462",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "31267",
       numberOfDigitizedItems: "31267",
     },
@@ -122,7 +122,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/e5462600-c5d9-012f-a6a3-58d385a7bc34",
       imageID: "58215588",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "27827",
       numberOfDigitizedItems: "27827",
     },
@@ -134,7 +134,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/80fa1460-c52f-012f-be77-58d385a7bc34",
       imageID: "506894",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "25428",
       numberOfDigitizedItems: "25428",
     },
@@ -145,7 +145,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/d3802d10-f49a-0139-3bff-0242ac110002",
       imageID: "58424723",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "24855",
       numberOfDigitizedItems: "24855",
     },
@@ -156,7 +156,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/e5114e30-c52f-012f-993c-58d385a7bc34",
       imageID: "474253",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "19235",
       numberOfDigitizedItems: "19235",
     },
@@ -167,7 +167,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/cd0fd890-b0de-0133-ad22-00505686d14e",
       imageID: "5706845",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "15771",
       numberOfDigitizedItems: "15771",
     },
@@ -178,7 +178,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/1e6dd2f0-c530-012f-c1f8-58d385a7bc34",
       imageID: "2011162",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "13637",
       numberOfDigitizedItems: "13637",
     },
@@ -189,7 +189,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/de1dcfb0-c5f6-012f-1dfc-58d385a7bc34",
       imageID: "4052030",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "11722",
       numberOfDigitizedItems: "11722",
     },
@@ -200,7 +200,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/1a0528c0-0d47-0133-a1f0-58d385a7b928",
       imageID: "5381653",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "9247",
       numberOfDigitizedItems: "9247",
     },
@@ -212,7 +212,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/491273d0-c605-012f-4af6-58d385a7bc34",
       imageID: "430996",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "8980",
       numberOfDigitizedItems: "8980",
     },
@@ -223,7 +223,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/26818d00-c611-012f-a212-58d385a7bc34",
       imageID: "92304",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "7085",
       numberOfDigitizedItems: "7085",
     },
@@ -234,7 +234,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/d5e04a00-c61a-012f-127f-58d385a7bc34",
       imageID: "2029425",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "7041",
       numberOfDigitizedItems: "7041",
     },
@@ -245,7 +245,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/bc9cb190-c598-012f-9f74-58d385a7bc34",
       imageID: "1231911",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "6247",
       numberOfDigitizedItems: "6247",
     },
@@ -256,7 +256,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/439afdd0-c62b-012f-66d1-58d385a7bc34",
       imageID: "74453",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "5781",
       numberOfDigitizedItems: "5781",
     },
@@ -267,7 +267,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/8f3e9bb0-c623-012f-5ab6-58d385a7bc34",
       imageID: "2005_6603_7_506_8",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "5505",
       numberOfDigitizedItems: "5505",
     },
@@ -278,7 +278,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/35301010-c58d-012f-1196-58d385a7bc34",
       imageID: "1256525",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "4930",
       numberOfDigitizedItems: "4930",
     },
@@ -289,7 +289,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/02d1c8f0-c52d-012f-a615-58d385a7bc34",
       imageID: "4026277",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "4379",
       numberOfDigitizedItems: "4379",
     },
@@ -300,7 +300,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/2600a3f0-c5ec-012f-424e-58d385a7bc34",
       imageID: "433823",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "3868",
       numberOfDigitizedItems: "3868",
     },
@@ -311,7 +311,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/f7ffc990-c5ae-012f-eb75-58d385a7bc34",
       imageID: "58086787",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "3845",
       numberOfDigitizedItems: "3845",
     },
@@ -322,7 +322,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/0e023030-c5ab-012f-a4c2-58d385a7bc34",
       imageID: "485174",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "3727",
       numberOfDigitizedItems: "3727",
     },
@@ -333,7 +333,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/5cd94760-c52a-012f-bcd4-3c075448cc4b",
       imageID: "57199999",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "3347",
       numberOfDigitizedItems: "3347",
     },
@@ -344,7 +344,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/8d08f9f0-c60b-012f-0c69-58d385a7bc34",
       imageID: "1150535",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "3343",
       numberOfDigitizedItems: "3343",
     },
@@ -356,7 +356,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/531a8850-c607-012f-0a5d-58d385a7bc34",
       imageID: "58767265",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "3321",
       numberOfDigitizedItems: "3321",
     },
@@ -367,7 +367,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/530a11c0-c8b6-0131-2d6e-58d385a7b928",
       imageID: "5242169",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "3129",
       numberOfDigitizedItems: "3129",
     },
@@ -378,7 +378,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/0f38cb80-c5ae-012f-b01b-58d385a7bc34",
       imageID: "colmer_164_2041",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "3122",
       numberOfDigitizedItems: "3122",
     },
@@ -389,7 +389,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/de8b3b60-c284-0135-01bc-33751ccfcc26",
       imageID: "57484879",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "2844",
       numberOfDigitizedItems: "2844",
     },
@@ -400,7 +400,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/f5301480-9c31-0131-7b95-58d385a7bbd0",
       imageID: "5212943",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "2598",
       numberOfDigitizedItems: "2598",
     },
@@ -411,7 +411,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/bb5c4380-c6f4-012f-df87-58d385a7bc34",
       imageID: "5239635",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "2577",
       numberOfDigitizedItems: "2577",
     },
@@ -422,7 +422,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/274b79c0-c5b6-012f-1730-58d385a7bc34",
       imageID: "1103827",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "2505",
       numberOfDigitizedItems: "2505",
     },
@@ -433,7 +433,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/924921a0-3cd0-0136-c557-0af54bc5b55e",
       imageID: "57987605",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "2505",
       numberOfDigitizedItems: "2505",
     },
@@ -444,7 +444,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/a71baeb0-c5b2-012f-595e-58d385a7bc34",
       imageID: "1252985",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "2338",
       numberOfDigitizedItems: "2338",
     },
@@ -455,7 +455,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/58226000-9cbe-013a-f681-0242ac110003",
       imageID: "58515903",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "2247",
       numberOfDigitizedItems: "2247",
     },
@@ -466,7 +466,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/7c22cac0-c5b8-012f-4613-58d385a7bc34",
       imageID: "ps_the_cd87_1319",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "2241",
       numberOfDigitizedItems: "2241",
     },
@@ -477,7 +477,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/812e5770-c60c-012f-7167-58d385a7bc34",
       imageID: "58491202",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "2194",
       numberOfDigitizedItems: "2194",
     },
@@ -488,7 +488,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/a1a9d830-c5a6-012f-00ec-58d385a7bc34",
       imageID: "5059757",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "2059",
       numberOfDigitizedItems: "2059",
     },
@@ -499,7 +499,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/a0108230-c5b9-012f-ed50-58d385a7bc34",
       imageID: "1702641",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "1987",
       numberOfDigitizedItems: "1987",
     },
@@ -510,7 +510,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/5b996640-c31c-0139-0bac-0242ac110004",
       imageID: "58771712",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "1937",
       numberOfDigitizedItems: "1937",
     },
@@ -521,7 +521,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/431cf9c0-d188-0137-4938-41b51856d1ac",
       imageID: "58128899",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "1881",
       numberOfDigitizedItems: "1881",
     },
@@ -532,7 +532,7 @@ export const mockCollectionsResponse = {
       apiUri:
         "https://api.repo.nypl.org/api/v2/collections/4e92ea50-bb61-0139-c8f3-0242ac110005",
       imageID: "58299571",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
       numItems: "1872",
       numberOfDigitizedItems: "1872",
     },

--- a/__tests__/__mocks__/data/repoApi/mockDivisionResponse.ts
+++ b/__tests__/__mocks__/data/repoApi/mockDivisionResponse.ts
@@ -48,7 +48,7 @@ export const mockDivisionResponse = {
       imageID: "TH-17806",
       numberOfDigitizedItems: "57361",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Martha Swope photographs",
@@ -57,7 +57,7 @@ export const mockDivisionResponse = {
       imageID: "swope_201850",
       numberOfDigitizedItems: "50860",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "true",
+      containsOnSiteMaterial: "true",
     },
     {
       title: "Friedman-Abeles photographs: [legacy collection]",
@@ -66,7 +66,7 @@ export const mockDivisionResponse = {
       imageID: "4038999",
       numberOfDigitizedItems: "39827",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Friedman-Abeles photographs",
@@ -75,7 +75,7 @@ export const mockDivisionResponse = {
       imageID: "58361645",
       numberOfDigitizedItems: "24855",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Kenn Duncan Photograph Archive, ca. 1960-1986",
@@ -84,7 +84,7 @@ export const mockDivisionResponse = {
       imageID: "2023685",
       numberOfDigitizedItems: "7041",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Vandamm theatrical photographs, 1900-1957",
@@ -93,7 +93,7 @@ export const mockDivisionResponse = {
       imageID: "psnypl_the_4222",
       numberOfDigitizedItems: "3727",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Prints depicting dance",
@@ -102,7 +102,7 @@ export const mockDivisionResponse = {
       imageID: "5884371",
       numberOfDigitizedItems: "2577",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "White Studio theatrical photographs",
@@ -111,7 +111,7 @@ export const mockDivisionResponse = {
       imageID: "G99F613_001",
       numberOfDigitizedItems: "2241",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "R. H. Burnside collection",
@@ -120,7 +120,7 @@ export const mockDivisionResponse = {
       imageID: "5143109",
       numberOfDigitizedItems: "1107",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Circle in the Square papers",
@@ -129,7 +129,7 @@ export const mockDivisionResponse = {
       imageID: "5137817",
       numberOfDigitizedItems: "1065",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Denishawn Collection: Photographs, nos. 1-3796",
@@ -138,7 +138,7 @@ export const mockDivisionResponse = {
       imageID: "5851238",
       numberOfDigitizedItems: "953",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Willa Kim designs",
@@ -147,7 +147,7 @@ export const mockDivisionResponse = {
       imageID: "58775309",
       numberOfDigitizedItems: "876",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Billy Rose Theatre Division scrapbooks",
@@ -156,7 +156,7 @@ export const mockDivisionResponse = {
       imageID: "4025813",
       numberOfDigitizedItems: "439",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Billy Rose Theatre Collection clipping file",
@@ -165,7 +165,7 @@ export const mockDivisionResponse = {
       imageID: "4025812",
       numberOfDigitizedItems: "327",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Collection of theatrical correspondence and ephemera",
@@ -174,7 +174,7 @@ export const mockDivisionResponse = {
       imageID: "58495085",
       numberOfDigitizedItems: "307",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Cinelandia",
@@ -183,7 +183,7 @@ export const mockDivisionResponse = {
       imageID: "58342131",
       numberOfDigitizedItems: "239",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "New York Shakespeare Festival records",
@@ -192,7 +192,7 @@ export const mockDivisionResponse = {
       imageID: "5942418",
       numberOfDigitizedItems: "202",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Carl Van Vechten Theatre Photographs",
@@ -201,7 +201,7 @@ export const mockDivisionResponse = {
       imageID: "57280951",
       numberOfDigitizedItems: "195",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Variety, vaudeville \u0026 burlesque",
@@ -210,7 +210,7 @@ export const mockDivisionResponse = {
       imageID: "variety_0325v",
       numberOfDigitizedItems: "185",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Music Division Iconography Collection",
@@ -219,7 +219,7 @@ export const mockDivisionResponse = {
       imageID: "4032031",
       numberOfDigitizedItems: "173",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Carol Rosegg photographs",
@@ -228,7 +228,7 @@ export const mockDivisionResponse = {
       imageID: "58810225",
       numberOfDigitizedItems: "158",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Motion picture record",
@@ -237,7 +237,7 @@ export const mockDivisionResponse = {
       imageID: "57955117",
       numberOfDigitizedItems: "153",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Patricia Zipprodt papers and designs",
@@ -246,7 +246,7 @@ export const mockDivisionResponse = {
       imageID: "5239923",
       numberOfDigitizedItems: "149",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Billy Rose Theatre Collection program file",
@@ -255,7 +255,7 @@ export const mockDivisionResponse = {
       imageID: "58437955",
       numberOfDigitizedItems: "128",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Joan Marcus photographs",
@@ -264,7 +264,7 @@ export const mockDivisionResponse = {
       imageID: "58825287",
       numberOfDigitizedItems: "118",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Jo Mielziner designs and technical drawings",
@@ -273,7 +273,7 @@ export const mockDivisionResponse = {
       imageID: "1817152",
       numberOfDigitizedItems: "116",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "L. J. Binns caricatures",
@@ -282,7 +282,7 @@ export const mockDivisionResponse = {
       imageID: "1628820",
       numberOfDigitizedItems: "105",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Billy Rose Theatre Collection scripts",
@@ -291,7 +291,7 @@ export const mockDivisionResponse = {
       imageID: "5045620",
       numberOfDigitizedItems: "102",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Jules Fisher collection of Jo Mielziner Designs",
@@ -300,7 +300,7 @@ export const mockDivisionResponse = {
       imageID: "56812236",
       numberOfDigitizedItems: "102",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Avery Willard photographs",
@@ -309,7 +309,7 @@ export const mockDivisionResponse = {
       imageID: "3884336",
       numberOfDigitizedItems: "100",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Mary Bryant papers",
@@ -318,7 +318,7 @@ export const mockDivisionResponse = {
       imageID: "58002505",
       numberOfDigitizedItems: "97",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Billy Rose Theatre Division Lobby Cards",
@@ -327,7 +327,7 @@ export const mockDivisionResponse = {
       imageID: "ps_the_1994",
       numberOfDigitizedItems: "85",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "New York City theater marquees",
@@ -336,7 +336,7 @@ export const mockDivisionResponse = {
       imageID: "400436",
       numberOfDigitizedItems: "80",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Billy Rose Theatre Division posters",
@@ -345,7 +345,7 @@ export const mockDivisionResponse = {
       imageID: "58363869",
       numberOfDigitizedItems: "73",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Century Flashlight Photographers circus photographs, 1924-1938",
@@ -354,7 +354,7 @@ export const mockDivisionResponse = {
       imageID: "58109245",
       numberOfDigitizedItems: "60",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Boris Aronson papers and designs",
@@ -363,7 +363,7 @@ export const mockDivisionResponse = {
       imageID: "58039556",
       numberOfDigitizedItems: "59",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "American Theatre Wing scrapbooks",
@@ -372,7 +372,7 @@ export const mockDivisionResponse = {
       imageID: "1711818",
       numberOfDigitizedItems: "58",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Robinson Locke collection",
@@ -381,7 +381,7 @@ export const mockDivisionResponse = {
       imageID: "psnypl_the_5171",
       numberOfDigitizedItems: "58",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Richard Tucker photographs",
@@ -390,7 +390,7 @@ export const mockDivisionResponse = {
       imageID: "1809922",
       numberOfDigitizedItems: "56",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Ruth Mitchell papers",
@@ -399,7 +399,7 @@ export const mockDivisionResponse = {
       imageID: "58018820",
       numberOfDigitizedItems: "47",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Century Flashlight Photographers circus photographs, 1928-1936",
@@ -408,7 +408,7 @@ export const mockDivisionResponse = {
       imageID: "57517169",
       numberOfDigitizedItems: "46",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Robert A. Wilson slides",
@@ -417,7 +417,7 @@ export const mockDivisionResponse = {
       imageID: "psnypl_the_4350",
       numberOfDigitizedItems: "43",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Richard Rodgers papers",
@@ -426,7 +426,7 @@ export const mockDivisionResponse = {
       imageID: "psnypl_the_5481",
       numberOfDigitizedItems: "42",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Brooke Hayward papers",
@@ -435,7 +435,7 @@ export const mockDivisionResponse = {
       imageID: "5004301",
       numberOfDigitizedItems: "39",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Ken Dewey Collection",
@@ -444,7 +444,7 @@ export const mockDivisionResponse = {
       imageID: "5404117",
       numberOfDigitizedItems: "39",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Richard Nelson papers and designs",
@@ -453,7 +453,7 @@ export const mockDivisionResponse = {
       imageID: "1581797",
       numberOfDigitizedItems: "36",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Alexandra Exter collection",
@@ -462,7 +462,7 @@ export const mockDivisionResponse = {
       imageID: "2005912",
       numberOfDigitizedItems: "34",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
     {
       title: "Robert Benney research materials",
@@ -471,7 +471,7 @@ export const mockDivisionResponse = {
       imageID: "1814176",
       numberOfDigitizedItems: "32",
       containsAVMaterial: "false",
-      containsOnSiteMaterials: "false",
+      containsOnSiteMaterial: "false",
     },
   ],
 };

--- a/__tests__/__mocks__/data/repoApi/mockDivisionsResponse.ts
+++ b/__tests__/__mocks__/data/repoApi/mockDivisionsResponse.ts
@@ -17,7 +17,7 @@ export const mockDivisionsResponse = {
           imageID: "5087462",
           numberOfDigitizedItems: 1560,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title:
@@ -27,7 +27,7 @@ export const mockDivisionsResponse = {
           imageID: "5123915",
           numberOfDigitizedItems: 861,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Walt Whitman papers, 1854-1892",
@@ -36,7 +36,7 @@ export const mockDivisionsResponse = {
           imageID: "5102809",
           numberOfDigitizedItems: 660,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Charles Dickens collection of papers [microfilm]",
@@ -45,7 +45,7 @@ export const mockDivisionsResponse = {
           imageID: "5095198",
           numberOfDigitizedItems: 625,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -62,7 +62,7 @@ export const mockDivisionsResponse = {
           imageID: "700001F",
           numberOfDigitizedItems: 34742,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title:
@@ -72,7 +72,7 @@ export const mockDivisionsResponse = {
           imageID: "psnypl_lhg_187",
           numberOfDigitizedItems: 3321,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Scrapbooks of New York City views",
@@ -81,7 +81,7 @@ export const mockDivisionsResponse = {
           imageID: "5184541",
           numberOfDigitizedItems: 3129,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title:
@@ -91,7 +91,7 @@ export const mockDivisionsResponse = {
           imageID: "1509403",
           numberOfDigitizedItems: 1569,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -107,7 +107,7 @@ export const mockDivisionsResponse = {
           imageID: "57404383",
           numberOfDigitizedItems: 2844,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Prints depicting dance",
@@ -116,7 +116,7 @@ export const mockDivisionsResponse = {
           imageID: "3883780",
           numberOfDigitizedItems: 2577,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Frederick Melton photographs",
@@ -125,7 +125,7 @@ export const mockDivisionsResponse = {
           imageID: "58128735",
           numberOfDigitizedItems: 1881,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Photographs of Indonesia",
@@ -134,7 +134,7 @@ export const mockDivisionsResponse = {
           imageID: "477086",
           numberOfDigitizedItems: 1812,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -150,7 +150,7 @@ export const mockDivisionsResponse = {
           imageID: "1516802",
           numberOfDigitizedItems: 1172,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Atlases of the United States",
@@ -159,7 +159,7 @@ export const mockDivisionsResponse = {
           imageID: "433879",
           numberOfDigitizedItems: 3868,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Maps of North America",
@@ -168,7 +168,7 @@ export const mockDivisionsResponse = {
           imageID: "434086",
           numberOfDigitizedItems: 3347,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Maps of New York City and State",
@@ -177,7 +177,7 @@ export const mockDivisionsResponse = {
           imageID: "ps_map_195",
           numberOfDigitizedItems: 2059,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -194,7 +194,7 @@ export const mockDivisionsResponse = {
           imageID: "wf39_000001",
           numberOfDigitizedItems: 177198,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Century Company records",
@@ -203,7 +203,7 @@ export const mockDivisionsResponse = {
           imageID: "5732648",
           numberOfDigitizedItems: 15771,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "New York World's Fair 1939 and 1940 Incorporated records",
@@ -212,7 +212,7 @@ export const mockDivisionsResponse = {
           imageID: "2011035",
           numberOfDigitizedItems: 13637,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Benjamin K. Miller collection of United States stamps",
@@ -221,7 +221,7 @@ export const mockDivisionsResponse = {
           imageID: "1127259",
           numberOfDigitizedItems: 5505,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -237,7 +237,7 @@ export const mockDivisionsResponse = {
           imageID: "1100704",
           numberOfDigitizedItems: 6247,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "American popular songs",
@@ -246,7 +246,7 @@ export const mockDivisionsResponse = {
           imageID: "g99c831_001",
           numberOfDigitizedItems: 4930,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Music Division set and costume design collection",
@@ -255,7 +255,7 @@ export const mockDivisionsResponse = {
           imageID: "1594791",
           numberOfDigitizedItems: 1283,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title:
@@ -265,7 +265,7 @@ export const mockDivisionsResponse = {
           imageID: "5586305",
           numberOfDigitizedItems: 736,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -281,7 +281,7 @@ export const mockDivisionsResponse = {
           imageID: "1150613",
           numberOfDigitizedItems: 2338,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Astor Library records",
@@ -290,7 +290,7 @@ export const mockDivisionsResponse = {
           imageID: "1642750",
           numberOfDigitizedItems: 4,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Edwin Hatfield Anderson records",
@@ -299,7 +299,7 @@ export const mockDivisionsResponse = {
           imageID: "58117706",
           numberOfDigitizedItems: 4,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Exhibitions Program Office records",
@@ -308,7 +308,7 @@ export const mockDivisionsResponse = {
           imageID: "58888155",
           numberOfDigitizedItems: 4,
           containsAVMaterial: "true",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -324,7 +324,7 @@ export const mockDivisionsResponse = {
           imageID: "ps_rbk_701",
           numberOfDigitizedItems: 19235,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title:
@@ -334,7 +334,7 @@ export const mockDivisionsResponse = {
           imageID: "1267898",
           numberOfDigitizedItems: 902,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Oscar Lion papers",
@@ -343,7 +343,7 @@ export const mockDivisionsResponse = {
           imageID: "5209998",
           numberOfDigitizedItems: 833,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Hortus Romanus juxta systems Tournefortianum paulo",
@@ -352,7 +352,7 @@ export const mockDivisionsResponse = {
           imageID: "1124926",
           numberOfDigitizedItems: 713,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -369,7 +369,7 @@ export const mockDivisionsResponse = {
           imageID: null,
           numberOfDigitizedItems: 720,
           containsAVMaterial: "true",
-          containsOnSiteMaterials: "true",
+          containsOnSiteMaterial: "true",
         },
         {
           title: "Margaret Carson audio-visual materials",
@@ -378,7 +378,7 @@ export const mockDivisionsResponse = {
           imageID: null,
           numberOfDigitizedItems: 201,
           containsAVMaterial: "true",
-          containsOnSiteMaterials: "true",
+          containsOnSiteMaterial: "true",
         },
         {
           title:
@@ -388,7 +388,7 @@ export const mockDivisionsResponse = {
           imageID: null,
           numberOfDigitizedItems: 126,
           containsAVMaterial: "true",
-          containsOnSiteMaterials: "true",
+          containsOnSiteMaterial: "true",
         },
         {
           title: "Music from Germany (Radio program)",
@@ -397,7 +397,7 @@ export const mockDivisionsResponse = {
           imageID: null,
           numberOfDigitizedItems: 125,
           containsAVMaterial: "true",
-          containsOnSiteMaterials: "true",
+          containsOnSiteMaterial: "true",
         },
       ],
     },
@@ -413,7 +413,7 @@ export const mockDivisionsResponse = {
           imageID: "58850025",
           numberOfDigitizedItems: 225,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Works Progress Administration (WPA) Art",
@@ -422,7 +422,7 @@ export const mockDivisionsResponse = {
           imageID: "5179776",
           numberOfDigitizedItems: 116,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title:
@@ -432,7 +432,7 @@ export const mockDivisionsResponse = {
           imageID: "58506995",
           numberOfDigitizedItems: 99,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "true",
+          containsOnSiteMaterial: "true",
         },
         {
           title: "Poster Collection",
@@ -441,7 +441,7 @@ export const mockDivisionsResponse = {
           imageID: "5119508",
           numberOfDigitizedItems: 80,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -457,7 +457,7 @@ export const mockDivisionsResponse = {
           imageID: "1169343",
           numberOfDigitizedItems: 305,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "The Negro in the New World",
@@ -466,7 +466,7 @@ export const mockDivisionsResponse = {
           imageID: "1227073",
           numberOfDigitizedItems: 167,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title:
@@ -476,7 +476,7 @@ export const mockDivisionsResponse = {
           imageID: "56917725",
           numberOfDigitizedItems: 153,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Timbuctoo the mysterious",
@@ -485,7 +485,7 @@ export const mockDivisionsResponse = {
           imageID: "1267647",
           numberOfDigitizedItems: 136,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -501,7 +501,7 @@ export const mockDivisionsResponse = {
           imageID: "58593610",
           numberOfDigitizedItems: 1937,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title:
@@ -511,7 +511,7 @@ export const mockDivisionsResponse = {
           imageID: "5388018",
           numberOfDigitizedItems: 1013,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title:
@@ -521,7 +521,7 @@ export const mockDivisionsResponse = {
           imageID: "1237959",
           numberOfDigitizedItems: 120,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Grenada Plantation Records",
@@ -530,7 +530,7 @@ export const mockDivisionsResponse = {
           imageID: "3996066",
           numberOfDigitizedItems: 109,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -546,7 +546,7 @@ export const mockDivisionsResponse = {
           imageID: null,
           numberOfDigitizedItems: 11,
           containsAVMaterial: "true",
-          containsOnSiteMaterials: "true",
+          containsOnSiteMaterial: "true",
         },
         {
           title: "The sound of Harlem",
@@ -555,7 +555,7 @@ export const mockDivisionsResponse = {
           imageID: "58795247",
           numberOfDigitizedItems: 2,
           containsAVMaterial: "true",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },
@@ -571,7 +571,7 @@ export const mockDivisionsResponse = {
           imageID: "1657160",
           numberOfDigitizedItems: 849,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Print Collection",
@@ -580,7 +580,7 @@ export const mockDivisionsResponse = {
           imageID: "1248468",
           numberOfDigitizedItems: 473,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Portrait collection",
@@ -589,7 +589,7 @@ export const mockDivisionsResponse = {
           imageID: "04scpr",
           numberOfDigitizedItems: 390,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
         {
           title: "Jean Blackwell Hutson photographs",
@@ -598,7 +598,7 @@ export const mockDivisionsResponse = {
           imageID: "58925832",
           numberOfDigitizedItems: 227,
           containsAVMaterial: "false",
-          containsOnSiteMaterials: "false",
+          containsOnSiteMaterial: "false",
         },
       ],
     },

--- a/app/collections/lane/[slug]/page.tsx
+++ b/app/collections/lane/[slug]/page.tsx
@@ -27,10 +27,6 @@ export default async function Lane({ params, searchParams }: LaneProps) {
     slug: params.slug.replace(/-/g, " "),
     pageNum: searchParams.page,
   });
-  // Repo API returns 404s within the data.
-  if (data?.headers?.code === "404") {
-    redirect("/404");
-  }
   const currentPage = Number(searchParams.page) || 1;
 
   return <CollectionLanePage data={data} currentPage={currentPage} />;

--- a/app/divisions/[slug]/page.tsx
+++ b/app/divisions/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import React from "react";
 import DivisionPage from "../../src/components/pages/divisionPage/divisionPage";
 import { slugToString } from "../../src/utils/utils";
-import { RepoApi } from "../../src/utils/apiClients/apiClients";
+import { CollectionsApi } from "../../src/utils/apiClients/apiClients";
 import { Suspense } from "react";
 import { redirect } from "next/navigation";
 
@@ -27,14 +27,10 @@ export default async function Division({
   params,
   searchParams,
 }: DivisionProps) {
-  const data = await RepoApi.getDivisionData({
+  const data = await CollectionsApi.getDivisionData({
     slug: params.slug,
     pageNum: searchParams.page,
   });
-  // Repo API returns 404s within the data.
-  if (data?.headers?.code === "404") {
-    redirect("/404");
-  }
 
   return (
     <Suspense>

--- a/app/divisions/page.tsx
+++ b/app/divisions/page.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from "react";
 import { Metadata } from "next";
 import DivisionsPage from "../src/components/pages/divisionsPage/divisionsPage";
-import { RepoApi } from "@/src/utils/apiClients/apiClients";
+import { CollectionsApi } from "@/src/utils/apiClients/apiClients";
 import { redirect } from "next/navigation";
 
 export const metadata: Metadata = {
@@ -12,11 +12,7 @@ export const metadata: Metadata = {
 };
 
 export default async function Divisions() {
-  const data = await RepoApi.getDivisionData();
-  // Repo API returns 404s within the data.
-  if (data?.headers?.code === "404") {
-    redirect("/404");
-  }
+  const data = await CollectionsApi.getDivisionData();
   return (
     <Suspense>
       <DivisionsPage summary={data?.summary} divisions={data?.divisions} />

--- a/app/src/components/card/card.test.tsx
+++ b/app/src/components/card/card.test.tsx
@@ -32,14 +32,14 @@ describe("Collection DCCard component", () => {
     expect(headingElement).toBeInTheDocument();
   });
 
-  it("renders the badge when containsOnSiteMaterials is true", () => {
+  it("renders the badge when containsOnSiteMaterial is true", () => {
     render(<DCCard {...mockCollectionProps} />);
     const card = new CollectionCardModel(mockCollections[0]);
     const badgeElement = screen.getByText(/Contains on-site materials/i);
     expect(badgeElement).toBeInTheDocument();
   });
 
-  it("does not render the badge when containsOnSiteMaterials is false", () => {
+  it("does not render the badge when containsOnSiteMaterial is false", () => {
     render(<DCCard {...mockCollectionPropsNoOnSite} />);
     const badgeElement = screen.queryByText(/Contains on-site materials/i);
     expect(badgeElement).not.toBeInTheDocument();

--- a/app/src/components/card/card.tsx
+++ b/app/src/components/card/card.tsx
@@ -58,7 +58,7 @@ export const Card = forwardRef<HTMLDivElement, DCCardProps>(
         }}
       >
         <CardContent>
-          {isCollection && record.containsOnSiteMaterials && (
+          {isCollection && record.containsOnSiteMaterial && (
             <StatusBadge sx={{ marginBottom: "0px" }} type="informative">
               Contains on-site materials
             </StatusBadge>

--- a/app/src/models/collectionCard.ts
+++ b/app/src/models/collectionCard.ts
@@ -8,7 +8,7 @@ export class CollectionCardModel {
   imageID: string | null;
   imageURL: string;
   numberOfDigitizedItems: number;
-  containsOnSiteMaterials: boolean;
+  containsOnSiteMaterial: boolean;
 
   constructor(data: any) {
     this.uuid = data.uuid;
@@ -18,7 +18,7 @@ export class CollectionCardModel {
     this.imageURL = imageURL(data.imageID, "square", "!288,288", "0");
     this.numberOfDigitizedItems =
       data.numberOfDigitizedItems || data.numItems || 0;
-    this.containsOnSiteMaterials =
-      parseBoolean(data.containsOnSiteMaterials) || false;
+    this.containsOnSiteMaterial =
+      parseBoolean(data.containsOnSiteMaterial) || false;
   }
 }

--- a/app/src/types/CollectionCardDataType.ts
+++ b/app/src/types/CollectionCardDataType.ts
@@ -5,7 +5,7 @@ export interface CollectionCardDataType {
   imageID: string | null;
   imageURL: string;
   numberOfDigitizedItems: number;
-  containsOnSiteMaterials: boolean;
+  containsOnSiteMaterial: boolean;
 }
 
 export default CollectionCardDataType;

--- a/app/src/types/CollectionDataType.ts
+++ b/app/src/types/CollectionDataType.ts
@@ -4,7 +4,7 @@ export interface CollectionDataType {
   url: string;
   imageID: string | null;
   numberOfDigitizedItems: number;
-  containsOnSiteMaterials: boolean;
+  containsOnSiteMaterial: boolean;
   containsAVMaterial: boolean;
 }
 

--- a/app/src/utils/apiClients/apiClients.tsx
+++ b/app/src/utils/apiClients/apiClients.tsx
@@ -132,26 +132,6 @@ export class RepoApi {
     return res?.nyplAPI?.response;
   }
 
-  static async getDivisionData({
-    pageNum = 1,
-    perPage = CARDS_PER_PAGE,
-    slug,
-  }: {
-    pageNum?: number;
-    perPage?: number;
-    slug?: string;
-  } = {}) {
-    let apiUrl = `${process.env.API_URL}/api/v2/divisions`;
-
-    if (slug) {
-      apiUrl += `/${slug}?page=${pageNum}&per_page=${perPage}`;
-    }
-
-    const res = await fetchApi({ apiUrl });
-
-    return res?.nyplAPI?.response;
-  }
-
   static async getLaneData({
     slug,
     pageNum = 1,
@@ -219,6 +199,26 @@ export class CollectionsApi {
       options: { isRepoApi: false },
     });
     return response;
+  }
+
+  static async getDivisionData({
+    pageNum = 1,
+    perPage = CARDS_PER_PAGE,
+    slug,
+  }: {
+    pageNum?: number;
+    perPage?: number;
+    slug?: string;
+  } = {}) {
+    let apiUrl = `${process.env.COLLECTIONS_API_URL}/divisions`;
+
+    if (slug) {
+      apiUrl += `/${slug}?page=${pageNum}&per_page=${perPage}`;
+    }
+    return await fetchApi({
+      apiUrl: apiUrl,
+      options: { isRepoApi: false },
+    });
   }
 
   static async getItemData(uuid: string) {

--- a/app/src/utils/apiClients/collectionsApiClient.test.tsx
+++ b/app/src/utils/apiClients/collectionsApiClient.test.tsx
@@ -48,6 +48,63 @@ describe("Collections API methods", () => {
     });
   });
 
+  describe("getDivisionData", () => {
+    it("forms the correct request from params with slug", async () => {
+      await CollectionsApi.getDivisionData({
+        slug: "testSlug",
+        pageNum: 1,
+        perPage: 3,
+      });
+
+      expect(fetchApi as jest.Mock).toHaveBeenCalledWith({
+        apiUrl: `${process.env.COLLECTIONS_API_URL}/divisions/testSlug?page=1&per_page=3`,
+        options: { isRepoApi: false },
+      });
+    });
+
+    it("forms the correct request from no params", async () => {
+      await CollectionsApi.getDivisionData();
+
+      expect(fetchApi as jest.Mock).toHaveBeenCalledWith({
+        apiUrl: `${process.env.COLLECTIONS_API_URL}/divisions`,
+        options: { isRepoApi: false },
+      });
+    });
+
+    it("returns successful response", async () => {
+      (fetchApi as jest.Mock).mockResolvedValueOnce(
+        Promise.resolve({
+          summary: "divisions test",
+          divisions: [
+            {
+              name: "Billy Rose Theatre Division",
+              slug: "billy-rose-theatre-division",
+              collections: [],
+            },
+            {
+              name: "Carl H. Pforzheimer Collection of Shelley and His Circle",
+              slug: "carl-h-pforzheimer-collection-of-shelley-and-his-circle",
+              collections: [],
+            },
+          ],
+        })
+      );
+      const result = await CollectionsApi.getDivisionData();
+      expect(result.divisions.length).toEqual(2);
+      expect(result).toHaveProperty("summary");
+    });
+
+    it("handles error response", async () => {
+      (fetchApi as jest.Mock).mockRejectedValue(
+        new Error("fetchApi: Request timed out")
+      );
+
+      await expect(CollectionsApi.getDivisionData()).rejects.toThrow(
+        new Error("fetchApi: Request timed out")
+      );
+    });
+  });
+
   describe("getHomePageData", () => {
     it("creates response containing random number and all 7 lanes", async () => {
       (fetchApi as jest.Mock).mockResolvedValueOnce(

--- a/app/src/utils/apiClients/repoApiClient.test.tsx
+++ b/app/src/utils/apiClients/repoApiClient.test.tsx
@@ -3,7 +3,7 @@ import {
   mockItemResponse,
 } from "__tests__/__mocks__/data/repoApi/mockApiResponses";
 import { fetchApi } from "../fetchApi/fetchApi";
-import { RepoApi } from "./apiClients";
+import { CollectionsApi, RepoApi } from "./apiClients";
 import defaultFeaturedItem from "@/src/data/defaultFeaturedItemData";
 
 jest.mock("../fetchApi/fetchApi");
@@ -30,66 +30,6 @@ describe("Repo API methods", () => {
       expect(result.numberOfDigitizedItems).toEqual("1,059,731");
       expect(result.featuredItem.imageID).toEqual(
         defaultFeaturedItem.featuredItem.imageID
-      );
-    });
-  });
-
-  describe("getDivisionData", () => {
-    it("forms the correct request from params with slug", async () => {
-      await RepoApi.getDivisionData({
-        slug: "testSlug",
-        pageNum: 1,
-        perPage: 3,
-      });
-
-      expect(fetchApi as jest.Mock).toHaveBeenCalledWith({
-        apiUrl: `${process.env.API_URL}/api/v2/divisions/testSlug?page=1&per_page=3`,
-      });
-    });
-
-    it("forms the correct request from no params", async () => {
-      await RepoApi.getDivisionData();
-
-      expect(fetchApi as jest.Mock).toHaveBeenCalledWith({
-        apiUrl: `${process.env.API_URL}/api/v2/divisions`,
-      });
-    });
-
-    it("returns successful response", async () => {
-      (fetchApi as jest.Mock).mockResolvedValueOnce(
-        Promise.resolve({
-          nyplAPI: {
-            response: {
-              headers: { status: "success", code: "200", message: "ok" },
-              summary: "divisions test",
-              divisions: [
-                {
-                  name: "Billy Rose Theatre Division",
-                  slug: "billy-rose-theatre-division",
-                  collections: [],
-                },
-                {
-                  name: "Carl H. Pforzheimer Collection of Shelley and His Circle",
-                  slug: "carl-h-pforzheimer-collection-of-shelley-and-his-circle",
-                  collections: [],
-                },
-              ],
-            },
-          },
-        })
-      );
-      const result = await RepoApi.getDivisionData();
-      expect(result.divisions.length).toEqual(2);
-      expect(result).toHaveProperty("summary");
-    });
-
-    it("handles error response", async () => {
-      (fetchApi as jest.Mock).mockRejectedValue(
-        new Error("fetchApi: Request timed out")
-      );
-
-      await expect(RepoApi.getDivisionData()).rejects.toThrow(
-        new Error("fetchApi: Request timed out")
       );
     });
   });

--- a/app/src/utils/apiClients/repoApiClient.test.tsx
+++ b/app/src/utils/apiClients/repoApiClient.test.tsx
@@ -117,7 +117,7 @@ describe("Repo API methods", () => {
                   apiUri:
                     "https://api.repo.nypl.org/api/v2/collections/e4d9e770-8b49-013d-5581-0242ac110002",
                   imageID: "3932292",
-                  containsOnSiteMaterials: "false",
+                  containsOnSiteMaterial: "false",
                   numItems: "1",
                   numberOfDigitizedItems: "1",
                 },
@@ -128,7 +128,7 @@ describe("Repo API methods", () => {
                   apiUri:
                     "https://api.repo.nypl.org/api/v2/collections/1f182f10-78ed-013d-5352-0242ac110004",
                   imageID: "58928925",
-                  containsOnSiteMaterials: "false",
+                  containsOnSiteMaterial: "false",
                   numItems: "2",
                   numberOfDigitizedItems: "2",
                 },
@@ -139,7 +139,7 @@ describe("Repo API methods", () => {
                   apiUri:
                     "https://api.repo.nypl.org/api/v2/collections/2f151240-6247-013d-50f1-0242ac110004",
                   imageID: "58928893",
-                  containsOnSiteMaterials: "false",
+                  containsOnSiteMaterial: "false",
                   numItems: "1",
                   numberOfDigitizedItems: "1",
                 },


### PR DESCRIPTION
## Ticket:

- [DR-3214](https://newyorkpubliclibrary.atlassian.net/browse/DR-3214)

## This PR does the following:

Updates the divisions endpoints to use the CollectionsAPI instead of RepoAPI

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?
Updated existing test and tested locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [x] I have updated the CHANGELOG.md.
