### PR TITLE
NO-REF Keep the current zoom level when navigating search results

### DIFF
--- a/app/src/components/items/uv/universalViewer.tsx
+++ b/app/src/components/items/uv/universalViewer.tsx
@@ -229,6 +229,11 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
                     zoomOut: "Zoom Out",
                   },
                 },
+                downloadDialogue: {
+                  options: {
+                    downloadCurrentViewEnabled: false,
+                  },
+                },
               },
             },
             [uv]

--- a/app/src/components/items/uv/universalViewer.tsx
+++ b/app/src/components/items/uv/universalViewer.tsx
@@ -129,6 +129,7 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
                 pagingHeaderPanel: true,
                 pagingOptionEnabled: true,
                 clickToZoomEnabled: false,
+                zoomToBoundsEnabled: false,
                 // saveUserSettings: false, // uncomment if you want to stop new prefs persisting
               },
               modules: {


### PR DESCRIPTION
## Ticket:

## This PR does the following:

For OCR, disables zooming to the word boundary and keeps the users current zoom level instead.

https://github.com/UniversalViewer/universalviewer/blob/1803ee15d4bcfe4f4e2292da27fb07661028b0db/manual/CONFIG.md#zoomtoboundsenabled

Also disables the Current View download option since it's sorta broken with the current Canvas dimensions.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
