### PR TITLE
Add resource type to item page views [DR-3836]

### DIFF
--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -119,6 +119,8 @@ export default async function ItemViewer({ params, searchParams }: ItemProps) {
         division: breadcrumbData[1]?.text,
         collection: breadcrumbData[2]?.text ?? "No detail",
         subcollection: item.subcollectionName ?? "No detail",
+        contentType: item.contentType,
+        resourceType: item.typeOfResource,
       }}
     >
       <ItemPage

--- a/app/src/components/pageLayout/pageLayout.tsx
+++ b/app/src/components/pageLayout/pageLayout.tsx
@@ -22,7 +22,13 @@ interface PageLayoutProps {
   activePage: string;
   breadcrumbs?: BreadcrumbsDataProps[];
   adobeAnalyticsPageName?: string;
-  ga4Data?: { collection?: string; division?: string; subcollection?: string };
+  ga4Data?: {
+    collection?: string;
+    division?: string;
+    subcollection?: string;
+    contentType?: string;
+    resourceType?: string;
+  };
   searchParams?: SearchParamsType | CollectionSearchParamsType;
 }
 
@@ -41,7 +47,9 @@ const PageLayout = ({
       trackGa4PageView(
         ga4Data.division,
         ga4Data.collection,
-        ga4Data.subcollection
+        ga4Data.subcollection,
+        ga4Data.contentType,
+        ga4Data.resourceType
       );
     }
   });

--- a/app/src/utils/ga4Utils.ts
+++ b/app/src/utils/ga4Utils.ts
@@ -1,7 +1,9 @@
 export const trackGa4PageView = (
   division?: string,
   collection?: string,
-  subCollection?: string
+  subCollection?: string,
+  contentType?: string,
+  resourceType?: string
 ) => {
   const dataLayer = window["dataLayer"] || [];
   dataLayer.push({
@@ -9,6 +11,8 @@ export const trackGa4PageView = (
     division_center: division ? division : "No Detail",
     collection: collection ? collection : "No Detail",
     subcollection: subCollection ? subCollection : "No Detail",
+    contentType: contentType ?? "Not set",
+    resourceType: resourceType ?? "Not set",
   });
 };
 

--- a/app/src/utils/ga4Utils.ts
+++ b/app/src/utils/ga4Utils.ts
@@ -11,8 +11,8 @@ export const trackGa4PageView = (
     division_center: division ? division : "No Detail",
     collection: collection ? collection : "No Detail",
     subcollection: subCollection ? subCollection : "No Detail",
-    contentType: contentType ?? "Not set",
-    resourceType: resourceType ?? "Not set",
+    dc_content_type: contentType ?? "Not set",
+    dc_resource_type: resourceType ?? "Not set",
   });
 };
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3836](https://newyorkpubliclibrary.atlassian.net/browse/DR-3836)

## This PR does the following:

Add content type and resource type to the item page page view events - the content type is simply image / audio / video, which gives a high level rollup, while the resource type is more specific, eg, cartographic, text, etc

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3836]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ