### PR TITLE
Explicitly avoid items page cache

### DIFF
--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -94,7 +94,6 @@ function formatItemBreadcrumbs(item: ItemModel) {
 }
 
 export default async function ItemViewer({ params, searchParams }: ItemProps) {
-  revalidatePath("/");
   console.log("params are: ", params);
   const [citationsData, itemData] = await Promise.all([
     CollectionsApi.getCitationsData(params.uuid),

--- a/app/src/utils/apiClients/apiClients.tsx
+++ b/app/src/utils/apiClients/apiClients.tsx
@@ -31,7 +31,7 @@ export class CollectionsApi {
     const apiUrl = `${process.env.COLLECTIONS_API_URL}/items/${uuid}/citations`;
     return await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false },
+      options: { isRepoApi: false, cache: "no-store" },
     });
   }
 
@@ -160,7 +160,7 @@ export class CollectionsApi {
   ): Promise<APIItem> {
     return await fetchApi({
       apiUrl: `${process.env.COLLECTIONS_API_URL}/items/${uuid}`,
-      options: { isRepoApi: false, clientIP: clientIP },
+      options: { isRepoApi: false, clientIP: clientIP, cache: "no-store" },
     });
   }
 

--- a/app/src/utils/fetchApi/fetchApi.ts
+++ b/app/src/utils/fetchApi/fetchApi.ts
@@ -25,6 +25,7 @@ export const fetchApi = async ({
     clientIP?: string | null;
     isRepoApi?: boolean;
     next?;
+    cache?: string;
   };
 }) => {
   const {
@@ -34,6 +35,7 @@ export const fetchApi = async ({
     clientIP = null,
     isRepoApi = true,
     next,
+    cache = "force-cache",
   } = options;
 
   const headers: Record<string, string> = {};

--- a/next.config.js
+++ b/next.config.js
@@ -40,6 +40,12 @@ const nextConfig = {
   // the modules that newrelic supports should not be mangled by webpack. Thus,
   // we need to "externalize" all of the modules that newrelic supports.
 
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
+
   webpack: (config) => {
     if (process.env.NEW_RELIC_APP_NAME) {
       nrExternals(config);


### PR DESCRIPTION
Currently, we use `revalidatePath` to wipe the cache from the items page
- reading a bite more, it seems like a simpler approach would be to just not cache the data used to load the items page, and then avoid calling revalidate.  In practice, the items endpoint is already not cached anyway, since nextJS has some underlying magic to not cache any of the data if 'dynamic' functions like `headers()` are called (we call this method to fetch the client side IP address).

In practice, this should do nothing, except maybe reduce a tiny bit of overhead in calling `revalidatePath`. I think this might just make some of the cache behavior a bit clearer. Additionally, I think the purpose of `revalidatePath` is to call it when data is mutated, ie, if you have a form submission or button that triggers data updates, and you want to wipe the cache so that the next GET isn't stale.  Since DC is read-only, seems like we can avoid that step.

If this looks okay on QA, I may reevaluate our other uses of revalidatePath as well.

## Ticket:

- JIRA ticket [DR-xxxx](url)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
