### PR TITLE
DR-3697 Format paragraphs for collection abstract

### DIFF
--- a/__tests__/__mocks__/data/collectionsApi/mockCollectionResponse.ts
+++ b/__tests__/__mocks__/data/collectionsApi/mockCollectionResponse.ts
@@ -1,7 +1,7 @@
 export const mockCollectionResponse = {
   title: "Sample Collection",
   uuid: "123-uuid",
-  abstract: "This is a sample abstract.",
+  abstract: ["This is a sample abstract."],
   accessCondition: ["Open access"],
   archivesCollectionID: "12345",
   bNumber: "b1234567",

--- a/app/src/components/collectionMetadata/collectionMetadata.tsx
+++ b/app/src/components/collectionMetadata/collectionMetadata.tsx
@@ -275,7 +275,7 @@ const CollectionMetadata = ({ data }: { data: CollectionMetadataProps }) => {
             Abstract
           </Text>
           {abstract.map((text, index) => (
-            <Text marginBottom="" key={index}>
+            <Text marginBottom="xs" key={index}>
               {parse(text)}
             </Text>
           ))}

--- a/app/src/components/collectionMetadata/collectionMetadata.tsx
+++ b/app/src/components/collectionMetadata/collectionMetadata.tsx
@@ -14,7 +14,7 @@ import parse from "html-react-parser";
 export type CollectionMetadataProps = {
   title: string;
   uuid: string;
-  abstract?: string;
+  abstract?: string[];
   accessCondition?: string[];
   mssID?: string;
   bNumbers?: string[];
@@ -274,7 +274,11 @@ const CollectionMetadata = ({ data }: { data: CollectionMetadataProps }) => {
           <Text size="overline1" marginBottom="xs">
             Abstract
           </Text>
-          <Text marginBottom="0">{abstract}</Text>
+          {abstract.map((text, index) => (
+            <Text marginBottom="" key={index}>
+              {parse(text)}
+            </Text>
+          ))}
         </Box>
       )}
 

--- a/app/src/data/schemas/collectionsUUIDSchema.ts
+++ b/app/src/data/schemas/collectionsUUIDSchema.ts
@@ -2,7 +2,7 @@
 export const collectionsUUIDSchema = {
   title: "string",
   uuid: "string",
-  abstract: "string",
+  abstract: ["string"],
   accessCondition: ["string"],
   archivesCollectionID: "string", // MSS ID, to be used in a archives.nypl.org url
   bNumber: "string", // to be used in a nypl.org/research/research-catalog/bib/ url

--- a/app/src/models/collection.ts
+++ b/app/src/models/collection.ts
@@ -1,7 +1,7 @@
 export class CollectionModel {
   title: string;
   uuid: string;
-  abstract?: string;
+  abstract?: string[];
   accessCondition?: string[];
   mssID?: string;
   bNumbers?: string[];

--- a/app/src/models/item.ts
+++ b/app/src/models/item.ts
@@ -114,9 +114,7 @@ export class ItemModel {
         : "";
 
     // for viewer configs and order print button
-    this.contentType = rawManifestMetadata["Content Type"]
-      ? rawManifestMetadata["Content Type"][0].toString()
-      : "";
+    this.contentType = itemDetail["contentType"] ?? "";
 
     // only used for order print button
     this.isImage =


### PR DESCRIPTION
## Ticket:
[DR-3697](https://newyorkpubliclibrary.atlassian.net/browse/DR-3697)

## This PR does the following:
<!-- What has been updated or added in this PR? -->
Converts the collection abstract field from a string to an array of strings. This allows it to be formatted to display paragraphs the same way that content notes are.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?
<!--- Please describe in detail how you tested your changes. -->
Updated tests where applicable and visually inspected a collections page where this change is relevant.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3697]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ