### PR TITLE
[DRAFT] NO-REF: Stabilize Playwright tests on ci

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,8 +14,8 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./playwright",
-  timeout: 30000, // default timeout for each test
-  expect: { timeout: 20000 }, // default timeout for each expect assertion
+  timeout: 60000, // default timeout for each test
+  expect: { timeout: 45000 }, // default timeout for each expect assertion
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright/base.ts
+++ b/playwright/base.ts
@@ -23,4 +23,15 @@ export const test = base.extend<RouteFilterFixtures>({
   ],
 });
 
+// Teardown with global afterEach cleanup hook
+test.afterEach(async ({ page }) => {
+  // 1. Clear session and cookies (Using compatible explicit calls)
+  await page.context().clearCookies();
+  await page.evaluate(() => window.localStorage.clear());
+  await page.evaluate(() => window.sessionStorage.clear());
+
+  // 2. Remove all network interception rules (Using the correct method)
+  await page.unrouteAll();
+});
+
 export { expect } from "@playwright/test";

--- a/playwright/base.ts
+++ b/playwright/base.ts
@@ -25,12 +25,12 @@ export const test = base.extend<RouteFilterFixtures>({
 
 // Teardown with global afterEach cleanup hook
 test.afterEach(async ({ page }) => {
-  // 1. Clear session and cookies (Using compatible explicit calls)
+  // 1. Clear session and cookies with explicit calls
   await page.context().clearCookies();
   await page.evaluate(() => window.localStorage.clear());
   await page.evaluate(() => window.sessionStorage.clear());
 
-  // 2. Remove all network interception rules (Using the correct method)
+  // 2. Remove all network interception rules
   await page.unrouteAll();
 });
 

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -118,7 +118,7 @@ test.describe("displays specific filter options", () => {
 
     await expect(searchPage.topicFilter).toBeVisible();
     await searchPage.topicFilter.click();
-    await expect(searchPage.topicOption).toBeVisible({ timeout: 20000 });
+    await expect(searchPage.topicOption).toBeVisible();
     await searchPage.topicOption.click();
     await expect(searchPage.applyFilterButton).toBeVisible();
     await searchPage.applyFilterButton.click();
@@ -253,9 +253,8 @@ test.describe("sorts search results", () => {
     await expect(searchPage.sortByNewest).toBeVisible();
     await expect(searchPage.sortByOldest).toBeVisible();
     await searchPage.sortByNewest.click();
-    await expect(searchPage.sortByNewestSelected).toBeVisible({
-      timeout: 20000,
-    });
+    await searchPage.sortByNewest.waitFor({ state: "hidden" });
+    await expect(searchPage.sortByNewestSelected).toBeVisible();
   });
 
   test("sorts search results alphabetically", async ({ page }) => {
@@ -266,6 +265,7 @@ test.describe("sorts search results", () => {
     await expect(searchPage.sortByAlpha).toBeVisible();
     await expect(searchPage.sortByReverseAlpha).toBeVisible();
     await searchPage.sortByAlpha.click();
+    await searchPage.sortByAlpha.waitFor({ state: "hidden" });
     await expect(searchPage.sortByAlphaSelected).toBeVisible();
   });
 
@@ -277,6 +277,7 @@ test.describe("sorts search results", () => {
     await expect(searchPage.sortByCollections).toBeVisible();
     await expect(searchPage.sortByItems).toBeVisible();
     await searchPage.sortByCollections.click();
+    await searchPage.sortByCollections.waitFor({ state: "hidden" });
     await expect(searchPage.sortByCollectionsSelected).toBeVisible();
   });
 


### PR DESCRIPTION
## Ticket:

- No JIRA ticket 

## This PR does the following:
<!-- What has been updated or added in this PR? -->
This PR addresses persistent test flakiness and timeout failures observed in the CI pipeline, especially under resource-constrained (`--workers=2`) environments.

**1. Synchronization of waits**: Adds targeted `waitFor({ state: 'hidden' })` calls after key data-altering clicks (e.g., sorting). This forces Playwright to wait for the UI to settle after an asynchronous action, eliminating timeouts observed on the 2-worker test-suite runs for the existing search.spec file.

**2. Standardize Timeout Buffer**: Increases the global `expect` action timeout in playwright.config.ts to 45000ms. This prevents the entire test run from failing due to the slow server response time experienced under low CI concurrency. Overall timeout also increased to 60000ms.  This is not a hard wait, it just allows the test-run to have a better chance at succeeding in the _first_ run so that time-consuming retries are not occurring as often on the CI.

**3. Code Cleanup**: Removes conflicting, hardcoded local timeouts from search.spec.ts.


## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Run this on localhost with 2 workers (eg. `npx playwright test --workers=2`) and with 6 workers against a prod build (`npm run build`).  Before the code-changes, the 2 worker test-runs consistently were timing out/failing on the sort-result blocks in the search.spec file, whether it was ran alone or as part of a suite.

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
