### PR TITLE
DR-3796 fix revert of search filters

### DIFF
--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -50,6 +50,7 @@ export default class SearchPage {
   readonly clearFilterButton: Locator;
   readonly clearNameFilterApplied: Locator;
   readonly clearTopicFilterApplied: Locator;
+  readonly clearPublisherFilterApplied: Locator;
   readonly clearAllFilters: Locator;
 
   // sort search results
@@ -184,6 +185,9 @@ export default class SearchPage {
     });
     this.clearNameFilterApplied = this.page.getByRole("button", {
       name: "Sheldonian Theatre, click to remove filter",
+    });
+    this.clearPublisherFilterApplied = this.page.getByRole("button", {
+      name: "Printed at the Theater,, click to remove filter",
     });
     this.clearAllFilters = this.page
       .locator("#search-filter-tags")

--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -34,6 +34,7 @@ export default class SearchPage {
   readonly publisherSelected: Locator;
   readonly divisionFilter: Locator;
   readonly divisionOption: Locator;
+  readonly divisionSelected: Locator;
   readonly typeFilter: Locator;
   readonly typeOption: Locator;
   readonly typeSelected: Locator;
@@ -47,6 +48,7 @@ export default class SearchPage {
   readonly hideFilters: Locator;
   readonly applyFilterButton: Locator;
   readonly clearFilterButton: Locator;
+  readonly clearNameFilterApplied: Locator;
   readonly clearTopicFilterApplied: Locator;
   readonly clearAllFilters: Locator;
 
@@ -90,20 +92,22 @@ export default class SearchPage {
     this.refineHeading = this.page.getByRole("heading", {
       name: "Refine your search",
     });
+
     this.topicFilter = this.page.getByRole("button", { name: "Topic" });
     this.topicOption = this.page
-      .locator("#select-topic")
+      .getByLabel("topic filter options")
       .getByText("Maps in education", { exact: true });
     this.topicSelected = this.page
-      .locator("#select-topic")
-      .getByText("Topic: Maps in education", { exact: true });
+      .getByRole("button", { name: "Select topic" })
+      .getByText("Topic: Maps in education");
+
     this.nameFilter = this.page.getByRole("button", { name: "Name" });
     this.nameOption = this.page
-      .locator("#select-name")
+      .getByLabel("name filter options")
       .getByText("Sheldonian Theatre", { exact: true });
-    this.nameSelected = this.page
-      .locator("#select-name")
-      .getByText("Name: Sheldonian Theatre", { exact: true });
+    this.nameSelected = this.page.getByText("Name: Sheldonian Theatre", {
+      exact: true,
+    });
     this.collectionFilter = this.page.getByRole("button", {
       name: "Collection",
     });
@@ -111,7 +115,7 @@ export default class SearchPage {
       .getByLabel("collection filter options")
       .getByText("Portolan atlas");
 
-    // The selected filter check below currently uses a fuzzy match
+    // The selected collection-filter check below currently uses a fuzzy match
     // because the collection UUID is appended to the
     // collectionSelected display text, which is visible to users when
     // collections have short titles. (DR-3838)
@@ -119,21 +123,39 @@ export default class SearchPage {
     this.collectionSelected = this.page.getByText("Collection: Portolan atlas");
     this.placeFilter = this.page.getByRole("button", { name: "Place" });
     this.placeOption = this.page
-      .locator("#select-place")
+      .getByLabel("place filter options")
       .getByText("England", { exact: true });
-    this.placeSelected = this.page
-      .locator("#select-place")
-      .getByText("Place: England", { exact: true });
+    this.placeSelected = this.page.getByText("Place: England", { exact: true });
     this.genreFilter = this.page.getByRole("button", { name: "Genre" });
+    this.genreOption = this.page
+      .getByLabel("genre filter options")
+      .getByText("Maps", { exact: true });
+    this.genreSelected = this.page.getByText("Genre: Maps", { exact: true });
     this.publisherFilter = this.page.getByRole("button", { name: "Publisher" });
     this.publisherOption = this.page
-      .locator("#select-publisher")
+      .getByLabel("publisher filter options")
       .getByText("Printed at the Theater,", { exact: true });
-    this.publisherSelected = this.page
-      .locator("#select-publisher")
-      .getByText("Publisher: Printed at the Theater,", { exact: true });
+    this.publisherSelected = this.page.getByText(
+      "Publisher: Printed at the Theater,",
+      { exact: true }
+    );
     this.divisionFilter = this.page.getByRole("button", { name: "Division" });
+    this.divisionOption = this.page
+      .getByLabel("division filter options")
+      .getByText("Lionel Pincus and Princess Firyal Map Division", {
+        exact: true,
+      });
+    this.divisionSelected = this.page.getByText(
+      "Division: Lionel Pincus and Princess Firyal Map Division",
+      { exact: true }
+    );
     this.typeFilter = this.page.getByRole("button", { name: "Type" });
+    this.typeOption = this.page
+      .getByLabel("type filter options")
+      .getByText("Cartographic", { exact: true });
+    this.typeSelected = this.page.getByText("Type: Cartographic", {
+      exact: true,
+    });
     this.startYear = this.page.getByRole("textbox", { name: "Start year" });
     this.endYear = this.page.getByRole("textbox", { name: "End year" });
     this.applyDates = this.page.getByRole("button", { name: "Apply dates" });
@@ -160,8 +182,8 @@ export default class SearchPage {
       name: "Clear filter",
       exact: true,
     });
-    this.clearTopicFilterApplied = this.page.getByRole("button", {
-      name: "Maps in education, click to remove filter",
+    this.clearNameFilterApplied = this.page.getByRole("button", {
+      name: "Sheldonian Theatre, click to remove filter",
     });
     this.clearAllFilters = this.page
       .locator("#search-filter-tags")
@@ -216,16 +238,16 @@ export default class SearchPage {
   }
 
   async filterSearchResults(): Promise<void> {
-    // filters a drop-down in the first row
-    await expect(this.topicFilter).toBeVisible();
-    await this.topicFilter.click();
-    await expect(this.topicOption).toBeVisible();
-    await this.topicOption.click();
+    // filters a drop-down (Name) in the first row
+    await expect(this.nameFilter).toBeVisible();
+    await this.nameFilter.click();
+    await expect(this.nameOption).toBeVisible();
+    await this.nameOption.click();
     await expect(this.applyFilterButton).toBeVisible();
     await this.applyFilterButton.click();
-    await expect(this.topicSelected).toBeVisible();
+    await expect(this.nameSelected).toBeVisible();
 
-    // filters a drop-down in the second row
+    // filters a drop-down (Publisher) in the second row
     if (await this.showFilters.isVisible()) {
       await expect(this.showFilters).toBeVisible();
       await this.showFilters.click();

--- a/playwright/tests/search-filters-modal.spec.ts
+++ b/playwright/tests/search-filters-modal.spec.ts
@@ -6,6 +6,20 @@ let searchPage: SearchPage;
 
 test.describe.serial("apply filters in open modal", () => {
   // Runs ONCE to create the shared, filtered page context.
+
+  /**
+  JUSTIFICATION FOR .serial USAGE:
+  
+  These tests intentionally use .serial to maintain browser state across multiple test steps. This deviates from Playwright's recommendation for isolated tests for the following reasons:
+  
+  1. Performance: Avoids 6 separate page loads (60% faster: 16.57s vs 26.23s)
+  2. Resource efficiency: Uses single worker instead of 6 parallel workers
+  3. User journey testing: Simulates realistic workflow of opening modal once and applying multiple filters in sequence
+  4. State accumulation: Each filter builds on previous selections
+
+  Alternative considered: Single comprehensive test, but rejected because individual filter
+  */
+
   test.beforeAll(async ({ browser }) => {
     // Manually create context/page to force serialization to remain in block
     const browserContext = await browser.newContext();

--- a/playwright/tests/search-filters-modal.spec.ts
+++ b/playwright/tests/search-filters-modal.spec.ts
@@ -7,7 +7,7 @@ let searchPage: SearchPage;
 test.describe.serial("apply filters in open modal", () => {
   // Runs ONCE to create the shared, filtered page context.
   test.beforeAll(async ({ browser }) => {
-    // Manually create context/page
+    // Manually create context/page to force serialization to remain in block
     const browserContext = await browser.newContext();
     const page = await browserContext.newPage();
 

--- a/playwright/tests/search-filters-modal.spec.ts
+++ b/playwright/tests/search-filters-modal.spec.ts
@@ -91,7 +91,7 @@ test.describe.serial("apply filters in open modal", () => {
     test("choose filter results by availability", async () => {
       await expect(searchPage.refineHeading).toBeVisible();
       await expect(searchPage.availablePublicDomain).toBeVisible();
-      await searchPage.availablePublicDomain.click();
+      await searchPage.availablePublicDomain.check();
       await expect(searchPage.availablePublicDomain).toBeChecked();
     });
   });

--- a/playwright/tests/search-filters-modal.spec.ts
+++ b/playwright/tests/search-filters-modal.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "../base";
+import SearchPage from "../pages/search.page";
+import { applyRouteFilters } from "../utils/routeFilters";
+import { Browser, Page } from "@playwright/test"; // <-- Import is only for types
+
+let searchPage: SearchPage;
+
+test.describe.serial("apply filters in open modal", () => {
+  // Runs ONCE to create the shared, filtered page context.
+  test.beforeAll(async ({ browser }) => {
+    // Manually create context/page
+    const browserContext = await browser.newContext();
+    const page = await browserContext.newPage();
+
+    // Apply global filters manually
+    await applyRouteFilters(page);
+
+    // Assign to global variable and load the page object
+    searchPage = new SearchPage(page);
+    await searchPage.loadPage(SearchPage.searchResultsUrl);
+  });
+
+  // TEARDOWN: close the entire context.
+  test.afterAll(async () => {
+    // Closes the BrowserContext, freeing up resources.
+    await searchPage.page.context().close();
+  });
+
+  test.describe.serial("choose specific filter options", () => {
+    // Go to search page once, open 2nd row, and check filters, date range and availability
+
+    test.beforeEach(async () => {
+      if (await searchPage.showFilters.isVisible()) {
+        await searchPage.showFilters.click();
+      }
+      // The state is now guaranteed to be 'open' for the test.
+      await expect(searchPage.refineHeading).toBeVisible();
+    });
+
+    // Test assertions use the globally available 'searchPage'
+    test("choose genre", async () => {
+      await expect(searchPage.genreFilter).toBeVisible();
+      await searchPage.genreFilter.click();
+      await expect(searchPage.genreOption).toBeVisible();
+      await searchPage.genreOption.check();
+      await expect(searchPage.applyFilterButton).toBeVisible();
+      await searchPage.applyFilterButton.click();
+      await expect(searchPage.genreSelected).toBeVisible();
+    });
+
+    test("choose publisher", async () => {
+      await expect(searchPage.publisherFilter).toBeVisible();
+      await searchPage.publisherFilter.click();
+      await expect(searchPage.publisherOption).toBeVisible();
+      await searchPage.publisherOption.check();
+      await expect(searchPage.applyFilterButton).toBeVisible();
+      await searchPage.applyFilterButton.click();
+      await expect(searchPage.publisherSelected).toBeVisible();
+    });
+
+    test("choose division", async () => {
+      await expect(searchPage.divisionFilter).toBeVisible();
+      await searchPage.divisionFilter.click();
+      await expect(searchPage.divisionOption).toBeVisible();
+      await searchPage.divisionOption.check();
+      await expect(searchPage.applyFilterButton).toBeVisible();
+      await searchPage.applyFilterButton.click();
+      await expect(searchPage.divisionSelected).toBeVisible();
+    });
+
+    test("choose type", async () => {
+      await expect(searchPage.typeFilter).toBeVisible();
+      await searchPage.typeFilter.click();
+      await expect(searchPage.typeOption).toBeVisible();
+      await searchPage.typeOption.check();
+      await expect(searchPage.applyFilterButton).toBeVisible();
+      await searchPage.applyFilterButton.click();
+      await expect(searchPage.typeSelected).toBeVisible();
+    });
+
+    test("choose filter results by date", async () => {
+      await expect(searchPage.startYear).toBeVisible();
+      await expect(searchPage.endYear).toBeVisible();
+      await searchPage.startYear.fill("1700");
+      await searchPage.endYear.fill("1800");
+      await expect(searchPage.applyDates).toBeVisible();
+      await searchPage.applyDates.click();
+      await expect(searchPage.startYear).toHaveValue("1700");
+      await expect(searchPage.endYear).toHaveValue("1800");
+    });
+
+    test("choose filter results by availability", async () => {
+      await expect(searchPage.refineHeading).toBeVisible();
+      await expect(searchPage.availablePublicDomain).toBeVisible();
+      await searchPage.availablePublicDomain.click();
+      await expect(searchPage.availablePublicDomain).toBeChecked();
+    });
+  });
+});

--- a/playwright/tests/search-filters-modal.spec.ts
+++ b/playwright/tests/search-filters-modal.spec.ts
@@ -89,7 +89,6 @@ test.describe.serial("apply filters in open modal", () => {
     });
 
     test("choose filter results by availability", async () => {
-      await expect(searchPage.refineHeading).toBeVisible();
       await expect(searchPage.availablePublicDomain).toBeVisible();
       await searchPage.availablePublicDomain.check();
       await expect(searchPage.availablePublicDomain).toBeChecked();

--- a/playwright/tests/search-filters-modal.spec.ts
+++ b/playwright/tests/search-filters-modal.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from "../base";
 import SearchPage from "../pages/search.page";
 import { applyRouteFilters } from "../utils/routeFilters";
-// import { Browser, Page } from "@playwright/test"; // <-- Import is only for types
 
 let searchPage: SearchPage;
 

--- a/playwright/tests/search-filters-modal.spec.ts
+++ b/playwright/tests/search-filters-modal.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "../base";
 import SearchPage from "../pages/search.page";
 import { applyRouteFilters } from "../utils/routeFilters";
-import { Browser, Page } from "@playwright/test"; // <-- Import is only for types
+// import { Browser, Page } from "@playwright/test"; // <-- Import is only for types
 
 let searchPage: SearchPage;
 

--- a/playwright/tests/search-items-result.spec.ts
+++ b/playwright/tests/search-items-result.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from "../base";
 import SearchPage from "../pages/search.page";
 import { applyRouteFilters } from "../utils/routeFilters";
-// import { Browser, Page } from "@playwright/test"; // <-- Import is only for types
 
 let searchPage: SearchPage;
 
@@ -9,7 +8,7 @@ let searchPage: SearchPage;
 test.describe.serial("find item with a basic keyword search", () => {
   // Runs ONCE to create the shared, filtered page context.
   test.beforeAll(async ({ browser }) => {
-    // Manually create context/page
+    // Manually create context/page to force serialization to remain in block
     const browserContext = await browser.newContext();
     const page = await browserContext.newPage();
 

--- a/playwright/tests/search-items-result.spec.ts
+++ b/playwright/tests/search-items-result.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "../base";
+import SearchPage from "../pages/search.page";
+import { applyRouteFilters } from "../utils/routeFilters";
+import { Browser, Page } from "@playwright/test"; // <-- Import is only for types
+
+let searchPage: SearchPage;
+
+// Do a new basic-search from the results-page
+test.describe.serial("find item with a basic keyword search", () => {
+  // Runs ONCE to create the shared, filtered page context.
+  test.beforeAll(async ({ browser }) => {
+    // Manually create context/page
+    const browserContext = await browser.newContext();
+    const page = await browserContext.newPage();
+
+    // Apply global filters manually
+    await applyRouteFilters(page);
+
+    // Assign to global variable and load the page object
+    searchPage = new SearchPage(page);
+    await searchPage.loadPage(SearchPage.searchResultsUrl);
+  });
+
+  // TEARDOWN: close the entire context.
+  test.afterAll(async () => {
+    // Closes the BrowserContext, freeing up resources.
+    await searchPage.page.context().close();
+  });
+
+  test.describe
+    .serial("verify that item in results goes to a valid page", () => {
+    test("enter keyword and submit", async () => {
+      // Test assertions use the globally available 'searchPage'
+      await expect(searchPage.searchBar).toBeVisible();
+      await searchPage.searchBar.fill(searchPage.searchKeyword);
+      await expect(searchPage.searchBar).toHaveValue(searchPage.searchKeyword);
+      await expect(searchPage.searchButton).toBeVisible();
+
+      await searchPage.searchButton.click();
+
+      // Page actions use searchPage.page
+      await searchPage.page.waitForURL("/search/**", {
+        waitUntil: "load",
+      });
+
+      await expect(searchPage.page).toHaveTitle(
+        "Search results - NYPL Digital Collections"
+      );
+    });
+
+    test("display search results with a clickable item", async () => {
+      await expect(searchPage.resultsHeading).toBeVisible();
+      await expect(searchPage.firstItemResult).toBeVisible();
+      await expect(searchPage.firstKeywordResult).toContainText(
+        searchPage.searchKeyword,
+        {
+          ignoreCase: true,
+        }
+      );
+      await searchPage.firstItemResult.click();
+      await expect(searchPage.page).toHaveURL(/\/(items)\//);
+      await expect(searchPage.refineHeading).not.toBeVisible();
+    });
+  });
+});

--- a/playwright/tests/search-items-result.spec.ts
+++ b/playwright/tests/search-items-result.spec.ts
@@ -7,6 +7,20 @@ let searchPage: SearchPage;
 // Do a new basic-search from the results-page
 test.describe.serial("find item with a basic keyword search", () => {
   // Runs ONCE to create the shared, filtered page context.
+
+  /**
+  JUSTIFICATION FOR .serial USAGE:
+  
+  These tests intentionally use .serial to maintain browser state across multiple test steps. This deviates from Playwright's recommendation for isolated tests for the following reasons:
+  
+  1. Performance: Avoids 6 separate page loads (60% faster: 16.57s vs 26.23s)
+  2. Resource efficiency: Uses single worker instead of 6 parallel workers
+  3. User journey testing: Simulates realistic workflow of opening modal once and applying multiple filters in sequence
+  4. State accumulation: Each filter builds on previous selections
+
+  Alternative considered: Single comprehensive test, but rejected because individual filter
+  */
+
   test.beforeAll(async ({ browser }) => {
     // Manually create context/page to force serialization to remain in block
     const browserContext = await browser.newContext();

--- a/playwright/tests/search-items-result.spec.ts
+++ b/playwright/tests/search-items-result.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "../base";
 import SearchPage from "../pages/search.page";
 import { applyRouteFilters } from "../utils/routeFilters";
-import { Browser, Page } from "@playwright/test"; // <-- Import is only for types
+// import { Browser, Page } from "@playwright/test"; // <-- Import is only for types
 
 let searchPage: SearchPage;
 

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -237,11 +237,11 @@ test.describe("clears search results filters", () => {
     const searchPage = new SearchPage(page);
     await expect(searchPage.refineHeading).toBeVisible();
 
-    await searchPage.filterSearchResults(); // reset filters to topic and publisher
+    await searchPage.filterSearchResults(); // reset filters to name and publisher
 
-    await expect(searchPage.clearTopicFilterApplied).toBeVisible();
-    await searchPage.clearTopicFilterApplied.click();
-    await expect(searchPage.topicSelected).not.toBeVisible();
+    await expect(searchPage.clearNameFilterApplied).toBeVisible();
+    await searchPage.clearNameFilterApplied.click();
+    await expect(searchPage.nameSelected).not.toBeVisible();
   });
 });
 

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../base";
 import SearchPage from "../pages/search.page";
 
 test.beforeEach(async ({ page }, testInfo) => {
@@ -226,11 +226,11 @@ test.describe("clears search results filters", () => {
 
     await searchPage.filterSearchResults(); // reset filters to topic and publisher
 
-    await expect(searchPage.topicFilter).toBeVisible();
-    await searchPage.topicFilter.click();
+    await expect(searchPage.nameFilter).toBeVisible();
+    await searchPage.nameFilter.click();
     await expect(searchPage.clearFilterButton).toBeVisible();
     await searchPage.clearFilterButton.click();
-    await expect(searchPage.topicSelected).not.toBeVisible();
+    await expect(searchPage.nameSelected).not.toBeVisible();
   });
 
   test("clears one filter in Filters Applied", async ({ page }) => {

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -212,20 +212,18 @@ test.describe("clears search results filters", () => {
     const searchPage = new SearchPage(page);
     await expect(searchPage.refineHeading).toBeVisible();
 
-    await searchPage.filterSearchResults(); // reset filters to topic and publisher
+    await searchPage.filterSearchResults(); // reset filters to name and publisher
 
     await expect(searchPage.clearAllFilters).toBeVisible();
     await searchPage.clearAllFilters.click();
-    await expect(searchPage.topicSelected).not.toBeVisible();
+    await expect(searchPage.nameSelected).not.toBeVisible();
     await expect(searchPage.publisherSelected).not.toBeVisible();
   });
 
   test("clears drop-down filter", async ({ page }) => {
     const searchPage = new SearchPage(page);
     await expect(searchPage.refineHeading).toBeVisible();
-
-    await searchPage.filterSearchResults(); // reset filters to topic and publisher
-
+    await searchPage.filterSearchResults(); // reset filters to name and publisher
     await expect(searchPage.nameFilter).toBeVisible();
     await searchPage.nameFilter.click();
     await expect(searchPage.clearFilterButton).toBeVisible();
@@ -242,6 +240,7 @@ test.describe("clears search results filters", () => {
     await expect(searchPage.clearNameFilterApplied).toBeVisible();
     await searchPage.clearNameFilterApplied.click();
     await expect(searchPage.nameSelected).not.toBeVisible();
+    await expect(searchPage.clearPublisherFilterApplied).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3796](https://newyorkpubliclibrary.atlassian.net/browse/DR-3796)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

This PR updates the reverted [PR-478](https://github.com/NYPL/digital-collections/pull/478).  I've also added a missing conditional check on "Applied Filters" to verify the correct filter remains "active/visible" in the "Applied Filters" section after the other is closed.

Otherwise this is the same set of tests that were added in the original PR.   I'm mainly just "reverting the revert" on a new branch from qa, and pulling in the test-files from the original PR-478.  Any questions/comments either carried over from the closed PR-478 or new can go in this PR.

## Open questions

<!-- Any questions you want to ask the reviewer? -->
Mostly covered in the approved, prior [PR-478](https://github.com/NYPL/digital-collections/pull/478). 

It should be noted there is a manual page/browser object required to enforce the serial behavior that we are using in two of the spec files (search-filters-modal.spec.ts and search-items-result.spec.ts).  The other "main" spec file, search.spec.ts, uses the POM page import conventionally since the serialization is isolated to the two other "search-<type>" specs.

## How has this been tested? How should a reviewer test this?

Ran the suite against qa-collections-api and ran it on a prod build and a dev build.

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3796]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ