### PR TITLE
DR-3831 - Get item content type from item detail

### DIFF
--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -114,9 +114,7 @@ export class ItemModel {
         : "";
 
     // for viewer configs and order print button
-    this.contentType = rawManifestMetadata["Content Type"]
-      ? rawManifestMetadata["Content Type"][0].toString()
-      : "";
+    this.contentType = itemDetail["contentType"] ?? "";
 
     // only used for order print button
     this.isImage =


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3831](https://newyorkpubliclibrary.atlassian.net/browse/DR-3831)

## This PR does the following:

This is on the list of fields we want to remove from the manifest - this is already in the item details endpoint, so just get it from there!

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3831]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ