### PR TITLE
DR-3790: Fix timeouts on homepage localhost tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Updated
-
+- Fix timeouts on homepage localhost tests (DR-3790)
 - Fix Playwright test timeouts
 
 ## [1.2.0] 2025-09-15

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ import { defineConfig, devices } from "@playwright/test";
  */
 export default defineConfig({
   testDir: "./playwright",
-  timeout: 60000, // default timeout for each test
+  timeout: 30000, // default timeout for each test
   expect: { timeout: 20000 }, // default timeout for each expect assertion
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,8 +13,8 @@ import { defineConfig, devices } from "@playwright/test";
  */
 export default defineConfig({
   testDir: "./playwright",
-  timeout: 30000, // default timeout for each test
-  expect: { timeout: 10000 }, // default timeout for each expect assertion
+  timeout: 60000, // default timeout for each test
+  expect: { timeout: 20000 }, // default timeout for each expect assertion
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright/pages/homepage.page.ts
+++ b/playwright/pages/homepage.page.ts
@@ -155,6 +155,9 @@ export class DCHomepage {
     this.footerAccessibilityLink = this.page.getByRole("link", {
       name: "Accessibility",
     });
+    this.footerPrivacyPolicyLink = this.page.getByRole("link", {
+      name: "Privacy Policy",
+    });
 
     //feedback button
     this.feedbackButton = this.page.getByRole("button", { name: "Feedback" });

--- a/playwright/pages/homepage.page.ts
+++ b/playwright/pages/homepage.page.ts
@@ -155,9 +155,6 @@ export class DCHomepage {
     this.footerAccessibilityLink = this.page.getByRole("link", {
       name: "Accessibility",
     });
-    this.footerPrivacyPolicyLink = this.page.getByRole("link", {
-      name: "Privacy Policy",
-    });
 
     //feedback button
     this.feedbackButton = this.page.getByRole("button", { name: "Feedback" });

--- a/playwright/tests/homepage.spec.ts
+++ b/playwright/tests/homepage.spec.ts
@@ -18,7 +18,7 @@ test.beforeEach(async ({ page }) => {
   await page.route("**/default.jpg", (route) => route.abort());
 
   // Navigate to the page after setting up the routing rules.
-  await page.goto("/", { waitUntil: "load" });
+  await page.goto("/");
 });
 
 test("verify navigation menu is displayed (items, collections, divisions, about)", async ({

--- a/playwright/tests/homepage.spec.ts
+++ b/playwright/tests/homepage.spec.ts
@@ -1,8 +1,10 @@
 import { test, expect } from "@playwright/test";
 import { DCHomepage } from "../pages/homepage.page";
 
+//test.setTimeout(60000);
+
 test.beforeEach(async ({ page }) => {
-  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.goto("/", { waitUntil: "networkidle" });
 });
 
 test("verify navigation menu is displayed (items, collections, divisions, about)", async ({
@@ -73,7 +75,10 @@ test("verify footer links are visible", async ({ page }) => {
 
 test("verify feedback button is visible", async ({ page }) => {
   // this test is flaky; increasing timeout
-  test.setTimeout(120000);
+  // test.setTimeout(120000);
+  // a timeout set wihin the block won't affect this test, so using page timeout override instead
+  page.setDefaultTimeout(60000); // 60 seconds
+
   const dchomepage = new DCHomepage(page);
   await expect(dchomepage.feedbackButton).toBeVisible();
   await dchomepage.feedbackButton.click();

--- a/playwright/tests/homepage.spec.ts
+++ b/playwright/tests/homepage.spec.ts
@@ -85,13 +85,13 @@ test("verify footer links are visible", async ({ page }) => {
   page.setDefaultTimeout(30000); // 30 seconds
   const dchomepage = new DCHomepage(page);
   // the full footer content should be tested in the footer repo, not here in DC
+
   await expect(dchomepage.footerAccessibilityLink).toBeVisible();
 });
 
 test("verify feedback button is visible", async ({ page }) => {
-  // With route-filtering on and domcontentload as a default,
-  // extending timeouts might not be necessary anymore for feedback button.
-  //page.setDefaultTimeout(60000); // 60 seconds
+  // With route-filtering on, extending timeouts might not be necessary
+  // for feedback button tests.
   test.setTimeout(60000);
 
   const dchomepage = new DCHomepage(page);

--- a/playwright/tests/homepage.spec.ts
+++ b/playwright/tests/homepage.spec.ts
@@ -1,10 +1,24 @@
 import { test, expect } from "@playwright/test";
 import { DCHomepage } from "../pages/homepage.page";
 
-//test.setTimeout(60000);
-
 test.beforeEach(async ({ page }) => {
-  await page.goto("/", { waitUntil: "networkidle" });
+  // Block analytics, tracking, and third-party domains
+  await page.route(/.*googletagmanager\.com.*/, (route) => route.abort());
+  await page.route(/.*demdex\.net.*/, (route) => route.abort());
+  await page.route(/.*adobedtm\.com.*/, (route) => route.abort());
+  await page.route(/.*everesttech\.net.*/, (route) => route.abort());
+  await page.route(/.*ipify\.org.*/, (route) => route.abort());
+  await page.route(/.*google\.com.*/, (route) => route.abort());
+  await page.route(/.*omappapi\.com.*/, (route) => route.abort());
+  await page.route(/.*google-analytics\.com.*/, (route) => route.abort());
+
+  // If necessary, block the main-image overlay from iiif
+  // When running the whole suite, feedback on the homepage will often
+  // timeout when default img overlays are slow
+  await page.route("**/default.jpg", (route) => route.abort());
+
+  // Navigate to the page after setting up the routing rules.
+  await page.goto("/", { waitUntil: "load" });
 });
 
 test("verify navigation menu is displayed (items, collections, divisions, about)", async ({
@@ -68,16 +82,17 @@ test("verify explore further section is visible", async ({ page }) => {
 });
 
 test("verify footer links are visible", async ({ page }) => {
+  page.setDefaultTimeout(30000); // 30 seconds
   const dchomepage = new DCHomepage(page);
   // the full footer content should be tested in the footer repo, not here in DC
   await expect(dchomepage.footerAccessibilityLink).toBeVisible();
 });
 
 test("verify feedback button is visible", async ({ page }) => {
-  // this test is flaky; increasing timeout
-  // test.setTimeout(120000);
-  // a timeout set wihin the block won't affect this test, so using page timeout override instead
-  page.setDefaultTimeout(60000); // 60 seconds
+  // With route-filtering on and domcontentload as a default,
+  // extending timeouts might not be necessary anymore for feedback button.
+  //page.setDefaultTimeout(60000); // 60 seconds
+  test.setTimeout(60000);
 
   const dchomepage = new DCHomepage(page);
   await expect(dchomepage.feedbackButton).toBeVisible();


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3790](https://newyorkpubliclibrary.atlassian.net/browse/DR-3790)

## This PR does the following:

<!-- What has been updated or added in this PR? -->
I've added a few things, after trying several alternatives, to try to address some of the continuing timeout issues, especially for the DC homepage tests.

The two main changes I've made are: 

- added route-filters on 3rd-party calls (New Relic, adobe, google, etc.) that normally wouldn't be running on dev testing
- changed wait-until to "load"

This builds on the improvements made recently that allow us to run our playwright tests on localhost against production builds for better performance and stability during testing.

## Open questions

<!-- Any questions you want to ask the reviewer? -->
When this is run in CI, I assume that New Relic, google, adobe etc. are not being called against the prod site.  Or maybe this is a minimal overhead in that case.  I found removing it from localhost calls against the prod build keeps it from being part of our analytics and runs faster, at least when the waitUntil-load method is used on the page. 

## How has this been tested? How should a reviewer test this?
<!--- Please describe in detail how you tested your changes. -->

I found that currently, while homepage.spec.ts would _sometimes_ run without failing, if it were run a few times -- or especially if run within the entire suite, we could replicate failures.  These were usually on the "verify feedback form" scenario in the homepage test.

I compared several different configurations until I found a combination that seems to be 0% flakey, at least during my testing.  Specifically I've found that the visual overlay that uses IIIF's "main-feature" splash image is loaded twice (a 900 px and 1600 px version) to produce the main visual element on the home page.  And whenever it fails (especially on localhost/dev, but even when run against a prod build) the feedback-form tests also fail.  Overall, this is about 10-20% of the time.  My theory is it's bottlenecking other assertions that Playwright might be waiting for on the "verify feedback form" functionality, which does happen to appear at the bottom of a DC homepage-load.  Even after changing to `{ waitUntil: "domcontentloaded" }` I found that the feedback-form test, no matter how large the timeout, would still  sometimes fail.

My goal was to find some combination that would run quickly, at least 7 times in a row, without a homepage.spec.ts fail, both as part of the entire test suite and when run individually.

The results of my testing look like this (if something failed over 30% of the time, I stopped  before 7 tries).  "Timeout" here refers to the timeout set in the specific feedback scenario via the "test" and "page" set methods.  Default.jpg is the visual overlay from IIIF.  There is a route-filter on it, as well as the 3rd-party calls.

Running suite:

|pass/fail|timeout|default.jpg|page-load-wait|avg-total|
|:--------|:--------|:--------|:--------|:--------|
|7/0 | 30000 | filter-out | "load" | 35-41s|
|1/3 | 30000 | filter-out | "domcontentloaded"| |
|1/3 | 60000 (test.set) | filter-out | "domcontentloaded" | |
|0/2 | 60000 (page.set) | filter-out | "domcontentloaded" | |


Single test only: homepage.spec.ts

|pass/fail|feedback-timeout|default.jpg|page-load-wait|avg-test-time|
|:--------|:--------|:--------|:--------|:--------|
|1/2 | 60000 (test.set) | filter | "domcontentloaded"| 9.1s|
|7/0| 30000 | filter | "load" | 10.6s|







## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3790]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ