### PR TITLE
Swap MAVO for Jean Blackwell Hutson photographs

### DIFF
--- a/app/src/data/lanesData.ts
+++ b/app/src/data/lanesData.ts
@@ -12,10 +12,10 @@ const lanesData = {
           imageID: "58270299",
         },
         {
-          uuid: "724303e0-c6bb-012f-afbd-58d385a7bc34",
-          title: "MAVO",
-          url: "https://digitalcollections.nypl.org/collections/mavo#/?tab=navigation",
-          imageID: "1408153",
+          uuid: "66d899e0-b7b9-013c-626c-0242ac110002",
+          title: "Jean Blackwell Hutson photographs",
+          url: "https://digitalcollections.nypl.org/collections/jean-blackwell-hutson-photographs#/?tab=navigation",
+          imageID: "58887224",
         },
         {
           uuid: "6b6532b0-5df7-013b-36f8-0242ac110002",


### PR DESCRIPTION
## Ticket:
[DR-3828](https://newyorkpubliclibrary.atlassian.net/browse/DR-3828)

## This PR does the following:

Swaps MAVO out for Jean Blackwell Hutson photographs in the recently digitized collections lane on the home page

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3828]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ