### PR TITLE
DR-3904 - Checks existence of correct media viewer for images

### DIFF
--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -34,7 +34,7 @@ export default class ItemMediaPage {
   }
 
   static get itemVideoURL(): string {
-    return `/items/${ItemMediaPage.IMAGE_UUID}`;
+    return `/items/${ItemMediaPage.VIDEO_UUID}`;
   }
 
   constructor(page: Page, expectedType: "IMAGE" | "VIDEO") {

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -6,23 +6,40 @@ export default class ItemMediaPage {
   static readonly IMAGE_UUID = "4387c9f0-c53c-012f-9924-58d385a7bc34";
   static readonly VIDEO_UUID = "8820d790-e50c-0130-3a92-3c075448cc4b";
 
-  // Structural locators
+  // Set the appropriate content type
+  static get CONTENT_MAP() {
+    return {
+      [ItemMediaPage.IMAGE_UUID]: "IMAGE",
+      [ItemMediaPage.VIDEO_UUID]: "VIDEO",
+    } as const;
+  }
+
+  // Store the expected content-type
+  readonly expectedContentType: "IMAGE" | "VIDEO";
+
+  //Viewer locator
   readonly viewerHeading: Locator;
 
-  // Image Control Locators (Unique to IMAGE viewer mode)
+  // Image control locators (unique to IMAGE viewer mode)
   readonly zoomInButton: Locator;
   readonly rotateRightButton: Locator;
   readonly fullScreenButton: Locator;
 
-  // Video/Audio Control Locators (Unique to VIDEO viewer mode)
+  // Video/Audio control locators (unique to VIDEO viewer mode)
   readonly playButton: Locator;
+  readonly scrubBar: Locator;
 
-  static get itemMediaURL(): string {
+  static get itemImageURL(): string {
     return `/items/${ItemMediaPage.IMAGE_UUID}`;
   }
 
-  constructor(page: Page) {
+  static get itemVideoURL(): string {
+    return `/items/${ItemMediaPage.VIDEO_UUID}`;
+  }
+
+  constructor(page: Page, expectedType: "IMAGE" | "VIDEO") {
     this.page = page;
+    this.expectedContentType = expectedType;
 
     this.viewerHeading = this.page.getByRole("heading", {
       name: "Media Viewer",
@@ -32,17 +49,48 @@ export default class ItemMediaPage {
     this.zoomInButton = page.getByRole("button", { name: "Zoom In" });
     this.rotateRightButton = page.getByRole("button", { name: "Rotate Right" });
     this.fullScreenButton = page.getByRole("button", { name: "Full Screen" });
-
-    this.playButton = page.getByRole("button", { name: "Play" });
+    // this.playButton = page.getByRole("button", { name: "Play" });
+    this.playButton = page.locator("button").filter({ hasText: /^Play$/ });
+    this.scrubBar = page.getByRole("slider", { name: "seek slider" });
   }
 
   async loadPage(gotoPage: string): Promise<void> {
     await this.page.goto(gotoPage);
-    await this.viewerHeading.waitFor({ state: "visible" });
+    // remove this possibly redundant wait?
+    // await this.viewerHeading.waitFor({ state: "visible" });
+  }
+
+  // Waits for the correct viewer type (Image or Video) to stabilize in the DOM.
+  async stabilizeViewer(): Promise<void> {
+    // check for VIDEO content
+    if (this.expectedContentType === "VIDEO") {
+      await this.playButton.waitFor({ state: "visible", timeout: 90000 });
+    }
+    // check for IMAGE content
+    else if (this.expectedContentType === "IMAGE") {
+      await this.viewerHeading.waitFor({ state: "visible", timeout: 90000 });
+    }
+    // throw an error if an unknown type is passed
+    else {
+      // If it's neither a video or an image, it SHOULD be an audio, which defaults to the video player.
+      // Later, we can test for audio and throw and error below if an unexpected type rears its head.
+      // throw new Error(`Unknown content type: ${this.expectedContentType}. Cannot determine viewer stabilization locator.`);
+      await this.playButton.waitFor({ state: "visible", timeout: 90000 });
+    }
   }
 
   async verifyViewerIsReady(): Promise<void> {
-    // this will be called in spec to confirm the stability step succeeded.
-    await expect(this.viewerHeading).toBeVisible();
+    // check the appropriate anchor based on the content type
+    if (this.expectedContentType === "VIDEO") {
+      await this.playButton.waitFor({ state: "visible" });
+    } else if (this.expectedContentType === "IMAGE") {
+      await this.viewerHeading.waitFor({ state: "visible" });
+    }
+    // If it's not an video or an image, it should be an audio file, which also uses the player
+    else {
+      await this.playButton.waitFor({ state: "visible" });
+      // Or, should we also specify audio, and throw an error if an unknown content type slips in there?
+      // throw new Error(`Unknown content type: ${this.expectedContentType}. Cannot determine viewer stabilization locator.`);
+    }
   }
 }

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -24,18 +24,15 @@ export default class ItemMediaPage {
   constructor(page: Page) {
     this.page = page;
 
-    // ANCHOR: The most stable, accessible element that appears when the UV is ready.
     this.viewerHeading = this.page.getByRole("heading", {
       name: "Media Viewer",
       level: 2,
     });
 
-    // CONTROLS: Standard accessible locators for image-specific controls
     this.zoomInButton = page.getByRole("button", { name: "Zoom In" });
     this.rotateRightButton = page.getByRole("button", { name: "Rotate Right" });
     this.fullScreenButton = page.getByRole("button", { name: "Full Screen" });
 
-    //  VIDEO CONTROL (we want to confirm is NOT visible on image pages)
     this.playButton = page.getByRole("button", { name: "Play" });
   }
 

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -1,8 +1,10 @@
 import { Locator, Page, expect } from "@playwright/test";
-import { IMAGE_UUID } from "../utils/mediaData";
 
 export default class ItemMediaPage {
   readonly page: Page;
+
+  static readonly IMAGE_UUID = "4387c9f0-c53c-012f-9924-58d385a7bc34";
+  static readonly VIDEO_UUID = "8820d790-e50c-0130-3a92-3c075448cc4b";
 
   // Structural locators
   readonly viewerHeading: Locator;
@@ -16,7 +18,7 @@ export default class ItemMediaPage {
   readonly playButton: Locator;
 
   static get itemMediaURL(): string {
-    return `/items/${IMAGE_UUID}`;
+    return `/items/${ItemMediaPage.IMAGE_UUID}`;
   }
 
   constructor(page: Page) {

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -1,0 +1,31 @@
+//item-media.page.ts
+import { Locator, Page, expect, TestInfo } from "@playwright/test";
+import { waitForSlowResource } from "../utils/slowWaitHelpers";
+
+export default class ItemMediaPage {
+  // FIX 2: Standard Class Name Convention
+  readonly page: Page;
+  // Assuming 'mainHeroImage' is the locator for your Universal Viewer component.
+  readonly mainHeroImage: Locator;
+
+  // FIX 3: The constructor is required to initialize 'this.page'
+  constructor(page: Page) {
+    this.page = page;
+    // Example initialization for the locator
+    this.mainHeroImage = page.locator(".universal-viewer-canvas");
+  }
+
+  // Waits for the Universal Viewer image to load using a temporary 90s timeout.
+  async verifyMainImageLoads(testInfo: TestInfo): Promise<void> {
+    // CRITICAL: Call the utility, passing the locator, the page instance,
+    // and the original timeout value from testInfo.
+    await waitForSlowResource(
+      this.mainHeroImage,
+      this.page,
+      testInfo.timeout // Get the original timeout (the overall test timeout)
+    );
+
+    // Final check that the image is now visible after the long wait
+    await expect(this.mainHeroImage).toBeVisible();
+  }
+}

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -1,4 +1,5 @@
 import { Locator, Page, expect } from "@playwright/test";
+import { IMAGE_UUID } from "../utils/mediaData";
 
 export default class ItemMediaPage {
   readonly page: Page;
@@ -14,7 +15,9 @@ export default class ItemMediaPage {
   // Video/Audio Control Locators (Unique to VIDEO viewer mode)
   readonly playButton: Locator;
 
-  static itemMediaURL: string = "/items/4387c9f0-c53c-012f-9924-58d385a7bc34";
+  static get itemMediaURL(): string {
+    return `/items/${IMAGE_UUID}`;
+  }
 
   constructor(page: Page) {
     this.page = page;
@@ -36,15 +39,11 @@ export default class ItemMediaPage {
 
   async loadPage(gotoPage: string): Promise<void> {
     await this.page.goto(gotoPage);
+    await this.viewerHeading.waitFor({ state: "visible" });
   }
 
-  //  Verify the media viewer loads using the most stable locator (the Heading).
-  async verifyMainImageLoads(): Promise<void> {
-    // 1. Wait for the stable, accessible heading (The definitive structural check)
-    // This uses the long timeout set in the spec file.
-    await this.viewerHeading.waitFor({ state: "visible" });
-
-    // 2. Final check on the actual rendering canvas.
-    // await expect(this.mainCanvas).toBeVisible();
+  async verifyViewerIsReady(): Promise<void> {
+    // this will be called in spec to confirm the stability step succeeded.
+    await expect(this.viewerHeading).toBeVisible();
   }
 }

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -1,30 +1,50 @@
-import { Locator, Page, expect, TestInfo } from "@playwright/test";
-import { waitForSlowResource } from "../utils/slowWaitHelpers";
+import { Locator, Page, expect } from "@playwright/test";
 
 export default class ItemMediaPage {
-  // FIX 2: Standard Class Name Convention
   readonly page: Page;
-  // Assuming 'mainHeroImage' is the locator for your Universal Viewer component.
-  readonly mainHeroImage: Locator;
 
-  // FIX 3: The constructor is required to initialize 'this.page'
+  // Structural locators
+  readonly viewerHeading: Locator;
+
+  // Image Control Locators (Unique to IMAGE viewer mode)
+  readonly zoomInButton: Locator;
+  readonly rotateRightButton: Locator;
+  readonly fullScreenButton: Locator;
+
+  // Video/Audio Control Locators (Unique to VIDEO viewer mode)
+  readonly playButton: Locator;
+
+  static itemMediaURL: string = "/items/4387c9f0-c53c-012f-9924-58d385a7bc34";
+
   constructor(page: Page) {
     this.page = page;
-    // Example initialization for the locator
-    this.mainHeroImage = page.locator(".universal-viewer-canvas");
+
+    // ANCHOR: The most stable, accessible element that appears when the UV is ready.
+    this.viewerHeading = this.page.getByRole("heading", {
+      name: "Media Viewer",
+      level: 2,
+    });
+
+    // CONTROLS: Standard accessible locators for image-specific controls
+    this.zoomInButton = page.getByRole("button", { name: "Zoom In" });
+    this.rotateRightButton = page.getByRole("button", { name: "Rotate Right" });
+    this.fullScreenButton = page.getByRole("button", { name: "Full Screen" });
+
+    //  VIDEO CONTROL (we want to confirm is NOT visible on image pages)
+    this.playButton = page.getByRole("button", { name: "Play" });
   }
 
-  // Waits for the Universal Viewer image to load using a temporary 90s timeout.
-  async verifyMainImageLoads(testInfo: TestInfo): Promise<void> {
-    // CRITICAL: Call the utility, passing the locator, the page instance,
-    // and the original timeout value from testInfo.
-    await waitForSlowResource(
-      this.mainHeroImage,
-      this.page,
-      testInfo.timeout // Get the original timeout (the overall test timeout)
-    );
+  async loadPage(gotoPage: string): Promise<void> {
+    await this.page.goto(gotoPage);
+  }
 
-    // Final check that the image is now visible after the long wait
-    await expect(this.mainHeroImage).toBeVisible();
+  //  Verify the media viewer loads using the most stable locator (the Heading).
+  async verifyMainImageLoads(): Promise<void> {
+    // 1. Wait for the stable, accessible heading (The definitive structural check)
+    // This uses the long timeout set in the spec file.
+    await this.viewerHeading.waitFor({ state: "visible" });
+
+    // 2. Final check on the actual rendering canvas.
+    // await expect(this.mainCanvas).toBeVisible();
   }
 }

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -34,7 +34,7 @@ export default class ItemMediaPage {
   }
 
   static get itemVideoURL(): string {
-    return `/items/${ItemMediaPage.VIDEO_UUID}`;
+    return `/items/${ItemMediaPage.IMAGE_UUID}`;
   }
 
   constructor(page: Page, expectedType: "IMAGE" | "VIDEO") {
@@ -89,7 +89,7 @@ export default class ItemMediaPage {
     // If it's not an video or an image, it should be an audio file, which also uses the player
     else {
       await this.playButton.waitFor({ state: "visible" });
-      // Or, should we also specify audio, and throw an error if an unknown content type slips in there?
+      // Or, should we also specify audio, and throw an error if an unknown 4th content type slips in there?
       // throw new Error(`Unknown content type: ${this.expectedContentType}. Cannot determine viewer stabilization locator.`);
     }
   }

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -1,4 +1,3 @@
-//item-media.page.ts
 import { Locator, Page, expect, TestInfo } from "@playwright/test";
 import { waitForSlowResource } from "../utils/slowWaitHelpers";
 

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -1,6 +1,5 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../base";
 import ItemMediaPage from "../pages/item-media.page";
-import { applyRouteFilters } from "../utils/routeFilters"; // Assuming filter utility exists
 
 let itemMediaPage: ItemMediaPage;
 
@@ -10,13 +9,8 @@ test.describe.configure({ timeout: 90000 });
 
 test.describe("Image Viewer Control Verification", () => {
   test.beforeEach(async ({ page }) => {
-    // Register the route filters BEFORE navigation.
-    await applyRouteFilters(page);
-
-    // Instantiate the Page Object
     itemMediaPage = new ItemMediaPage(page);
 
-    // Load the specific Image item URL
     await itemMediaPage.loadPage(ItemMediaPage.itemMediaURL);
 
     // Wait for the stable UV heading to confirm the module is fully initialized

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -3,8 +3,7 @@ import ItemMediaPage from "../pages/item-media.page";
 
 let itemMediaPage: ItemMediaPage;
 
-// CRITICAL: Configure the suite's timeout settings before the describe block.
-// Assumes 90s is the required timeout for the slow UV module.
+// configure  suite's timeout settings before the describe block.
 test.describe.configure({ timeout: 90000 });
 
 test.describe("Image Viewer Control Verification", () => {
@@ -13,22 +12,21 @@ test.describe("Image Viewer Control Verification", () => {
 
     await itemMediaPage.loadPage(ItemMediaPage.itemMediaURL);
 
-    // Wait for the stable UV heading to confirm the module is fully initialized
+    // wait for stable UV heading to confirm the module is fully loaded
     await itemMediaPage.viewerHeading.waitFor({ state: "visible" });
   });
 
   test("should verify all IMAGE-specific controls are visible", async () => {
-    // Assert on the mandatory structural anchor
     await expect(itemMediaPage.viewerHeading).toBeVisible();
 
-    // Assert IMAGE Controls are visible
+    // check if IMAGE Controls are visible
     await expect(itemMediaPage.zoomInButton).toBeVisible();
     await expect(itemMediaPage.rotateRightButton).toBeVisible();
     await expect(itemMediaPage.fullScreenButton).toBeVisible();
   });
 
   test("should verify VIDEO controls are NOT visible", async () => {
-    // Assert VIDEO Controls are hidden (crucial for verifying correct UV mode)
+    // check that no AUDIO/VIDEO controls are appearing (verifying correct UV mode)
     await expect(itemMediaPage.playButton).toBeHidden();
   });
 });

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -1,5 +1,3 @@
-//item-media.spec.ts
-
 import { test, expect, TestInfo } from "@playwright/test"; // Note: TestInfo is required
 import ItemMediaPage from "../pages/item-media.page"; // Your new Page Object
 import { applyRouteFilters } from "../utils/routeFilters";

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -6,18 +6,15 @@ let itemMediaPage: ItemMediaPage;
 // configure  suite's timeout settings before the describe block.
 test.describe.configure({ timeout: 90000 });
 
-test.describe("Image Viewer Control Verification", () => {
+test.describe("Verify Image Viewer Controls", () => {
   test.beforeEach(async ({ page }) => {
     itemMediaPage = new ItemMediaPage(page);
 
     await itemMediaPage.loadPage(ItemMediaPage.itemMediaURL);
-
-    // wait for stable UV heading to confirm the module is fully loaded
-    await itemMediaPage.viewerHeading.waitFor({ state: "visible" });
   });
 
-  test("should verify all IMAGE-specific controls are visible", async () => {
-    await expect(itemMediaPage.viewerHeading).toBeVisible();
+  test("all image-specific controls are visible", async () => {
+    await itemMediaPage.verifyViewerIsReady();
 
     // check if IMAGE Controls are visible
     await expect(itemMediaPage.zoomInButton).toBeVisible();
@@ -25,7 +22,7 @@ test.describe("Image Viewer Control Verification", () => {
     await expect(itemMediaPage.fullScreenButton).toBeVisible();
   });
 
-  test("should verify VIDEO controls are NOT visible", async () => {
+  test("video controls are NOT visible", async () => {
     // check that no AUDIO/VIDEO controls are appearing (verifying correct UV mode)
     await expect(itemMediaPage.playButton).toBeHidden();
   });

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -1,66 +1,40 @@
-import { test, expect, TestInfo } from "@playwright/test"; // Note: TestInfo is required
-import ItemMediaPage from "../pages/item-media.page"; // Your new Page Object
-import { applyRouteFilters } from "../utils/routeFilters";
+import { test, expect } from "@playwright/test";
+import ItemMediaPage from "../pages/item-media.page";
+import { applyRouteFilters } from "../utils/routeFilters"; // Assuming filter utility exists
 
-let itemMediaPage: ItemMediaPage; // Global variable
+let itemMediaPage: ItemMediaPage;
 
-test.describe("Universal Viewer Stability and Timeout Test", () => {
+// CRITICAL: Configure the suite's timeout settings before the describe block.
+// Assumes 90s is the required timeout for the slow UV module.
+test.describe.configure({ timeout: 90000 });
+
+test.describe("Image Viewer Control Verification", () => {
   test.beforeEach(async ({ page }) => {
     // Register the route filters BEFORE navigation.
     await applyRouteFilters(page);
+
     // Instantiate the Page Object
     itemMediaPage = new ItemMediaPage(page);
-    // await itemMediaPage.loadPage(ItemMediaPage.itemResultURL);
-    await page.goto(
-      "http://localhost:3000/items/4387c9f0-c53c-012f-9924-58d385a7bc34"
-    );
+
+    // Load the specific Image item URL
+    await itemMediaPage.loadPage(ItemMediaPage.itemMediaURL);
+
+    // Wait for the stable UV heading to confirm the module is fully initialized
+    await itemMediaPage.viewerHeading.waitFor({ state: "visible" });
   });
 
-  // This test forces the 90-second wait logic to run and confirms the image is visible.
-  test("should verify the slow-loading Universal Viewer image stabilizes", async ({
-    page,
-  }, testInfo: TestInfo) => {
-    // The single line that executes the full, complex logic:
-    // 1. Reads the original timeout (30s) from testInfo.
-    // 2. Extends the page timeout to 90s.
-    // 3. Waits for the locator to become visible.
-    // 4. Restores the original 30s timeout.
-    // 5. Asserts final visibility.
-    await itemMediaPage.verifyMainImageLoads(testInfo);
+  test("should verify all IMAGE-specific controls are visible", async () => {
+    // Assert on the mandatory structural anchor
+    await expect(itemMediaPage.viewerHeading).toBeVisible();
+
+    // Assert IMAGE Controls are visible
+    await expect(itemMediaPage.zoomInButton).toBeVisible();
+    await expect(itemMediaPage.rotateRightButton).toBeVisible();
+    await expect(itemMediaPage.fullScreenButton).toBeVisible();
   });
 
-  // More tests here later...
+  test("should verify VIDEO controls are NOT visible", async () => {
+    // Assert VIDEO Controls are hidden (crucial for verifying correct UV mode)
+    await expect(itemMediaPage.playButton).toBeHidden();
+  });
 });
-
-// // This hook runs before the test and sets up the network blocking.
-// test.beforeEach(async ({ page }) => {
-//   // Block analytics, tracking, and third-party domains
-//   await page.route(/.*adobedc\.net.*/, (route) => route.abort());
-//   await page.route(/.*adobedtm\.com.*/, (route) => route.abort());
-//   await page.route(/.*demdex\.net.*/, (route) => route.abort());
-//   await page.route(/.*everesttech\.net.*/, (route) => route.abort());
-//   await page.route(/.*google-analytics\.com.*/, (route) => route.abort());
-//   await page.route(/.*google\.com.*/, (route) => route.abort());
-//   await page.route(/.*googletagmanager\.com.*/, (route) => route.abort());
-//   await page.route(/.*ipify\.org.*/, (route) => route.abort());
-//   await page.route(/.*newrelic\.com.*/, (route) => route.abort());
-//   await page.route(/.*nr-data\.net.*/, (route) => route.abort());
-//   await page.route(/.*omappapi\.com.*/, (route) => route.abort());
-// });
-
-// test("check load", async ({ page }) => {
-//   // CRITICAL: Replace '/your-target-page' with the actual URL path you need to inspect.
-//   await page.goto(
-//      "http://localhost:3000/items/4387c9f0-c53c-012f-9924-58d385a7bc34"
-//       //  "https://digitalcollections.nypl.org/items/4387c9f0-c53c-012f-9924-58d385a7bc34"
-//   );
-
-//   // OPTIONAL WAIT: Give the UV module several seconds to load its resources
-//   await page.waitForTimeout(7000); // Wait 7 seconds
-
-//   // Freezes the session
-//   await page.pause();
-
-//   // The test will pause here until the default timeout (or until you interact with the UI).
-//   // It provides an active browser session for inspection.
-// });

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -1,0 +1,68 @@
+//item-media.spec.ts
+
+import { test, expect, TestInfo } from "@playwright/test"; // Note: TestInfo is required
+import ItemMediaPage from "../pages/item-media.page"; // Your new Page Object
+import { applyRouteFilters } from "../utils/routeFilters";
+
+let itemMediaPage: ItemMediaPage; // Global variable
+
+test.describe("Universal Viewer Stability and Timeout Test", () => {
+  test.beforeEach(async ({ page }) => {
+    // Register the route filters BEFORE navigation.
+    await applyRouteFilters(page);
+    // Instantiate the Page Object
+    itemMediaPage = new ItemMediaPage(page);
+    // await itemMediaPage.loadPage(ItemMediaPage.itemResultURL);
+    await page.goto(
+      "http://localhost:3000/items/4387c9f0-c53c-012f-9924-58d385a7bc34"
+    );
+  });
+
+  // This test forces the 90-second wait logic to run and confirms the image is visible.
+  test("should verify the slow-loading Universal Viewer image stabilizes", async ({
+    page,
+  }, testInfo: TestInfo) => {
+    // The single line that executes the full, complex logic:
+    // 1. Reads the original timeout (30s) from testInfo.
+    // 2. Extends the page timeout to 90s.
+    // 3. Waits for the locator to become visible.
+    // 4. Restores the original 30s timeout.
+    // 5. Asserts final visibility.
+    await itemMediaPage.verifyMainImageLoads(testInfo);
+  });
+
+  // More tests here later...
+});
+
+// // This hook runs before the test and sets up the network blocking.
+// test.beforeEach(async ({ page }) => {
+//   // Block analytics, tracking, and third-party domains
+//   await page.route(/.*adobedc\.net.*/, (route) => route.abort());
+//   await page.route(/.*adobedtm\.com.*/, (route) => route.abort());
+//   await page.route(/.*demdex\.net.*/, (route) => route.abort());
+//   await page.route(/.*everesttech\.net.*/, (route) => route.abort());
+//   await page.route(/.*google-analytics\.com.*/, (route) => route.abort());
+//   await page.route(/.*google\.com.*/, (route) => route.abort());
+//   await page.route(/.*googletagmanager\.com.*/, (route) => route.abort());
+//   await page.route(/.*ipify\.org.*/, (route) => route.abort());
+//   await page.route(/.*newrelic\.com.*/, (route) => route.abort());
+//   await page.route(/.*nr-data\.net.*/, (route) => route.abort());
+//   await page.route(/.*omappapi\.com.*/, (route) => route.abort());
+// });
+
+// test("check load", async ({ page }) => {
+//   // CRITICAL: Replace '/your-target-page' with the actual URL path you need to inspect.
+//   await page.goto(
+//      "http://localhost:3000/items/4387c9f0-c53c-012f-9924-58d385a7bc34"
+//       //  "https://digitalcollections.nypl.org/items/4387c9f0-c53c-012f-9924-58d385a7bc34"
+//   );
+
+//   // OPTIONAL WAIT: Give the UV module several seconds to load its resources
+//   await page.waitForTimeout(7000); // Wait 7 seconds
+
+//   // Freezes the session
+//   await page.pause();
+
+//   // The test will pause here until the default timeout (or until you interact with the UI).
+//   // It provides an active browser session for inspection.
+// });

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -13,7 +13,7 @@ test.describe("Verify Image Viewer Controls", () => {
     await itemMediaPage.loadPage(ItemMediaPage.itemImageURL);
   });
 
-  test("all image-specific controls are visible", async () => {
+  test("primary image-specific controls are visible", async () => {
     await itemMediaPage.verifyViewerIsReady();
 
     // check if IMAGE Controls are visible
@@ -22,7 +22,8 @@ test.describe("Verify Image Viewer Controls", () => {
     await expect(itemMediaPage.fullScreenButton).toBeVisible();
   });
 
-  test("video controls are NOT visible", async () => {
+  // flakey test because it checks before ANY controls are visible, so will always pass
+  test.skip("video controls are NOT visible", async () => {
     // check that no AUDIO/VIDEO controls are appearing (verifying correct UV mode)
     await expect(itemMediaPage.playButton).toBeHidden();
   });
@@ -35,7 +36,7 @@ test.describe("Verify Video Viewer Controls", () => {
     await itemMediaPage.loadPage(ItemMediaPage.itemVideoURL);
   });
 
-  test("all video-specific controls are visible", async () => {
+  test("primary video-specific controls are visible", async () => {
     await itemMediaPage.verifyViewerIsReady();
 
     // check if VIDEO Controls are visible
@@ -43,8 +44,18 @@ test.describe("Verify Video Viewer Controls", () => {
     await expect(itemMediaPage.playButton).toBeVisible();
   });
 
-  test("image controls are NOT visible", async () => {
-    // check that no IMAGE controls are appearing (verifying correct UV mode)
+  // unnecessary assertions, which also will get false-positives in async mode
+  test.skip("image controls are NOT visible", async () => {
+    // This will get a false positive in the DOM for the same reasons as
+    // the negative-assertion about video-controls will similarly fail in
+    // the main image-controls test.
+    // We could serially wait for the answer to the previous
+    // assertion (is media-play-button visible?) here, first.  But we
+    // can probably leave these negative assertions below out, because if
+    // you are on a video player, it's all or nothing:  you're not going to see
+    // ANY of the image controls we are checking
+    // for below on the video-player UV.  And the reverse holds true
+    // for the image-viewer UV.
     await expect(itemMediaPage.zoomInButton).toBeHidden();
     await expect(itemMediaPage.rotateRightButton).toBeHidden();
     await expect(itemMediaPage.fullScreenButton).toBeHidden();

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -8,9 +8,9 @@ test.describe.configure({ timeout: 90000 });
 
 test.describe("Verify Image Viewer Controls", () => {
   test.beforeEach(async ({ page }) => {
-    itemMediaPage = new ItemMediaPage(page);
+    itemMediaPage = new ItemMediaPage(page, "IMAGE");
 
-    await itemMediaPage.loadPage(ItemMediaPage.itemMediaURL);
+    await itemMediaPage.loadPage(ItemMediaPage.itemImageURL);
   });
 
   test("all image-specific controls are visible", async () => {
@@ -25,5 +25,28 @@ test.describe("Verify Image Viewer Controls", () => {
   test("video controls are NOT visible", async () => {
     // check that no AUDIO/VIDEO controls are appearing (verifying correct UV mode)
     await expect(itemMediaPage.playButton).toBeHidden();
+  });
+});
+
+test.describe("Verify Video Viewer Controls", () => {
+  test.beforeEach(async ({ page }) => {
+    itemMediaPage = new ItemMediaPage(page, "VIDEO");
+
+    await itemMediaPage.loadPage(ItemMediaPage.itemVideoURL);
+  });
+
+  test("all video-specific controls are visible", async () => {
+    await itemMediaPage.verifyViewerIsReady();
+
+    // check if VIDEO Controls are visible
+
+    await expect(itemMediaPage.playButton).toBeVisible();
+  });
+
+  test("image controls are NOT visible", async () => {
+    // check that no IMAGE controls are appearing (verifying correct UV mode)
+    await expect(itemMediaPage.zoomInButton).toBeHidden();
+    await expect(itemMediaPage.rotateRightButton).toBeHidden();
+    await expect(itemMediaPage.fullScreenButton).toBeHidden();
   });
 });

--- a/playwright/utils/mediaData.ts
+++ b/playwright/utils/mediaData.ts
@@ -1,2 +1,0 @@
-export const IMAGE_UUID = "4387c9f0-c53c-012f-9924-58d385a7bc34";
-export const VIDEO_UUID = "8820d790-e50c-0130-3a92-3c075448cc4b";

--- a/playwright/utils/mediaData.ts
+++ b/playwright/utils/mediaData.ts
@@ -1,0 +1,2 @@
+export const IMAGE_UUID = "4387c9f0-c53c-012f-9924-58d385a7bc34";
+export const VIDEO_UUID = "8820d790-e50c-0130-3a92-3c075448cc4b";

--- a/playwright/utils/routeFilters.ts
+++ b/playwright/utils/routeFilters.ts
@@ -4,11 +4,14 @@ export async function applyRouteFilters(page: Page) {
   // Block analytics, tracking, and third-party domains
   await page.route(/.*adobedc\.net.*/, (route) => route.abort());
   await page.route(/.*adobedtm\.com.*/, (route) => route.abort());
+  await page.route(/.*ipify\.org.*/, (route) => route.abort());
   await page.route(/.*demdex\.net.*/, (route) => route.abort());
   await page.route(/.*everesttech\.net.*/, (route) => route.abort());
   await page.route(/.*google-analytics\.com.*/, (route) => route.abort());
+  await page.route(/.*googleapis\.com.*/, (route) => route.abort());
   await page.route(/.*google\.com.*/, (route) => route.abort());
   await page.route(/.*googletagmanager\.com.*/, (route) => route.abort());
+  await page.route(/.*gstatic\.com.*/, (route) => route.abort());
   await page.route(/.*ipify\.org.*/, (route) => route.abort());
   await page.route(/.*newrelic\.com.*/, (route) => route.abort());
   await page.route(/.*nr-data\.net.*/, (route) => route.abort());

--- a/playwright/utils/slowWaitHelpers.ts
+++ b/playwright/utils/slowWaitHelpers.ts
@@ -1,0 +1,18 @@
+import { Page, Locator } from "@playwright/test";
+
+const SLOW_RESOURCE_TIMEOUT = 90000;
+
+export async function waitForSlowResource(
+  locator: Locator,
+  page: Page,
+  originalTimeout: number
+) {
+  // Set temporary long timeout for this action
+  page.setDefaultTimeout(SLOW_RESOURCE_TIMEOUT);
+
+  // Perform the critical wait action
+  await locator.waitFor({ state: "visible" });
+
+  // Restore original timeout
+  page.setDefaultTimeout(originalTimeout);
+}


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3904](https://newyorkpubliclibrary.atlassian.net/browse/DR-3904)

## This PR does the following:

<!-- What has been updated or added in this PR? -->
This PR checks whether an image's item page is displaying the correct Universal Viewer media-type controls.

## Open questions

<!-- Any questions you want to ask the reviewer? -->
Currently, we are only checking that an type of "still image" does not display inadvertently an audio/video player UV modal.  In future PRs, this can be extended to the reverse: that a video displays its correct controls.   There is a sample UUID for both image and audio types in a utils helper "mediaData.ts" that can be used for extending to video checks.

Right now the UUID variable takes a sample item selected to be in both the qa and prod api data.  In future iterations, it would be nice for this test go be able to take the first random image UUID it finds, and pass that to the "control-checker," and then do the same for a random video item that it finds.  

But as it is, I think the test still fulfills the primary goal:  which is to make sure that the wrong type of UV modal is not being used for an item's stated media type.

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

Ran tests against both types of UUID (video and image).  Also ran the test suite, and checked with both qa-api and prod-api  settings in the local env.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3904]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ