### PR TITLE
use Next Image component on About page

### DIFF
--- a/app/src/components/aboutPageElements/aboutPageElements.tsx
+++ b/app/src/components/aboutPageElements/aboutPageElements.tsx
@@ -51,29 +51,29 @@ const aboutData = [
           {" "}
           Start by searching or browse through{" "}
           <Link href="https://digitalcollections.nypl.org/search/index">
-            item
+            items
           </Link>
           ,{" "}
           <Link href="https://digitalcollections.nypl.org/collections">
-            collection
+            collections
           </Link>
           , or{" "}
           <Link href="https://digitalcollections.nypl.org/divisions">
-            division
+            divisions
           </Link>
           .
         </Text>
 
         <Text>
           {" "}
-          <b>Looking for images you can reuse freely? </b>
+          <b> Want images you can reuse freely? </b>
         </Text>
         <Text>
           You can explore materials that have{" "}
           <Link href="https://digitalcollections.nypl.org/search/index?filters=%5Brights%3DpublicDomain%5D">
-            no known U.S. copyright restrictions{" "}
+            no known U.S. copyright restrictions
           </Link>
-          . Just check the <b>&quot;Show Only Public Domain&quot;</b> option
+          . Just check the <b>&quot;Search Only Public Domain&quot;</b> option
           when searching or in the filter area.{" "}
         </Text>
 
@@ -105,7 +105,7 @@ const aboutData = [
         </Text>
 
         <Text>
-          <b>Want to sort your results? You&apos;ve got options:</b>
+          <b>Want to sort your results?</b> You&apos;ve got options:
         </Text>
         <List type="ul">
           <li>
@@ -144,9 +144,11 @@ const aboutData = [
           viewer.{" "}
         </Text>
         <Text sx={{ marginTop: "s" }}>
-          Available download options will appear in the menu. Simply click on
-          your preferred file size and check your browser&apos;s download folder
-          or new tab for the image.{" "}
+          Available download options will appear in the menu.
+        </Text>
+        <Text>
+          Simply click on your preferred file size and check your browser&apos;s
+          download folder or new tab for the image.{" "}
         </Text>
         <Text sx={{ marginTop: "s" }}>
           When viewing items as a two page spread, select the page you want to

--- a/app/src/components/aboutPageElements/aboutPageElements.tsx
+++ b/app/src/components/aboutPageElements/aboutPageElements.tsx
@@ -5,9 +5,9 @@ import {
   Heading,
   Accordion,
   Box,
-  Image,
 } from "@nypl/design-system-react-components";
-
+import Image from "next/image";
+import itemImage from "../../../../public/item.png";
 const aboutData = [
   {
     heading: (
@@ -152,7 +152,14 @@ const aboutData = [
           When viewing items as a two page spread, select the page you want to
           download by clicking on the right or left image.{" "}
         </Text>
-        <Image alt="item-view" src="/item.png" height={"100%"} width={"100%"} />
+        <Image
+          alt="item-view"
+          src={itemImage}
+          style={{
+            width: "100%",
+            minHeight: "100%",
+          }}
+        />
       </Box>
     ),
   },

--- a/playwright/pages/about.page.ts
+++ b/playwright/pages/about.page.ts
@@ -77,13 +77,13 @@ export class AboutPage {
 
     // links
     this.searchLink = page.getByRole("link", { name: "search", exact: true });
-    this.itemLink = page.getByRole("link", { name: "item", exact: true });
+    this.itemLink = page.getByRole("link", { name: "items", exact: true });
     this.collectionLink = page.getByRole("link", {
-      name: "collection",
+      name: "collections",
       exact: true,
     });
     this.divisionLink = page.getByRole("link", {
-      name: "division",
+      name: "divisions",
       exact: true,
     });
     this.aboutLink = page.getByRole("link", { name: "about", exact: true });


### PR DESCRIPTION
attempt to fix broken image on QA by explicitly importing the image via relative path and and then passing the image into the Next Image component (following the pattern that we use on the homepage for local assets)