### PR TITLE
Dr 3796 finish final test search filters

### DIFF
--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -125,6 +125,12 @@ export default class SearchPage {
       .locator("#select-place")
       .getByText("Place: England", { exact: true });
     this.genreFilter = this.page.getByRole("button", { name: "Genre" });
+    this.genreOption = this.page
+      .locator("#select-genre")
+      .getByText("Maps", { exact: true });
+    this.genreSelected = this.page
+      .locator("#select-genre")
+      .getByText("Genre: Maps", { exact: true });
     this.publisherFilter = this.page.getByRole("button", { name: "Publisher" });
     this.publisherOption = this.page
       .locator("#select-publisher")
@@ -133,7 +139,23 @@ export default class SearchPage {
       .locator("#select-publisher")
       .getByText("Publisher: Printed at the Theater,", { exact: true });
     this.divisionFilter = this.page.getByRole("button", { name: "Division" });
+    this.divisionOption = this.page
+      .locator("#select-division")
+      .getByText("Lionel Pincus and Princess Firyal Map Division", {
+        exact: true,
+      });
+    this.divisionSelected = this.page
+      .locator("#select-division")
+      .getByText("Division: Lionel Pincus and Princess Firyal Map Division", {
+        exact: true,
+      });
     this.typeFilter = this.page.getByRole("button", { name: "Type" });
+    this.typeOption = this.page
+      .locator("#select-type")
+      .getByText("Cartographic", { exact: true });
+    this.typeSelected = this.page
+      .locator("#select-type")
+      .getByText("Type: Cartographic", { exact: true });
     this.startYear = this.page.getByRole("textbox", { name: "Start year" });
     this.endYear = this.page.getByRole("textbox", { name: "End year" });
     this.applyDates = this.page.getByRole("button", { name: "Apply dates" });

--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -34,6 +34,7 @@ export default class SearchPage {
   readonly publisherSelected: Locator;
   readonly divisionFilter: Locator;
   readonly divisionOption: Locator;
+  readonly divisionSelected: Locator;
   readonly typeFilter: Locator;
   readonly typeOption: Locator;
   readonly typeSelected: Locator;

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -6,11 +6,15 @@ let searchPage: SearchPage;
 test.beforeEach(async ({ page }, testInfo) => {
   const excludedTests = [
     "find item with a keyword search",
+    "enter keyword and submit",
+    "display search results with a clickable item",
     "after opening 2nd row filters",
     "choose publisher",
     "choose genre",
     "choose division",
     "choose type",
+    "filter search results by date",
+    "filter search results by availability",
   ];
 
   if (!excludedTests.includes(testInfo.title)) {
@@ -57,7 +61,7 @@ test.describe("find item with a keyword search", () => {
   // results were actually returned for a search.   Thus, an item-link
   // should be expected to be here by default when it passes.
 
-  test("display search results and clickable item", async () => {
+  test("display search results with a clickable item", async () => {
     await expect(searchPage.resultsHeading).toBeVisible();
     await expect(searchPage.firstItemResult).toBeVisible();
     await expect(searchPage.firstKeywordResult).toContainText(
@@ -368,24 +372,13 @@ test.describe("sorts search results", () => {
   });
 });
 
-test.describe("clicks on an item in search results", () => {
-  test("clicks on an item in unfiltered search results", async () => {
-    await expect(searchPage.refineHeading).toBeVisible();
+test("clicks on an item in filtered search results", async () => {
+  await expect(searchPage.refineHeading).toBeVisible();
 
-    await expect(searchPage.firstItemResult).toBeVisible();
-    await searchPage.firstItemResult.click();
-    await expect(searchPage.page).toHaveURL(/\/(items)\//);
-    await expect(searchPage.refineHeading).not.toBeVisible();
-  });
+  await searchPage.filterSearchResults();
 
-  test("clicks on an item in filtered search results", async () => {
-    await expect(searchPage.refineHeading).toBeVisible();
-
-    await searchPage.filterSearchResults();
-
-    await expect(searchPage.firstItemResult).toBeVisible();
-    await searchPage.firstItemResult.click();
-    await expect(searchPage.page).toHaveURL(/\/(items)\//);
-    await expect(searchPage.refineHeading).not.toBeVisible();
-  });
+  await expect(searchPage.firstItemResult).toBeVisible();
+  await searchPage.firstItemResult.click();
+  await expect(searchPage.page).toHaveURL(/\/(items)\//);
+  await expect(searchPage.refineHeading).not.toBeVisible();
 });

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -147,7 +147,7 @@ test.describe("displays specific filter options", () => {
     await expect(searchPage.topicFilter).toBeVisible();
     await searchPage.topicFilter.click();
     await expect(searchPage.topicOption).toBeVisible();
-    await searchPage.topicOption.click();
+    await searchPage.topicOption.check();
     await expect(searchPage.applyFilterButton).toBeVisible();
     await searchPage.applyFilterButton.click();
     await expect(searchPage.topicSelected).toBeVisible();
@@ -158,7 +158,7 @@ test.describe("displays specific filter options", () => {
     await expect(searchPage.nameFilter).toBeVisible();
     await searchPage.nameFilter.click();
     await expect(searchPage.nameOption).toBeVisible();
-    await searchPage.nameOption.click();
+    await searchPage.nameOption.check();
     await expect(searchPage.applyFilterButton).toBeVisible();
     await searchPage.applyFilterButton.click();
     await expect(searchPage.nameSelected).toBeVisible();
@@ -183,7 +183,7 @@ test.describe("displays specific filter options", () => {
     await expect(searchPage.placeFilter).toBeVisible();
     await searchPage.placeFilter.click();
     await expect(searchPage.placeOption).toBeVisible();
-    await searchPage.placeOption.click();
+    await searchPage.placeOption.check();
     await expect(searchPage.applyFilterButton).toBeVisible();
     await searchPage.applyFilterButton.click();
     await expect(searchPage.placeSelected).toBeVisible();
@@ -215,7 +215,7 @@ test.describe("displays specific filter options", () => {
       await expect(searchPage.genreFilter).toBeVisible();
       await searchPage.genreFilter.click();
       await expect(searchPage.genreOption).toBeVisible();
-      await searchPage.genreOption.click();
+      await searchPage.genreOption.check();
       await expect(searchPage.applyFilterButton).toBeVisible();
       await searchPage.applyFilterButton.click();
       await expect(searchPage.genreSelected).toBeVisible();
@@ -225,7 +225,7 @@ test.describe("displays specific filter options", () => {
       await expect(searchPage.publisherFilter).toBeVisible();
       await searchPage.publisherFilter.click();
       await expect(searchPage.publisherOption).toBeVisible();
-      await searchPage.publisherOption.click();
+      await searchPage.publisherOption.check();
       await expect(searchPage.applyFilterButton).toBeVisible();
       await searchPage.applyFilterButton.click();
       await expect(searchPage.publisherSelected).toBeVisible();
@@ -235,7 +235,7 @@ test.describe("displays specific filter options", () => {
       await expect(searchPage.divisionFilter).toBeVisible();
       await searchPage.divisionFilter.click();
       await expect(searchPage.divisionOption).toBeVisible();
-      await searchPage.divisionOption.click();
+      await searchPage.divisionOption.check();
       await expect(searchPage.applyFilterButton).toBeVisible();
       await searchPage.applyFilterButton.click();
       await expect(searchPage.divisionSelected).toBeVisible();
@@ -245,7 +245,7 @@ test.describe("displays specific filter options", () => {
       await expect(searchPage.typeFilter).toBeVisible();
       await searchPage.typeFilter.click();
       await expect(searchPage.typeOption).toBeVisible();
-      await searchPage.typeOption.click();
+      await searchPage.typeOption.check();
       await expect(searchPage.applyFilterButton).toBeVisible();
       await searchPage.applyFilterButton.click();
       await expect(searchPage.typeSelected).toBeVisible();

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -5,7 +5,7 @@ let searchPage: SearchPage;
 
 test.beforeEach(async ({ page }, testInfo) => {
   const excludedTests = [
-    "searches for a keyword from homepage",
+    "find item with a keyword search",
     "after opening 2nd row filters",
     "choose publisher",
     "choose genre",
@@ -18,31 +18,58 @@ test.beforeEach(async ({ page }, testInfo) => {
   }
 });
 
-test("searches for a keyword from homepage", async ({ page }) => {
-  searchPage = await SearchPage.loadPage("/", page);
+// Do a new search from a results-page
+test.describe("find item with a keyword search", () => {
+  let searchPage: SearchPage;
+  let page: Page;
+  let browserContext: BrowserContext;
 
-  await expect(searchPage.searchBar).toBeVisible();
-  await searchPage.searchBar.fill(searchPage.searchKeyword);
-  await expect(searchPage.searchBar).toHaveValue(searchPage.searchKeyword);
-  await expect(searchPage.searchButton).toBeVisible();
+  test.beforeAll(async ({ browser }) => {
+    browserContext = await browser.newContext();
+    page = await browserContext.newPage();
 
-  await searchPage.searchButton.click();
-  await page.waitForURL("/search/**", {
-    waitUntil: "load",
+    searchPage = await SearchPage.loadPage(SearchPage.searchResultsUrl, page);
+    await expect(searchPage.showFilters).toBeVisible();
+    await searchPage.showFilters.click();
   });
 
-  await expect(page).toHaveTitle("Search results - NYPL Digital Collections");
-});
+  test.afterAll(async () => {
+    // Close the page and context
+    await page.close();
+    await browserContext.close();
+  });
 
-test("displays search results", async () => {
-  await expect(searchPage.resultsHeading).toBeVisible();
-  await expect(searchPage.firstItemResult).toBeVisible();
-  await expect(searchPage.firstKeywordResult).toContainText(
-    searchPage.searchKeyword,
-    {
-      ignoreCase: true,
-    }
-  );
+  test("enter keyword and submit", async () => {
+    await expect(searchPage.searchBar).toBeVisible();
+    await searchPage.searchBar.fill(searchPage.searchKeyword);
+    await expect(searchPage.searchBar).toHaveValue(searchPage.searchKeyword);
+    await expect(searchPage.searchButton).toBeVisible();
+
+    await searchPage.searchButton.click();
+    await page.waitForURL("/search/**", {
+      waitUntil: "load",
+    });
+
+    await expect(page).toHaveTitle("Search results - NYPL Digital Collections");
+  });
+
+  // Item check can go here since this test's purpose is to verify
+  // results were actually returned for a search.   Thus, an item-link
+  // should be expected to be here by default when it passes.
+
+  test("display search results and clickable item", async () => {
+    await expect(searchPage.resultsHeading).toBeVisible();
+    await expect(searchPage.firstItemResult).toBeVisible();
+    await expect(searchPage.firstKeywordResult).toContainText(
+      searchPage.searchKeyword,
+      {
+        ignoreCase: true,
+      }
+    );
+    await searchPage.firstItemResult.click();
+    await expect(searchPage.page).toHaveURL(/\/(items)\//);
+    await expect(searchPage.refineHeading).not.toBeVisible();
+  });
 });
 
 test.describe("displays search results filters", () => {

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -1,10 +1,19 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page, type BrowserContext } from "@playwright/test";
 import SearchPage from "../pages/search.page";
 
 let searchPage: SearchPage;
 
 test.beforeEach(async ({ page }, testInfo) => {
-  if (testInfo.title !== "searches for a keyword from homepage") {
+  const excludedTests = [
+    "searches for a keyword from homepage",
+    "after opening 2nd row filters",
+    "choose publisher",
+    "choose genre",
+    "choose division",
+    "choose type",
+  ];
+
+  if (!excludedTests.includes(testInfo.title)) {
     searchPage = await SearchPage.loadPage(SearchPage.searchResultsUrl, page);
   }
 });
@@ -149,18 +158,85 @@ test.describe("displays specific filter options", () => {
     await expect(searchPage.placeSelected).toBeVisible();
   });
 
-  test("filters drop-downs in second row", async () => {
-    await expect(searchPage.refineHeading).toBeVisible();
+  // Go to search page once, open 2nd row, and check filters, date range and availability
+  test.describe.serial("after opening 2nd row filters", () => {
+    let searchPage: SearchPage;
+    let page: Page;
+    let browserContext: BrowserContext;
 
-    await expect(searchPage.showFilters).toBeVisible();
-    await searchPage.showFilters.click();
-    await expect(searchPage.publisherFilter).toBeVisible();
-    await searchPage.publisherFilter.click();
-    await expect(searchPage.publisherOption).toBeVisible();
-    await searchPage.publisherOption.click();
-    await expect(searchPage.applyFilterButton).toBeVisible();
-    await searchPage.applyFilterButton.click();
-    await expect(searchPage.publisherSelected).toBeVisible();
+    test.beforeAll(async ({ browser }) => {
+      // Perform one-time setup here
+      browserContext = await browser.newContext();
+      page = await browserContext.newPage();
+
+      searchPage = await SearchPage.loadPage(SearchPage.searchResultsUrl, page);
+      await expect(searchPage.showFilters).toBeVisible();
+      await searchPage.showFilters.click();
+    });
+
+    test.afterAll(async () => {
+      // Close the page and context
+      await page.close();
+      await browserContext.close();
+    });
+
+    test("choose genre", async () => {
+      await expect(searchPage.genreFilter).toBeVisible();
+      await searchPage.genreFilter.click();
+      await expect(searchPage.genreOption).toBeVisible();
+      await searchPage.genreOption.click();
+      await expect(searchPage.applyFilterButton).toBeVisible();
+      await searchPage.applyFilterButton.click();
+      await expect(searchPage.genreSelected).toBeVisible();
+    });
+
+    test("choose publisher", async () => {
+      await expect(searchPage.publisherFilter).toBeVisible();
+      await searchPage.publisherFilter.click();
+      await expect(searchPage.publisherOption).toBeVisible();
+      await searchPage.publisherOption.click();
+      await expect(searchPage.applyFilterButton).toBeVisible();
+      await searchPage.applyFilterButton.click();
+      await expect(searchPage.publisherSelected).toBeVisible();
+    });
+
+    test("choose division", async () => {
+      await expect(searchPage.divisionFilter).toBeVisible();
+      await searchPage.divisionFilter.click();
+      await expect(searchPage.divisionOption).toBeVisible();
+      await searchPage.divisionOption.click();
+      await expect(searchPage.applyFilterButton).toBeVisible();
+      await searchPage.applyFilterButton.click();
+      await expect(searchPage.divisionSelected).toBeVisible();
+    });
+
+    test("choose type", async () => {
+      await expect(searchPage.typeFilter).toBeVisible();
+      await searchPage.typeFilter.click();
+      await expect(searchPage.typeOption).toBeVisible();
+      await searchPage.typeOption.click();
+      await expect(searchPage.applyFilterButton).toBeVisible();
+      await searchPage.applyFilterButton.click();
+      await expect(searchPage.typeSelected).toBeVisible();
+    });
+
+    test("filter search results by date", async () => {
+      await expect(searchPage.startYear).toBeVisible();
+      await expect(searchPage.endYear).toBeVisible();
+      await searchPage.startYear.fill("1700");
+      await searchPage.endYear.fill("1800");
+      await expect(searchPage.applyDates).toBeVisible();
+      await searchPage.applyDates.click();
+      await expect(searchPage.startYear).toHaveValue("1700");
+      await expect(searchPage.endYear).toHaveValue("1800");
+    });
+
+    test("filter search results by availability", async () => {
+      await expect(searchPage.refineHeading).toBeVisible();
+      await expect(searchPage.availablePublicDomain).toBeVisible();
+      await searchPage.availablePublicDomain.click();
+      await expect(searchPage.availablePublicDomain).toBeChecked();
+    });
   });
 
   test("filters search results by dates", async () => {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3796](https://newyorkpubliclibrary.atlassian.net/browse/DR-3796)

## This PR does the following:

Adds the remaining filters -- genre, division and type -- to the search-filter tests.  Also some refactoring to get radio check assertions correct, and to try to get things to run a little faster.

## Open questions

I still would like to clean up some of the testing language to make it easier to follow in reports, but these tests do work now, and the whole suite, when run in chromium, currently takes 1.6 min with these changes.  I plan to focus the next PR on timeouts and flakey or brittle tests.

## How has this been tested? How should a reviewer test this?

Ran `npx playwright test --project=chromium `

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
-  X  All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3796]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ