### PR TITLE
Dr-3900 - Item fields: collection

### DIFF
--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -11,8 +11,9 @@ export default class ItemMetadataPage {
   readonly titleText: Locator;
   readonly collectionHeading: Locator;
   readonly collectionText: Locator;
-  readonly collectionLink: Locator;
   // there are multiple links on collection that we'll need to test
+  readonly collectionRootLink: Locator;
+  readonly collectionLevelOneLink: Locator;
   readonly datesHeading: Locator;
   readonly datesText: Locator;
   readonly datesLink: Locator;
@@ -44,6 +45,9 @@ export default class ItemMetadataPage {
   static readonly EXPECTED_OCLC_VALUE = "24501668";
   static readonly EXPECTED_BNUMBER_VALUE = "b14924644";
   static readonly EXPECTED_SHELF_LOCATOR_VALUE = "Map Div. 97-6199 [LHS 839]";
+  static readonly EXPECTED_COLLECTION_ROOT_VALUE =
+    "Lawrence H. Slaughter Collection of English maps, charts, globes, books and atlases";
+  static readonly EXPECTED_COLLECTION_LEVEL_ONE_VALUE = "Charts and maps";
   readonly rightsHeading: Locator;
   readonly rightsText: Locator;
   readonly dataSourceHeading: Locator;
@@ -56,16 +60,18 @@ export default class ItemMetadataPage {
     // This finds the specific <p> element containing 'Title'
     this.titleHeading = this.page.getByText("Title", { exact: true });
 
-    // Defines the TARGET (the content right after the header)
     // This is the relative locator that enforces the structural relationship.
     this.titleText = this.titleHeading.locator("+ p");
+
+    // Identifiers
+    this.identifiersHeading = this.page.getByText("Identifiers", {
+      exact: true,
+    });
+    this.identifiersText = this.identifiersHeading.locator("+ p");
 
     // Collection
     this.collectionHeading = this.page.getByText("Collection", { exact: true });
     this.collectionText = this.collectionHeading.locator("+ p");
-    this.collectionLink = this.collectionText.getByRole("link").first(); // Target the link within the following paragraph
-
-    this.collectionLink = this.collectionText.getByRole("link").first(); // Target the link within the following paragraph
 
     // Dates/Origin  (this can be Dates or Date?)
     this.datesHeading = this.page.getByText("Dates/Origin", { exact: true });
@@ -192,6 +198,30 @@ export default class ItemMetadataPage {
     // confirms the text value includes the Call Number.
     await expect(this.shelfLocatorText).toContainText(
       ItemMetadataPage.EXPECTED_SHELF_LOCATOR_VALUE
+    );
+  }
+
+  async verifyCollectionRootLink(): Promise<void> {
+    // check for the main link
+    const collectionRootLinkLocator = this.collectionText
+      .getByRole("link")
+      .nth(0);
+
+    await expect(collectionRootLinkLocator).toBeVisible();
+    await expect(collectionRootLinkLocator).toHaveText(
+      ItemMetadataPage.EXPECTED_COLLECTION_ROOT_VALUE
+    );
+  }
+
+  async verifyCollectionLevelOneLink(): Promise<void> {
+    // check for the second link
+    const collectionLevelOneLinkLocator = this.collectionText
+      .getByRole("link")
+      .nth(1);
+
+    await expect(collectionLevelOneLinkLocator).toBeVisible();
+    await expect(collectionLevelOneLinkLocator).toHaveText(
+      ItemMetadataPage.EXPECTED_COLLECTION_LEVEL_ONE_VALUE
     );
   }
 

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -25,7 +25,7 @@ test.describe("Verify Metadata Fields", () => {
       await itemMetadataPage.verifyCollectionRootLink();
     });
 
-    test("should include sub-collection link, if present", async () => {
+    test("should include sub-collection link", async () => {
       await itemMetadataPage.verifyCollectionLevelOneLink();
     });
   });
@@ -41,18 +41,18 @@ test.describe("Verify Metadata Fields", () => {
       await itemMetadataPage.verifyUUIDIdentifierIsPresent();
     });
 
-    test("should include RLIN/OCLC identifier if present", async () => {
+    test("should include RLIN/OCLC identifier", async () => {
       await itemMetadataPage.verifyOclcIdentifierIsPresent();
     });
 
-    test("should include the NYPL Catalog Link if present", async () => {
+    test("should include the NYPL Catalog Link", async () => {
       await itemMetadataPage.verifyCatalogLinkIsPresent();
     });
   });
 });
 
 test.describe("Other Identifiers", () => {
-  test("should include Shelf Locator if present", async () => {
+  test("should include Shelf Locator", async () => {
     await itemMetadataPage.verifyShelfLocatorIsPresent();
   });
 });

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -14,6 +14,22 @@ test.describe("Metadata Fields", () => {
     await itemMetadataPage.verifyTitleTextContent();
   });
 
+  test.describe("Collection", () => {
+    test.beforeEach(async () => {
+      // Verify collection heading and containers before checking content
+      await expect(itemMetadataPage.collectionHeading).toBeVisible();
+      await expect(itemMetadataPage.collectionText).toBeVisible();
+    });
+
+    test("should include main/root collection link", async () => {
+      await itemMetadataPage.verifyCollectionRootLink();
+    });
+
+    test("should include sub-collection link, if present", async () => {
+      await itemMetadataPage.verifyCollectionLevelOneLink();
+    });
+  });
+
   test.describe("Identifiers", () => {
     test.beforeEach(async () => {
       // Verify identifiers heading and containers before checking content
@@ -32,6 +48,25 @@ test.describe("Metadata Fields", () => {
     test("should include the NYPL Catalog Link if present", async () => {
       await itemMetadataPage.verifyCatalogLinkIsPresent();
     });
+  });
+  test.describe("Collection/Titles", () => {
+    test.beforeEach(async () => {
+      // Verify collections heading and containers before checking content
+      await expect(itemMetadataPage.collectionHeading).toBeVisible();
+      await expect(itemMetadataPage.collectionText).toBeVisible();
+    });
+
+    // test("should include UUID", async () => {
+    //   await itemMetadataPage.verifyUUIDIdentifierIsPresent();
+    // });
+
+    // test("should include RLIN/OCLC identifier if present", async () => {
+    //   await itemMetadataPage.verifyOclcIdentifierIsPresent();
+    // });
+
+    // test("should include the NYPL Catalog Link if present", async () => {
+    //   await itemMetadataPage.verifyCatalogLinkIsPresent();
+    // });
   });
 });
 

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -49,25 +49,6 @@ test.describe("Metadata Fields", () => {
       await itemMetadataPage.verifyCatalogLinkIsPresent();
     });
   });
-  test.describe("Collection/Titles", () => {
-    test.beforeEach(async () => {
-      // Verify collections heading and containers before checking content
-      await expect(itemMetadataPage.collectionHeading).toBeVisible();
-      await expect(itemMetadataPage.collectionText).toBeVisible();
-    });
-
-    // test("should include UUID", async () => {
-    //   await itemMetadataPage.verifyUUIDIdentifierIsPresent();
-    // });
-
-    // test("should include RLIN/OCLC identifier if present", async () => {
-    //   await itemMetadataPage.verifyOclcIdentifierIsPresent();
-    // });
-
-    // test("should include the NYPL Catalog Link if present", async () => {
-    //   await itemMetadataPage.verifyCatalogLinkIsPresent();
-    // });
-  });
 });
 
 test.describe("Other Identifiers", () => {

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -8,7 +8,7 @@ test.beforeEach(async ({ page }) => {
   await itemMetadataPage.loadPage(ItemMetadataPage.itemResultURL);
 });
 
-test.describe("Metadata Fields", () => {
+test.describe("Verify Metadata Fields", () => {
   test("should display Title heading and corresponding text", async () => {
     await expect(itemMetadataPage.titleHeading).toBeVisible();
     await itemMetadataPage.verifyTitleTextContent();


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3900](https://newyorkpubliclibrary.atlassian.net/browse/DR-3900)

## This PR does the following:

Adds field-checking for the expected two-level links under the "Collection" section for this known sample-record. 

## Open questions

There will be link-checking added, probably via a flexible helper, in the next PR following this one, since many, if not most, of the remaining field "checks" will have active links (like the "Collection fields" do).   The goal of the link-checking will be to verify that the links go to valid (ie not "No Results") pages in DC.

## How has this been tested? How should a reviewer test this?

Ran the tests on a local prod build with the `--workers=2` flag set.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3900]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ