### PR TITLE
DR-3875 Video player crossorigin

### DIFF
--- a/app/src/components/items/plyr/customAVPlayer.tsx
+++ b/app/src/components/items/plyr/customAVPlayer.tsx
@@ -50,6 +50,7 @@ const CustomAVPlayer = forwardRef<APITypes, any>((props, ref) => {
       className="plyr-react plyr"
       height={playerHeight}
       width="100%"
+      crossOrigin="anonymous"
     />
   );
 });


### PR DESCRIPTION
## Ticket:
[DR-3875](https://newyorkpubliclibrary.atlassian.net/browse/DR-3875)

## This PR does the following:
Adds `crossOrigin="anonymous"` to the video player. This now sends an `Origin` header with the request so the CORS settings in CloudFront/S3 should work on `*.nypl.org` domains.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?
Can't fully test this since `localhost` and `*.vercel.app` aren't part of AllowedOrigins, but from the vercel preview can see that an `Origin` header has been added to the request headers. Can verify if things are working in QA and if not roll back this change.

## Accessibility concerns or updates

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3875]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ