### PR TITLE
Consume fetch response body on error

### DIFF
--- a/app/src/utils/fetchApi/fetchApi.test.tsx
+++ b/app/src/utils/fetchApi/fetchApi.test.tsx
@@ -118,24 +118,28 @@ describe("fetchApi", () => {
 
   it("handles a Collections API 422 error for invalid param values", async () => {
     const mockBadParams = { param1: "value1", param2: "value2" };
-    const mockResponse = { response: "mockResponse" };
+    const mockResponse = "mockResponse";
     (global as any).fetch = jest.fn(() =>
       Promise.resolve({
         status: 422,
         statusText: "Invalid parameter value: something something",
-        json: async () => mockResponse,
+        text: async () => mockResponse,
       })
     ) as jest.Mock;
 
-    const response = await fetchApi({
-      apiUrl: mockApiUrl,
-      options: {
-        isRepoApi: false,
-        params: mockBadParams,
-      },
-    });
-
-    expect(response).toEqual(mockResponse);
+    await expect(
+      fetchApi({
+        apiUrl: mockApiUrl,
+        options: {
+          isRepoApi: false,
+          params: mockBadParams,
+        },
+      })
+    ).rejects.toEqual(
+      new Error(
+        "Error fetching mockurl.org?param1=value1&param2=value2: 422 mockResponse"
+      )
+    );
   });
 
   it("throws an error for non-200 status", async () => {
@@ -143,11 +147,12 @@ describe("fetchApi", () => {
       Promise.resolve({
         status: 500,
         statusText: "Internal Server Error",
+        text: async () => "Bad things happened",
       })
     ) as jest.Mock;
 
     await expect(fetchApi({ apiUrl: mockApiUrl })).rejects.toEqual(
-      new Error("fetchApi: 500 Internal Server Error")
+      new Error(`Error fetching ${mockApiUrl}: 500 Bad things happened`)
     );
   });
 

--- a/app/src/utils/fetchApi/fetchApi.ts
+++ b/app/src/utils/fetchApi/fetchApi.ts
@@ -71,26 +71,24 @@ export const fetchApi = async ({
     ]);
   };
 
+  let response: Response;
   try {
-    const response = (await fetchWithTimeout(apiUrl, {
+    response = (await fetchWithTimeout(apiUrl, {
       method,
       headers: headers,
       body: method === "POST" ? JSON.stringify(body) : undefined,
       next,
     })) as Response;
-
-    if (response.status === 422) {
-      logger.error(`Invalid parameter value: ${apiUrl}`);
-    } else if (!response.ok) {
-      throw new Error(
-        `fetchApi: ${response.status} ${
-          response.statusText ? response.statusText : "No message"
-        }`
-      );
-    }
-    return await response.json();
   } catch (error) {
     logger.error(error);
     throw new Error(error.message);
   }
+  if (response.ok) {
+    return await response.json();
+  }
+  const responseText = await response.text();
+
+  throw new Error(
+    `Error fetching ${apiUrl}: ${response.status} ${responseText}`
+  );
 };


### PR DESCRIPTION
Doing some digging, I read that a potential source of memory leaks is not consuming the response body of a fetch response. Noticed that we don't consume the body on error, so changed things up a bit to parse and log the text of the body if we don't get an ok response.

Did a bit of refactoring as a part of this, namely, getting rid of the nested error handling and removing the 422 specific handling, which probably made sense when this was first written but now is probably fine to remove since we have a stabilized API.

## Ticket:

- JIRA ticket [DR-xxxx](url)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
