### PR TITLE
Dr 3900 - Item fields: names

### DIFF
--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -52,6 +52,7 @@ export default class ItemMetadataPage {
   static readonly EXPECTED_COLLECTION_ROOT_VALUE =
     "Lawrence H. Slaughter Collection of English maps, charts, globes, books and atlases";
   static readonly EXPECTED_COLLECTION_LEVEL_ONE_VALUE = "Charts and maps";
+  static readonly EXPECTED_NAME_COUNT = 2;
   static readonly EXPECTED_NAME_ONE_VALUE = "Ratzer, Bernard";
   static readonly EXPECTED_NAME_ONE_ROLE_VALUE = "(Cartographer)";
   static readonly EXPECTED_NAME_TWO_ROLE_VALUE = "Kitchin, Thomas, 1718-1784";
@@ -229,9 +230,70 @@ export default class ItemMetadataPage {
     );
   }
 
-  async verifyNameFieldValues(): Promise<void> {
-    // something will go here
+  async verifyNameFieldList(): Promise<void> {
+    // Find all name entry containers
+    const allNameEntryContainers = this.nameText.locator(":scope > *");
+
+    // If the item returns less/more than the expected nodes, this line fails immediately.
+    await expect(allNameEntryContainers).toHaveCount(
+      ItemMetadataPage.EXPECTED_NAME_COUNT
+    );
   }
+
+  async verifyNameOneValue(): Promise<void> {
+    // Locate the specific name link
+    const nameOneLink = this.nameText.getByRole("link").nth(0);
+
+    // Assert Link Content (Value Check)
+    await expect(nameOneLink).toBeVisible();
+    await expect(nameOneLink).toHaveText(
+      ItemMetadataPage.EXPECTED_NAME_ONE_VALUE
+    );
+  }
+
+  async verifyNameOneRole(): Promise<void> {
+    // Locate the parent container using its structural selector
+    const nameOneEntryContainer = this.nameText.locator(":scope > *").nth(0);
+
+    // Check the full container text for the ROLE.
+    const fullExpectedText = `${ItemMetadataPage.EXPECTED_NAME_ONE_VALUE} ${ItemMetadataPage.EXPECTED_NAME_ONE_ROLE_VALUE}`;
+
+    // We use toContainText to ensure the role text follows the name correctly within the <span> container.
+    await expect(nameOneEntryContainer).toContainText(fullExpectedText);
+  }
+
+  async verifyNameTwoValue(): Promise<void> {
+    const nameTwoLink = this.nameText.getByRole("link").nth(1);
+
+    await expect(nameTwoLink).toBeVisible();
+    await expect(nameTwoLink).toHaveText(
+      ItemMetadataPage.EXPECTED_NAME_TWO_VALUE
+    );
+  }
+
+  async verifyNameTwoRole(): Promise<void> {
+    const nameTwoEntryContainer = this.nameText.locator(":scope > *").nth(1);
+    const fullExpectedText = `${ItemMetadataPage.EXPECTED_NAME_TWO_VALUE} ${ItemMetadataPage.EXPECTED_NAME_TWO_ROLE_VALUE}`;
+
+    await expect(nameTwoEntryContainer).toContainText(fullExpectedText);
+  }
+
+  // async verifyNameTwoLinkAndRole(): Promise<void> {
+
+  //   const nameTwoLink = this.nameText.getByRole("link").nth(1);
+  //   const nameTwoEntryContainer = this.nameText.locator(':scope > *').nth(1);
+
+  //   await expect(nameTwoLink).toBeVisible()
+  //   await expect(nameTwoLink).toHaveText(
+  //     ItemMetadataPage.EXPECTED_NAME_TWO_VALUE,
+  //   );
+
+  //   const fullExpectedText = `${ItemMetadataPage.EXPECTED_NAME_TWO_VALUE} ${ItemMetadataPage.EXPECTED_NAME_TWO_ROLE_VALUE}`;
+
+  //   await expect(nameTwoEntryContainer).toContainText(
+  //     fullExpectedText,
+  //   );
+  // }
 
   async verifyRightsContent(): Promise<void> {
     // Structural check: Ensure the element exists and is visible

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -55,8 +55,8 @@ export default class ItemMetadataPage {
   static readonly EXPECTED_NAME_COUNT = 2;
   static readonly EXPECTED_NAME_ONE_VALUE = "Ratzer, Bernard";
   static readonly EXPECTED_NAME_ONE_ROLE_VALUE = "(Cartographer)";
-  static readonly EXPECTED_NAME_TWO_ROLE_VALUE = "Kitchin, Thomas, 1718-1784";
-  static readonly EXPECTED_NAME_TWO_VALUE = "(Engraver)";
+  static readonly EXPECTED_NAME_TWO_VALUE = "Kitchin, Thomas, 1718-1784";
+  static readonly EXPECTED_NAME_TWO_ROLE_VALUE = "(Engraver)";
 
   constructor(page: Page) {
     this.page = page;
@@ -230,6 +230,17 @@ export default class ItemMetadataPage {
     );
   }
 
+  /**
+   * Enforces a patient wait for the Names section heading to be structurally attached
+   * to the DOM, compensating for asynchronous loading delays.
+   */
+
+  // DIDN'T WORK:
+  // async waitForNamesSection(): Promise<void> {
+  //     // Use the explicit wait for attachment/visibility with a long timeout
+  //     await this.nameHeading.waitFor({ state: 'attached', timeout: 45000 });
+  // }
+
   async verifyNameFieldList(): Promise<void> {
     // Find all name entry containers
     const allNameEntryContainers = this.nameText.locator(":scope > *");
@@ -308,4 +319,10 @@ export default class ItemMetadataPage {
   async loadPage(gotoPage: string): Promise<void> {
     await this.page.goto(gotoPage);
   }
+
+  // async loadPage(gotoPage: string): Promise<void> {
+  //   // Force Playwright to wait only for the core DOM and JS execution,
+  //   // ignoring slow assets like the Universal Viewer.
+  //   await this.page.goto(gotoPage, { waitUntil: 'domcontentloaded' });
+  // }
 }

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -98,19 +98,19 @@ export default class ItemMetadataPage {
       .getByText(/Shelf locator:/i);
 
     // Topics
-    this.topicHeading = this.page.getByText("Topic", { exact: true });
+    this.topicHeading = this.page.getByText("Topics", { exact: true });
     this.topicText = this.topicHeading.locator("+ p");
 
     // Name (Creator/Author)
-    this.nameHeading = this.page.getByText("Name", { exact: true });
+    this.nameHeading = this.page.getByText("Names", { exact: true });
     this.nameText = this.nameHeading.locator("+ p");
 
     // Place/Geographic
-    this.placeHeading = this.page.getByText("Place", { exact: true });
+    this.placeHeading = this.page.getByText("Places", { exact: true });
     this.placeText = this.placeHeading.locator("+ p");
 
     // Genre
-    this.genreHeading = this.page.getByText("Genre", { exact: true });
+    this.genreHeading = this.page.getByText("Genres", { exact: true });
     this.genreText = this.genreHeading.locator("+ p");
 
     // Notes
@@ -230,20 +230,9 @@ export default class ItemMetadataPage {
     );
   }
 
-  /**
-   * Enforces a patient wait for the Names section heading to be structurally attached
-   * to the DOM, compensating for asynchronous loading delays.
-   */
-
-  // DIDN'T WORK:
-  // async waitForNamesSection(): Promise<void> {
-  //     // Use the explicit wait for attachment/visibility with a long timeout
-  //     await this.nameHeading.waitFor({ state: 'attached', timeout: 45000 });
-  // }
-
   async verifyNameFieldList(): Promise<void> {
     // Find all name entry containers
-    const allNameEntryContainers = this.nameText.locator(":scope > *");
+    const allNameEntryContainers = this.nameText.locator("span");
 
     // If the item returns less/more than the expected nodes, this line fails immediately.
     await expect(allNameEntryContainers).toHaveCount(
@@ -264,7 +253,7 @@ export default class ItemMetadataPage {
 
   async verifyNameOneRole(): Promise<void> {
     // Locate the parent container using its structural selector
-    const nameOneEntryContainer = this.nameText.locator(":scope > *").nth(0);
+    const nameOneEntryContainer = this.nameText.locator("span").nth(0);
 
     // Check the full container text for the ROLE.
     const fullExpectedText = `${ItemMetadataPage.EXPECTED_NAME_ONE_VALUE} ${ItemMetadataPage.EXPECTED_NAME_ONE_ROLE_VALUE}`;
@@ -283,28 +272,11 @@ export default class ItemMetadataPage {
   }
 
   async verifyNameTwoRole(): Promise<void> {
-    const nameTwoEntryContainer = this.nameText.locator(":scope > *").nth(1);
+    const nameTwoEntryContainer = this.nameText.locator("span").nth(1);
     const fullExpectedText = `${ItemMetadataPage.EXPECTED_NAME_TWO_VALUE} ${ItemMetadataPage.EXPECTED_NAME_TWO_ROLE_VALUE}`;
 
     await expect(nameTwoEntryContainer).toContainText(fullExpectedText);
   }
-
-  // async verifyNameTwoLinkAndRole(): Promise<void> {
-
-  //   const nameTwoLink = this.nameText.getByRole("link").nth(1);
-  //   const nameTwoEntryContainer = this.nameText.locator(':scope > *').nth(1);
-
-  //   await expect(nameTwoLink).toBeVisible()
-  //   await expect(nameTwoLink).toHaveText(
-  //     ItemMetadataPage.EXPECTED_NAME_TWO_VALUE,
-  //   );
-
-  //   const fullExpectedText = `${ItemMetadataPage.EXPECTED_NAME_TWO_VALUE} ${ItemMetadataPage.EXPECTED_NAME_TWO_ROLE_VALUE}`;
-
-  //   await expect(nameTwoEntryContainer).toContainText(
-  //     fullExpectedText,
-  //   );
-  // }
 
   async verifyRightsContent(): Promise<void> {
     // Structural check: Ensure the element exists and is visible
@@ -319,10 +291,4 @@ export default class ItemMetadataPage {
   async loadPage(gotoPage: string): Promise<void> {
     await this.page.goto(gotoPage);
   }
-
-  // async loadPage(gotoPage: string): Promise<void> {
-  //   // Force Playwright to wait only for the core DOM and JS execution,
-  //   // ignoring slow assets like the Universal Viewer.
-  //   await this.page.goto(gotoPage, { waitUntil: 'domcontentloaded' });
-  // }
 }

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -84,12 +84,6 @@ export default class ItemMetadataPage {
     { name: "Kitchin, Thomas, 1718-1784", role: "Engraver" },
   ];
 
-  static readonly EXPECTED_NAME_COUNT = 2;
-  static readonly EXPECTED_NAME_ONE_VALUE = "Ratzer, Bernard";
-  static readonly EXPECTED_NAME_ONE_ROLE_VALUE = "(Cartographer)";
-  static readonly EXPECTED_NAME_TWO_VALUE = "Kitchin, Thomas, 1718-1784";
-  static readonly EXPECTED_NAME_TWO_ROLE_VALUE = "(Engraver)";
-
   constructor(page: Page) {
     this.page = page;
 

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -39,6 +39,10 @@ export default class ItemMetadataPage {
   readonly typeText: Locator;
   readonly identifiersHeading: Locator;
   readonly identifiersText: Locator;
+  readonly rightsHeading: Locator;
+  readonly rightsText: Locator;
+  readonly dataSourceHeading: Locator;
+  readonly dataSourceLink: Locator;
   static readonly EXPECTED_TITLE_VALUE =
     "To His Excellency Sr. Henry Moore, Bart";
   static readonly EXPECTED_UUID_VALUE = "8b2b3160-c5d5-012f-d95c-58d385a7bc34";
@@ -48,10 +52,6 @@ export default class ItemMetadataPage {
   static readonly EXPECTED_COLLECTION_ROOT_VALUE =
     "Lawrence H. Slaughter Collection of English maps, charts, globes, books and atlases";
   static readonly EXPECTED_COLLECTION_LEVEL_ONE_VALUE = "Charts and maps";
-  readonly rightsHeading: Locator;
-  readonly rightsText: Locator;
-  readonly dataSourceHeading: Locator;
-  readonly dataSourceLink: Locator;
 
   constructor(page: Page) {
     this.page = page;

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -52,6 +52,10 @@ export default class ItemMetadataPage {
   static readonly EXPECTED_COLLECTION_ROOT_VALUE =
     "Lawrence H. Slaughter Collection of English maps, charts, globes, books and atlases";
   static readonly EXPECTED_COLLECTION_LEVEL_ONE_VALUE = "Charts and maps";
+  static readonly EXPECTED_NAME_ONE_VALUE = "Ratzer, Bernard";
+  static readonly EXPECTED_NAME_ONE_ROLE_VALUE = "(Cartographer)";
+  static readonly EXPECTED_NAME_TWO_ROLE_VALUE = "Kitchin, Thomas, 1718-1784";
+  static readonly EXPECTED_NAME_TWO_VALUE = "(Engraver)";
 
   constructor(page: Page) {
     this.page = page;
@@ -223,6 +227,10 @@ export default class ItemMetadataPage {
     await expect(collectionLevelOneLinkLocator).toHaveText(
       ItemMetadataPage.EXPECTED_COLLECTION_LEVEL_ONE_VALUE
     );
+  }
+
+  async verifyNameFieldValues(): Promise<void> {
+    // something will go here
   }
 
   async verifyRightsContent(): Promise<void> {

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -1,7 +1,34 @@
 import { Locator, Page, expect } from "@playwright/test";
 
+class FieldLocatorService {
+  // Method returns an object containing both the Locator and the content/text Pattern
+  public getNameLocatorAndPattern(
+    allEntryContainers: Locator,
+    expectedData: { name: string; role: string }
+  ): { locator: Locator; pattern: RegExp } {
+    // Define escaped delimiters for the front-end pattern
+    const prefix = "\\(";
+    const suffix = "\\)";
+
+    // Pattern: [Name] + [one or more whitespace (\s+)] + [(Literal Paren)] + [Role] + [Literal Paren]
+    const fullExpectedPattern = new RegExp(
+      expectedData.name + "\\s+" + prefix + expectedData.role + suffix,
+      "i"
+    );
+
+    // Filter the general locator to find the specific container
+    const locator = allEntryContainers.filter({
+      hasText: fullExpectedPattern,
+    });
+
+    // return locator values and full-text for assertions
+    return { locator: locator, pattern: fullExpectedPattern };
+  }
+}
+
 export default class ItemMetadataPage {
   readonly page: Page;
+  private locatorService = new FieldLocatorService();
 
   static itemResultURL: string = "/items/8b2b3160-c5d5-012f-d95c-58d385a7bc34";
 
@@ -52,6 +79,11 @@ export default class ItemMetadataPage {
   static readonly EXPECTED_COLLECTION_ROOT_VALUE =
     "Lawrence H. Slaughter Collection of English maps, charts, globes, books and atlases";
   static readonly EXPECTED_COLLECTION_LEVEL_ONE_VALUE = "Charts and maps";
+  static readonly EXPECTED_NAMES = [
+    { name: "Ratzer, Bernard", role: "Cartographer" },
+    { name: "Kitchin, Thomas, 1718-1784", role: "Engraver" },
+  ];
+
   static readonly EXPECTED_NAME_COUNT = 2;
   static readonly EXPECTED_NAME_ONE_VALUE = "Ratzer, Bernard";
   static readonly EXPECTED_NAME_ONE_ROLE_VALUE = "(Cartographer)";
@@ -230,52 +262,45 @@ export default class ItemMetadataPage {
     );
   }
 
-  async verifyNameFieldList(): Promise<void> {
-    // Find all name entry containers
+  async verifyNameCount(): Promise<void> {
+    const allNameEntryContainers = this.nameText.locator("span");
+    await expect(allNameEntryContainers).toHaveCount(
+      ItemMetadataPage.EXPECTED_NAMES.length
+    );
+  }
+
+  // Checks if Name is a clickable link and Role is text.
+  async verifyNameLinks(): Promise<void> {
     const allNameEntryContainers = this.nameText.locator("span");
 
-    // If the item returns less/more than the expected nodes, this line fails immediately.
-    await expect(allNameEntryContainers).toHaveCount(
-      ItemMetadataPage.EXPECTED_NAME_COUNT
-    );
+    for (const expectedName of ItemMetadataPage.EXPECTED_NAMES) {
+      const { locator: nameContainer } =
+        this.locatorService.getNameLocatorAndPattern(
+          allNameEntryContainers,
+          expectedName
+        );
+
+      const nameLink = nameContainer.getByRole("link");
+
+      await expect(nameLink).toBeVisible();
+      await expect(nameLink).toHaveText(expectedName.name);
+    }
   }
 
-  async verifyNameOneValue(): Promise<void> {
-    // Locate the specific name link
-    const nameOneLink = this.nameText.getByRole("link").nth(0);
+  // Check if Name and Role matches expected value
+  async verifyNameDataValues(): Promise<void> {
+    const allNameEntryContainers = this.nameText.locator("span");
 
-    // Assert Link Content (Value Check)
-    await expect(nameOneLink).toBeVisible();
-    await expect(nameOneLink).toHaveText(
-      ItemMetadataPage.EXPECTED_NAME_ONE_VALUE
-    );
-  }
+    for (const expectedName of ItemMetadataPage.EXPECTED_NAMES) {
+      const { locator: nameContainer, pattern: fullExpectedPattern } =
+        this.locatorService.getNameLocatorAndPattern(
+          allNameEntryContainers,
+          expectedName
+        );
 
-  async verifyNameOneRole(): Promise<void> {
-    // Locate the parent container using its structural selector
-    const nameOneEntryContainer = this.nameText.locator("span").nth(0);
-
-    // Check the full container text for the ROLE.
-    const fullExpectedText = `${ItemMetadataPage.EXPECTED_NAME_ONE_VALUE} ${ItemMetadataPage.EXPECTED_NAME_ONE_ROLE_VALUE}`;
-
-    // We use toContainText to ensure the role text follows the name correctly within the <span> container.
-    await expect(nameOneEntryContainer).toContainText(fullExpectedText);
-  }
-
-  async verifyNameTwoValue(): Promise<void> {
-    const nameTwoLink = this.nameText.getByRole("link").nth(1);
-
-    await expect(nameTwoLink).toBeVisible();
-    await expect(nameTwoLink).toHaveText(
-      ItemMetadataPage.EXPECTED_NAME_TWO_VALUE
-    );
-  }
-
-  async verifyNameTwoRole(): Promise<void> {
-    const nameTwoEntryContainer = this.nameText.locator("span").nth(1);
-    const fullExpectedText = `${ItemMetadataPage.EXPECTED_NAME_TWO_VALUE} ${ItemMetadataPage.EXPECTED_NAME_TWO_ROLE_VALUE}`;
-
-    await expect(nameTwoEntryContainer).toContainText(fullExpectedText);
+      // Verify the full text (including the non-clickable role) is present.
+      await expect(nameContainer).toHaveText(fullExpectedPattern);
+    }
   }
 
   async verifyRightsContent(): Promise<void> {

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -25,7 +25,7 @@ test.describe("Verify Metadata Fields", () => {
       await itemMetadataPage.verifyCollectionRootLink();
     });
 
-    test("should include sub-collection link, if present", async () => {
+    test("should include sub-collection link", async () => {
       await itemMetadataPage.verifyCollectionLevelOneLink();
     });
   });
@@ -41,18 +41,18 @@ test.describe("Verify Metadata Fields", () => {
       await itemMetadataPage.verifyUUIDIdentifierIsPresent();
     });
 
-    test("should include RLIN/OCLC identifier if present", async () => {
+    test("should include RLIN/OCLC identifier", async () => {
       await itemMetadataPage.verifyOclcIdentifierIsPresent();
     });
 
-    test("should include the NYPL Catalog Link if present", async () => {
+    test("should include the NYPL Catalog Link", async () => {
       await itemMetadataPage.verifyCatalogLinkIsPresent();
     });
   });
 });
 
 test.describe("Other Identifiers", () => {
-  test("should include Shelf Locator if present", async () => {
+  test("should include Shelf Locator", async () => {
     await itemMetadataPage.verifyShelfLocatorIsPresent();
   });
 });

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -75,32 +75,32 @@ test.describe.serial("Metadata Checks", () => {
       });
     });
 
-    test.describe("Names", () => {
-      test.beforeEach(async () => {
-        // Verify collection heading and containers before checking content
-        await expect(itemMetadataPage.nameHeading).toBeVisible();
-        await expect(itemMetadataPage.nameText).toBeVisible();
-      });
+    // test.describe("Names", () => {
+    //   test.beforeEach(async () => {
+    //     // Verify collection heading and containers before checking content
+    //     await expect(itemMetadataPage.nameHeading).toBeVisible();
+    //     await expect(itemMetadataPage.nameText).toBeVisible();
+    //   });
 
-      test("should contain all available names", async () => {
-        await itemMetadataPage.verifyNameFieldList();
-      });
+    //   test("should contain all available names", async () => {
+    //     await itemMetadataPage.verifyNameFieldList();
+    //   });
 
-      test("should include name one link", async () => {
-        await itemMetadataPage.verifyNameOneValue();
-      });
+    //   test("should include name one link", async () => {
+    //     await itemMetadataPage.verifyNameOneValue();
+    //   });
 
-      test("should include name one's role", async () => {
-        await itemMetadataPage.verifyNameOneRole();
-      });
+    //   test("should include name one's role", async () => {
+    //     await itemMetadataPage.verifyNameOneRole();
+    //   });
 
-      test("should include name two link", async () => {
-        await itemMetadataPage.verifyNameTwoValue();
-      });
+    //   test("should include name two link", async () => {
+    //     await itemMetadataPage.verifyNameTwoValue();
+    //   });
 
-      test("should include name two's role", async () => {
-        await itemMetadataPage.verifyNameTwoRole();
-      });
-    });
+    //   test("should include name two's role", async () => {
+    //     await itemMetadataPage.verifyNameTwoRole();
+    //   });
+    // });
   });
 });

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -1,74 +1,106 @@
 import { test, expect } from "../base";
 import ItemMetadataPage from "../pages/item-metadata.page";
+import { applyRouteFilters } from "../utils/routeFilters";
 
 let itemMetadataPage: ItemMetadataPage;
 
-test.beforeEach(async ({ page }) => {
-  itemMetadataPage = new ItemMetadataPage(page);
-  await itemMetadataPage.loadPage(ItemMetadataPage.itemResultURL);
-});
+// Do a new basic-search from the results-page
+test.describe.serial("Metadata Checks", () => {
+  // Runs ONCE to create the shared, filtered page context.
 
-test.describe("Verify Metadata Fields", () => {
-  test("should display Title heading and corresponding text", async () => {
-    await expect(itemMetadataPage.titleHeading).toBeVisible();
-    await itemMetadataPage.verifyTitleTextContent();
+  test.beforeAll(async ({ browser }) => {
+    // Manually create context/page to force serialization to remain in block
+    const browserContext = await browser.newContext();
+    const page = await browserContext.newPage();
+
+    // Apply global filters manually
+    await applyRouteFilters(page);
+
+    // Assign to global variable and load the page object
+    itemMetadataPage = new ItemMetadataPage(page);
+    await itemMetadataPage.loadPage(ItemMetadataPage.itemResultURL);
   });
 
-  test.describe("Collection", () => {
-    test.beforeEach(async () => {
-      // Verify collection heading and containers before checking content
-      await expect(itemMetadataPage.collectionHeading).toBeVisible();
-      await expect(itemMetadataPage.collectionText).toBeVisible();
-    });
-
-    test("should include main/root collection link", async () => {
-      await itemMetadataPage.verifyCollectionRootLink();
-    });
-
-    test("should include sub-collection link", async () => {
-      await itemMetadataPage.verifyCollectionLevelOneLink();
-    });
+  // TEARDOWN: close the entire context.
+  test.afterAll(async () => {
+    // Closes the BrowserContext, freeing up resources.
+    await searchPage.page.context().close();
   });
 
-  test.describe("Identifiers", () => {
-    test.beforeEach(async () => {
-      // Verify identifiers heading and containers before checking content
-      await expect(itemMetadataPage.identifiersHeading).toBeVisible();
-      await expect(itemMetadataPage.identifiersText).toBeVisible();
+  test.describe.serial("Verify Metadata Fields", () => {
+    test("should display Title heading and corresponding text", async () => {
+      await expect(itemMetadataPage.titleHeading).toBeVisible();
+      await itemMetadataPage.verifyTitleTextContent();
     });
 
-    test("should include UUID", async () => {
-      await itemMetadataPage.verifyUUIDIdentifierIsPresent();
+    test.describe("Collection", () => {
+      test.beforeEach(async () => {
+        // Verify collection heading and containers before checking content
+        await expect(itemMetadataPage.collectionHeading).toBeVisible();
+        await expect(itemMetadataPage.collectionText).toBeVisible();
+      });
+
+      test("should include main/root collection link", async () => {
+        await itemMetadataPage.verifyCollectionRootLink();
+      });
+
+      test("should include sub-collection link", async () => {
+        await itemMetadataPage.verifyCollectionLevelOneLink();
+      });
     });
 
-    test("should include RLIN/OCLC identifier", async () => {
-      await itemMetadataPage.verifyOclcIdentifierIsPresent();
+    test.describe("Identifiers", () => {
+      test.beforeEach(async () => {
+        // Verify identifiers heading and containers before checking content
+        await expect(itemMetadataPage.identifiersHeading).toBeVisible();
+        await expect(itemMetadataPage.identifiersText).toBeVisible();
+      });
+
+      test("should include UUID", async () => {
+        await itemMetadataPage.verifyUUIDIdentifierIsPresent();
+      });
+
+      test("should include RLIN/OCLC identifier", async () => {
+        await itemMetadataPage.verifyOclcIdentifierIsPresent();
+      });
+
+      test("should include the NYPL Catalog Link", async () => {
+        await itemMetadataPage.verifyCatalogLinkIsPresent();
+      });
     });
 
-    test("should include the NYPL Catalog Link", async () => {
-      await itemMetadataPage.verifyCatalogLinkIsPresent();
+    test.describe("Other Identifiers", () => {
+      test("should include Shelf Locator", async () => {
+        await itemMetadataPage.verifyShelfLocatorIsPresent();
+      });
     });
-  });
-});
 
-test.describe("Other Identifiers", () => {
-  test("should include Shelf Locator", async () => {
-    await itemMetadataPage.verifyShelfLocatorIsPresent();
-  });
-});
+    test.describe("Names", () => {
+      test.beforeEach(async () => {
+        // Verify collection heading and containers before checking content
+        await expect(itemMetadataPage.nameHeading).toBeVisible();
+        await expect(itemMetadataPage.nameText).toBeVisible();
+      });
 
-test.describe("Name", () => {
-  test.beforeEach(async () => {
-    // Verify collection heading and containers before checking content
-    await expect(itemMetadataPage.nameHeading).toBeVisible();
-    await expect(itemMetadataPage.nameText).toBeVisible();
-  });
+      test("should contain all available names", async () => {
+        await itemMetadataPage.verifyNameFieldList();
+      });
 
-  test.describe("should include first name and role", async () => {
-    //test goes here
-  });
+      test("should include name one link", async () => {
+        await itemMetadataPage.verifyNameOneValue();
+      });
 
-  test.describe("should include second name and role", async () => {
-    //test goes here
+      test("should include name one's role", async () => {
+        await itemMetadataPage.verifyNameOneRole();
+      });
+
+      test("should include name two link", async () => {
+        await itemMetadataPage.verifyNameTwoValue();
+      });
+
+      test("should include name two's role", async () => {
+        await itemMetadataPage.verifyNameTwoRole();
+      });
+    });
   });
 });

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -56,3 +56,19 @@ test.describe("Other Identifiers", () => {
     await itemMetadataPage.verifyShelfLocatorIsPresent();
   });
 });
+
+test.describe("Name", () => {
+  test.beforeEach(async () => {
+    // Verify collection heading and containers before checking content
+    await expect(itemMetadataPage.nameHeading).toBeVisible();
+    await expect(itemMetadataPage.nameText).toBeVisible();
+  });
+
+  test.describe("should include first name and role", async () => {
+    //test goes here
+  });
+
+  test.describe("should include second name and role", async () => {
+    //test goes here
+  });
+});

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -57,50 +57,21 @@ test.describe("Other Identifiers", () => {
   });
 });
 
-// test.describe("Name", () => {
-//   test.beforeEach(async () => {
-//     // Verify collection heading and containers before checking content
-//     await expect(itemMetadataPage.nameHeading).toBeVisible();
-//     await expect(itemMetadataPage.nameText).toBeVisible();
-//   });
-
-//   test.describe("should include first name and role", async () => {
-//     //test goes here
-//   });
-
-//   test.describe("should include second name and role", async () => {
-//     //test goes here
-//   });
-// });
-
-// Inside item-metadata.spec.ts
-
 test.describe("Names", () => {
-  test.beforeEach(async () => {
-    // Verify collection heading and containers before checking content
-    await itemMetadataPage.nameHeading.focus();
-
+  test.beforeEach(async ({ page }) => {
     await expect(itemMetadataPage.nameHeading).toBeVisible();
     await expect(itemMetadataPage.nameText).toBeVisible();
   });
 
-  test("should contain all available names", async () => {
-    await itemMetadataPage.verifyNameFieldList();
+  test("should display the correct number of expected name fields", async () => {
+    await itemMetadataPage.verifyNameCount();
   });
 
-  test("should include name one link", async () => {
-    await itemMetadataPage.verifyNameOneValue();
+  test("should display link for name and text for Role", async () => {
+    await itemMetadataPage.verifyNameLinks();
   });
 
-  test("should include name one's role", async () => {
-    await itemMetadataPage.verifyNameOneRole();
-  });
-
-  test("should include name two link", async () => {
-    await itemMetadataPage.verifyNameTwoValue();
-  });
-
-  test("should include name two's role", async () => {
-    await itemMetadataPage.verifyNameTwoRole();
+  test("should display correct name and role values", async () => {
+    await itemMetadataPage.verifyNameDataValues();
   });
 });

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -1,106 +1,106 @@
 import { test, expect } from "../base";
 import ItemMetadataPage from "../pages/item-metadata.page";
-import { applyRouteFilters } from "../utils/routeFilters";
 
 let itemMetadataPage: ItemMetadataPage;
 
-// Do a new basic-search from the results-page
-test.describe.serial("Metadata Checks", () => {
-  // Runs ONCE to create the shared, filtered page context.
+test.beforeEach(async ({ page }) => {
+  itemMetadataPage = new ItemMetadataPage(page);
+  await itemMetadataPage.loadPage(ItemMetadataPage.itemResultURL);
+});
 
-  test.beforeAll(async ({ browser }) => {
-    // Manually create context/page to force serialization to remain in block
-    const browserContext = await browser.newContext();
-    const page = await browserContext.newPage();
-
-    // Apply global filters manually
-    await applyRouteFilters(page);
-
-    // Assign to global variable and load the page object
-    itemMetadataPage = new ItemMetadataPage(page);
-    await itemMetadataPage.loadPage(ItemMetadataPage.itemResultURL);
+test.describe("Verify Metadata Fields", () => {
+  test("should display Title heading and corresponding text", async () => {
+    await expect(itemMetadataPage.titleHeading).toBeVisible();
+    await itemMetadataPage.verifyTitleTextContent();
   });
 
-  // TEARDOWN: close the entire context.
-  test.afterAll(async () => {
-    // Closes the BrowserContext, freeing up resources.
-    await searchPage.page.context().close();
+  test.describe("Collection", () => {
+    test.beforeEach(async () => {
+      // Verify collection heading and containers before checking content
+      await expect(itemMetadataPage.collectionHeading).toBeVisible();
+      await expect(itemMetadataPage.collectionText).toBeVisible();
+    });
+
+    test("should include main/root collection link", async () => {
+      await itemMetadataPage.verifyCollectionRootLink();
+    });
+
+    test("should include sub-collection link", async () => {
+      await itemMetadataPage.verifyCollectionLevelOneLink();
+    });
   });
 
-  test.describe.serial("Verify Metadata Fields", () => {
-    test("should display Title heading and corresponding text", async () => {
-      await expect(itemMetadataPage.titleHeading).toBeVisible();
-      await itemMetadataPage.verifyTitleTextContent();
+  test.describe("Identifiers", () => {
+    test.beforeEach(async () => {
+      // Verify identifiers heading and containers before checking content
+      await expect(itemMetadataPage.identifiersHeading).toBeVisible();
+      await expect(itemMetadataPage.identifiersText).toBeVisible();
     });
 
-    test.describe("Collection", () => {
-      test.beforeEach(async () => {
-        // Verify collection heading and containers before checking content
-        await expect(itemMetadataPage.collectionHeading).toBeVisible();
-        await expect(itemMetadataPage.collectionText).toBeVisible();
-      });
-
-      test("should include main/root collection link", async () => {
-        await itemMetadataPage.verifyCollectionRootLink();
-      });
-
-      test("should include sub-collection link", async () => {
-        await itemMetadataPage.verifyCollectionLevelOneLink();
-      });
+    test("should include UUID", async () => {
+      await itemMetadataPage.verifyUUIDIdentifierIsPresent();
     });
 
-    test.describe("Identifiers", () => {
-      test.beforeEach(async () => {
-        // Verify identifiers heading and containers before checking content
-        await expect(itemMetadataPage.identifiersHeading).toBeVisible();
-        await expect(itemMetadataPage.identifiersText).toBeVisible();
-      });
-
-      test("should include UUID", async () => {
-        await itemMetadataPage.verifyUUIDIdentifierIsPresent();
-      });
-
-      test("should include RLIN/OCLC identifier", async () => {
-        await itemMetadataPage.verifyOclcIdentifierIsPresent();
-      });
-
-      test("should include the NYPL Catalog Link", async () => {
-        await itemMetadataPage.verifyCatalogLinkIsPresent();
-      });
+    test("should include RLIN/OCLC identifier", async () => {
+      await itemMetadataPage.verifyOclcIdentifierIsPresent();
     });
 
-    test.describe("Other Identifiers", () => {
-      test("should include Shelf Locator", async () => {
-        await itemMetadataPage.verifyShelfLocatorIsPresent();
-      });
+    test("should include the NYPL Catalog Link", async () => {
+      await itemMetadataPage.verifyCatalogLinkIsPresent();
     });
+  });
+});
 
-    // test.describe("Names", () => {
-    //   test.beforeEach(async () => {
-    //     // Verify collection heading and containers before checking content
-    //     await expect(itemMetadataPage.nameHeading).toBeVisible();
-    //     await expect(itemMetadataPage.nameText).toBeVisible();
-    //   });
+test.describe("Other Identifiers", () => {
+  test("should include Shelf Locator", async () => {
+    await itemMetadataPage.verifyShelfLocatorIsPresent();
+  });
+});
 
-    //   test("should contain all available names", async () => {
-    //     await itemMetadataPage.verifyNameFieldList();
-    //   });
+// test.describe("Name", () => {
+//   test.beforeEach(async () => {
+//     // Verify collection heading and containers before checking content
+//     await expect(itemMetadataPage.nameHeading).toBeVisible();
+//     await expect(itemMetadataPage.nameText).toBeVisible();
+//   });
 
-    //   test("should include name one link", async () => {
-    //     await itemMetadataPage.verifyNameOneValue();
-    //   });
+//   test.describe("should include first name and role", async () => {
+//     //test goes here
+//   });
 
-    //   test("should include name one's role", async () => {
-    //     await itemMetadataPage.verifyNameOneRole();
-    //   });
+//   test.describe("should include second name and role", async () => {
+//     //test goes here
+//   });
+// });
 
-    //   test("should include name two link", async () => {
-    //     await itemMetadataPage.verifyNameTwoValue();
-    //   });
+// Inside item-metadata.spec.ts
 
-    //   test("should include name two's role", async () => {
-    //     await itemMetadataPage.verifyNameTwoRole();
-    //   });
-    // });
+test.describe("Names", () => {
+  test.beforeEach(async () => {
+    // Verify collection heading and containers before checking content
+    await itemMetadataPage.nameHeading.focus();
+
+    await expect(itemMetadataPage.nameHeading).toBeVisible();
+    await expect(itemMetadataPage.nameText).toBeVisible();
+  });
+
+  test("should contain all available names", async () => {
+    await itemMetadataPage.verifyNameFieldList();
+  });
+
+  test("should include name one link", async () => {
+    await itemMetadataPage.verifyNameOneValue();
+  });
+
+  test("should include name one's role", async () => {
+    await itemMetadataPage.verifyNameOneRole();
+  });
+
+  test("should include name two link", async () => {
+    await itemMetadataPage.verifyNameTwoValue();
+  });
+
+  test("should include name two's role", async () => {
+    await itemMetadataPage.verifyNameTwoRole();
   });
 });


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3900](https://newyorkpubliclibrary.atlassian.net/browse/DR-3900)

## This PR does the following:

<!-- What has been updated or added in this PR? -->
Added tests to check Name and Name-Role values on the item page.  These tests also verify that Name is linked and Role is plain-text. 

## Open questions

<!-- Any questions you want to ask the reviewer? -->

 I started with a simple "NAME_ONE_VALUE," "NAME_TWO_ROLE," type of assertion.  But I refactored this to take a list of name-role combinations instead.  Also, it is a known feature of Solr that values in multi-valued fields can sort randomly, so I did not want the test to have a brittle dependence on _which_ name appeared first in the UX field list. 
 
 Because they aren't semantically marked up, we're relying on spans to break out the name-value nodes.  Tried this first with a "scope >" attribute in Playwright, but was foiled there by some `<br>` tags hanging out below the spans.  Span seems to do the trick here, and can also be utilized for Topic, or other multiValued field-checks.

I've left some comments in-place to help in reviewing this more complex test interaction, but these will be removed before the final-merge.


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

Ran test suite on localhost against a prod build with the `--workers=2` flag.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3900]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ