### PR TITLE
implement redirects for synthetic collections 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-<<<<<<< HEAD
+## Updated
+- updated middleware file to redirect synthetic collections (DR-3750)
+
 ## [1.0.0] 2025-08-04
 - Added Playwright test for Name filter for search-results page (DR-3796)
 - Added Playwright test for George Arents Division's landing page (DR-3716)
@@ -16,12 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed multiple languages not displaying (DR-3764)
 - Fixed typo on Items page 
 - Updated public domain item count on /about page (DR-3065)
-=======
 
 ## [0.4.7] 2027-07-17
 ### Updated
 - Removed broken site banner (NO-REF)
->>>>>>> production
 
 ## [0.4.6] 2025-07-15
 ### Updated

--- a/app/src/config/constants.ts
+++ b/app/src/config/constants.ts
@@ -99,3 +99,17 @@ export const METADATA_FIELDS = [
   "Access",
   "Rights",
 ];
+
+export const OG_DC_SYNTHETIC_DANCE_COLLECTIONS = [
+  "/dancevideo/general#home",
+  "/dancevideo/general",
+  "/danceaudiovideo",
+  "/dance",
+  "/dancevideo",
+];
+
+export const OG_DC_SYNTHETIC_ORAL_HISTORY_COLLECTIONS = [
+  "/american-jewish-committee",
+  "/general#hub",
+  "/dorot",
+];

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,10 @@ import collectionSlugToUuidMapping from "@/src/data/collectionSlugUuidMapping";
 import { divisionSlugMapping } from "@/src/data/divisionSlugMapping";
 import { deSlugify, isDCUuid } from "@/src/utils/utils";
 import { NextRequest, NextResponse } from "next/server";
+import {
+  OG_DC_SYNTHETIC_DANCE_COLLECTIONS,
+  OG_DC_SYNTHETIC_ORAL_HISTORY_COLLECTIONS,
+} from "@/src/config/constants";
 
 const filterMap = {
   placeTerm_mtxt_s: "place",
@@ -20,6 +24,22 @@ const filterMap = {
 export function middleware(req: NextRequest) {
   const url = req.nextUrl;
   const pathname = url.pathname;
+
+  if (OG_DC_SYNTHETIC_DANCE_COLLECTIONS.includes(pathname)) {
+    const newUrl = new URL(
+      req.nextUrl.origin + "/collections/e9403300-0035-0130-e03d-58d385a7bc34"
+    );
+    return NextResponse.redirect(newUrl, 301);
+  }
+
+  if (OG_DC_SYNTHETIC_ORAL_HISTORY_COLLECTIONS.includes(pathname)) {
+    const newUrl = new URL(
+      req.nextUrl.origin + "/collections/da4687f0-cc71-0130-fb40-58d385a7b928"
+    );
+    return NextResponse.redirect(newUrl, 301);
+  }
+
+  console.log("pathname is: ", pathname);
   const itemsMatch = pathname.match(/^\/items\/([^\/?#]+)/);
 
   if (itemsMatch) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -27,7 +27,7 @@ export function middleware(req: NextRequest) {
 
   if (OG_DC_SYNTHETIC_DANCE_COLLECTIONS.includes(pathname)) {
     const newUrl = new URL(
-      req.nextUrl.origin + "/collections/e9403300-0035-0130-e03d-58d385a7bc34"
+      req.nextUrl.origin + "/collections/ab0d3c70-60fc-0131-32d3-58d385a7bbd0"
     );
     return NextResponse.redirect(newUrl, 301);
   }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [implement redirects for synthetic collections](https://newyorkpubliclibrary.atlassian.net/browse/DR-3750)

## This PR does the following:

<!-- What has been updated or added in this PR? -->
- adds custom redirects for two collections from OG DC 

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->
There's a list of all synthetic collections in OG DC that can befound https://newyorkpubliclibrary.atlassian.net/browse/DR-3750

I tested a few of them with /synthetic-slug and /collections/synthetic-slug routes - /slug returns the OG DC 404, which means we actually need to add something to the RP to point /synthetic-slug to DCFL (or maybe just all routes at this point). 

/collections/synthetic-slug already redirects to the search page (TY Emma).

so, what's left is the custom routes in the OG DC routes.rb file

` get 'danceaudiovideo' => 'dancevideo/general#home'
  get '/dance' => redirect('/danceaudiovideo')
  get '/dancevideo' => redirect('/danceaudiovideo')

  get 'american-jewish-committee' => 'general#hub'
  get '/dorot' => redirect('/american-jewish-committee')`

Adding any of these routes to the root url should redirect you to a /collections/:uud page.  Need to confirm this approach with Lana, but putting this up for review anyway.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
