### PR TITLE
Dr 3796 Fix failing tests on CI

### DIFF
--- a/playwright/tests/search-filters-sort.spec.ts
+++ b/playwright/tests/search-filters-sort.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "../base";
+import SearchPage from "../pages/search.page";
+
+let searchPage: SearchPage;
+
+test.describe.serial("choose specific sort options", () => {
+  test.beforeEach(async ({ page }) => {
+    searchPage = new SearchPage(page);
+    await searchPage.loadPage(SearchPage.searchResultsUrl);
+
+    await searchPage.sortButton.click();
+
+    await expect(searchPage.refineHeading).toBeVisible();
+  });
+
+  test("sorts search results by relevance", async ({ page }) => {
+    // await searchPage.sortButton.click();
+    await expect(searchPage.sortByRelevance).toBeVisible();
+    await searchPage.sortByRelevance.click({ force: true });
+    await expect(searchPage.sortByRelevanceSelected).toBeVisible({
+      timeout: 20000,
+    });
+  });
+
+  test("sorts search results by age", async ({ page }) => {
+    // const searchPage = new SearchPage(page);
+    await expect(searchPage.sortByNewest).toBeVisible();
+    await expect(searchPage.sortByOldest).toBeVisible();
+    await searchPage.sortByNewest.click({ force: true });
+    await expect(searchPage.sortByNewestSelected).toBeVisible({
+      timeout: 20000,
+    });
+  });
+
+  test("sorts search results alphabetically", async ({ page }) => {
+    // const searchPage = new SearchPage(page);
+    await expect(searchPage.sortByAlpha).toBeVisible();
+    await expect(searchPage.sortByReverseAlpha).toBeVisible();
+    await searchPage.sortByAlpha.click({ force: true });
+    await expect(searchPage.sortByAlphaSelected).toBeVisible({
+      timeout: 20000,
+    });
+  });
+
+  test("sorts search results by type", async ({ page }) => {
+    // const searchPage = new SearchPage(page);
+    await expect(searchPage.sortByCollections).toBeVisible();
+    await expect(searchPage.sortByItems).toBeVisible();
+    await searchPage.sortByCollections.click({ force: true });
+    await expect(searchPage.sortByCollectionsSelected).toBeVisible({
+      timeout: 20000,
+    });
+  });
+});

--- a/playwright/tests/search-filters-sort.spec.ts
+++ b/playwright/tests/search-filters-sort.spec.ts
@@ -3,7 +3,7 @@ import SearchPage from "../pages/search.page";
 
 let searchPage: SearchPage;
 
-test.describe.serial("choose specific sort options", () => {
+test.describe("choose specific sort options", () => {
   test.beforeEach(async ({ page }) => {
     searchPage = new SearchPage(page);
     await searchPage.loadPage(SearchPage.searchResultsUrl);

--- a/playwright/tests/search-filters-sort.spec.ts
+++ b/playwright/tests/search-filters-sort.spec.ts
@@ -14,7 +14,6 @@ test.describe.serial("choose specific sort options", () => {
   });
 
   test("sorts search results by relevance", async ({ page }) => {
-    // await searchPage.sortButton.click();
     await expect(searchPage.sortByRelevance).toBeVisible();
     await searchPage.sortByRelevance.click({ force: true });
     await expect(searchPage.sortByRelevanceSelected).toBeVisible({
@@ -23,7 +22,6 @@ test.describe.serial("choose specific sort options", () => {
   });
 
   test("sorts search results by age", async ({ page }) => {
-    // const searchPage = new SearchPage(page);
     await expect(searchPage.sortByNewest).toBeVisible();
     await expect(searchPage.sortByOldest).toBeVisible();
     await searchPage.sortByNewest.click({ force: true });
@@ -33,7 +31,6 @@ test.describe.serial("choose specific sort options", () => {
   });
 
   test("sorts search results alphabetically", async ({ page }) => {
-    // const searchPage = new SearchPage(page);
     await expect(searchPage.sortByAlpha).toBeVisible();
     await expect(searchPage.sortByReverseAlpha).toBeVisible();
     await searchPage.sortByAlpha.click({ force: true });
@@ -43,7 +40,6 @@ test.describe.serial("choose specific sort options", () => {
   });
 
   test("sorts search results by type", async ({ page }) => {
-    // const searchPage = new SearchPage(page);
     await expect(searchPage.sortByCollections).toBeVisible();
     await expect(searchPage.sortByItems).toBeVisible();
     await searchPage.sortByCollections.click({ force: true });

--- a/playwright/tests/search.spec.ts
+++ b/playwright/tests/search.spec.ts
@@ -244,53 +244,6 @@ test.describe("clears search results filters", () => {
   });
 });
 
-test.describe("sorts search results", () => {
-  test("sorts search results by age", async ({ page }) => {
-    const searchPage = new SearchPage(page);
-    await expect(searchPage.resultsHeading).toBeVisible();
-    await expect(searchPage.sortButton).toBeVisible();
-    await searchPage.sortButton.click();
-    await expect(searchPage.sortByNewest).toBeVisible();
-    await expect(searchPage.sortByOldest).toBeVisible();
-    await searchPage.sortByNewest.click();
-    await expect(searchPage.sortByNewestSelected).toBeVisible({
-      timeout: 20000,
-    });
-  });
-
-  test("sorts search results alphabetically", async ({ page }) => {
-    const searchPage = new SearchPage(page);
-    await expect(searchPage.resultsHeading).toBeVisible();
-    await expect(searchPage.sortButton).toBeVisible();
-    await searchPage.sortButton.click();
-    await expect(searchPage.sortByAlpha).toBeVisible();
-    await expect(searchPage.sortByReverseAlpha).toBeVisible();
-    await searchPage.sortByAlpha.click();
-    await expect(searchPage.sortByAlphaSelected).toBeVisible();
-  });
-
-  test("sorts search results by type", async ({ page }) => {
-    const searchPage = new SearchPage(page);
-    await expect(searchPage.resultsHeading).toBeVisible();
-    await expect(searchPage.sortButton).toBeVisible();
-    await searchPage.sortButton.click();
-    await expect(searchPage.sortByCollections).toBeVisible();
-    await expect(searchPage.sortByItems).toBeVisible();
-    await searchPage.sortByCollections.click();
-    await expect(searchPage.sortByCollectionsSelected).toBeVisible();
-  });
-
-  test("sorts search results by relevance", async ({ page }) => {
-    const searchPage = new SearchPage(page);
-    await expect(searchPage.resultsHeading).toBeVisible();
-    await expect(searchPage.sortButton).toBeVisible();
-    await searchPage.sortButton.click();
-    await expect(searchPage.sortByRelevance).toBeVisible();
-    await searchPage.sortByRelevance.click();
-    await expect(searchPage.sortByRelevanceSelected).toBeVisible();
-  });
-});
-
 test.describe("clicks on an item in search results", () => {
   test("clicks on an item in unfiltered search results", async ({ page }) => {
     const searchPage = new SearchPage(page);


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3796](https://newyorkpubliclibrary.atlassian.net/browse/DR-3796)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

This PR moves the brittle (when run on the CI) sort-filter tests into their own test file, s**earch-filters-sort.spec.ts**.  Although I've attached it to the DR-3796 ticket (where the sort-filters revisions originated), the purpose of this work is to stabilize our CI runs, which have been consistently failing this week only on the sort tests.

After attacking this from a timing angle first, I found that what was really going on was that the CI "viewport" is often pretty crummy in a headless environment, so Playwright _thinks_ it's not seeing visible states that are really there in the DOM.   And so a `.click()` event can fail because Playwright doesn't "see" the locator on the CI.

It turns out that using `click( {force: true} )` is sort of a magic bullet when applied in these scenarios.   After I added this to the sort filter tests, they immediately stopped failing under the `--workers=2` flag that the CI runs under.

I'm going to keep the sort-results isolated to their own file, because they do also do some heavy-lifting in terms of their conditional checks that rely on a fully loaded new results set each time.  But with the `force: true` in my toolkit now, these kinds of brittle CI scenarios are hopefully something we'll see less of.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3796]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ