### PR TITLE
Add media play start ga4 event (DR-3593) (DR-3594)

### DIFF
--- a/app/src/components/items/plyr/customAVPlayer.tsx
+++ b/app/src/components/items/plyr/customAVPlayer.tsx
@@ -29,6 +29,13 @@ const CustomAVPlayer = forwardRef<APITypes, any>((props, ref) => {
     };
     const api = current as { plyr: PlyrInstance };
     api.plyr.on("timeupdate", handleTimeUpdate);
+    api.plyr.on("playing", () => {
+      if (!loggedProgressEvents.current.has(0)) {
+        trackAVProgress(source.type, source.title, 0);
+        console.log("Playback started");
+        loggedProgressEvents.current.add(0);
+      }
+    });
     api.plyr.on("ended", () => {
       if (!loggedProgressEvents.current.has(100)) {
         trackAVProgress(source.type, source.title, 100);


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3593](https://newyorkpubliclibrary.atlassian.net/browse/DR-3593)
- JIRA ticket [DR-3594](https://newyorkpubliclibrary.atlassian.net/browse/DR-3594)

## This PR does the following:

Fire an event when the player starts to track '0%' progress.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3593]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DR-3594]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ