### PR TITLE
Dr 3900- item fields physical description and notes

### DIFF
--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -218,6 +218,10 @@ export default class ItemMetadataPage {
     this.typeHeading = this.page.getByText("Type of Resource", { exact: true });
     this.typeText = this.typeHeading.locator("+ p");
 
+    // Languages
+    this.languageHeading = this.page.getByText("Languages", { exact: true });
+    this.languageText = this.languageHeading.locator("+ p");
+
     // Rights Statement
     this.rightsHeading = this.page.getByText("Rights Statement", {
       exact: true,

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -327,17 +327,14 @@ export default class ItemMetadataPage {
     }
   }
 
-  async verifyNotesCount(): Promise<void> {
-    const rawText = await this.notesText.innerText();
-    // Playwright's innerText() converts <br> tags to newlines
-    const actualNotes = rawText
-      .split("\n")
-      .filter((line) => line.trim().length > 0);
-
-    expect(actualNotes.length).toEqual(ItemMetadataPage.EXPECTED_NOTES.length);
+  async verifyPhysicalDescriptionContent(): Promise<void> {
+    await expect(this.physicalHeading).toBeVisible();
+    await expect(this.physicalText).toContainText(
+      ItemMetadataPage.EXPECTED_PHYSICAL_DESCRIPTION_VALUE
+    );
   }
 
-  async verifyNotesValues(): Promise<void> {
+  async verifyNotesText(): Promise<void> {
     const rawText = await this.notesText.innerText();
 
     // Normalize whitespace and split by newline to verify each distinct note
@@ -347,6 +344,16 @@ export default class ItemMetadataPage {
       .filter((val) => val.length > 0);
 
     expect(actualNotes).toEqual(ItemMetadataPage.EXPECTED_NOTES);
+  }
+
+  async verifyNotesCount(): Promise<void> {
+    const rawText = await this.notesText.innerText();
+    // Playwright's innerText() converts <br> tags to newlines
+    const actualNotes = rawText
+      .split("\n")
+      .filter((line) => line.trim().length > 0);
+
+    expect(actualNotes.length).toEqual(ItemMetadataPage.EXPECTED_NOTES.length);
   }
 
   async verifyRightsContent(): Promise<void> {

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -1,5 +1,8 @@
 import { Locator, Page, expect } from "@playwright/test";
 
+// sets which UUID is to be used for sample record navigation
+export type MetadataScenario = "DEFAULT" | "SAMPLE1" | "SAMPLE2";
+
 class FieldLocatorService {
   // Method returns an object containing both the Locator and the content/text Pattern
   public getNameLocatorAndPattern(
@@ -24,13 +27,39 @@ class FieldLocatorService {
     // return locator values and full-text for assertions
     return { locator: locator, pattern: fullExpectedPattern };
   }
+
+  public getBasicLocator(
+    allEntryContainers: Locator,
+    expectedText: string
+  ): { locator: Locator; pattern: RegExp } {
+    // Pattern:  define pattern here
+    const basicExpectedPattern = new RegExp(`^${expectedText}$`, "i");
+
+    // Filter the general locator to find the specific container
+    const locator = allEntryContainers.filter({
+      hasText: basicExpectedPattern,
+    });
+
+    // return locator values and full-text for assertions
+    return { locator: locator, pattern: basicExpectedPattern };
+  }
 }
 
 export default class ItemMetadataPage {
   readonly page: Page;
   private locatorService = new FieldLocatorService();
 
-  static itemResultURL: string = "/items/8b2b3160-c5d5-012f-d95c-58d385a7bc34";
+  // Sample URL-Record Mapping
+  private static readonly SCENARIOS: Record<MetadataScenario, string> = {
+    DEFAULT: "8b2b3160-c5d5-012f-d95c-58d385a7bc34",
+    SAMPLE1: "25a47180-c55f-012f-3759-58d385a7bc34", // Topics
+    SAMPLE2: "4649be20-9890-0138-2359-2360945aaf51", // Genres
+  };
+
+  async loadScenario(scenario: MetadataScenario): Promise<void> {
+    const uuid = ItemMetadataPage.SCENARIOS[scenario];
+    await this.page.goto(`/items/${uuid}`);
+  }
 
   // item-metadata
   readonly itemDataHeader: Locator;
@@ -83,6 +112,8 @@ export default class ItemMetadataPage {
     { name: "Ratzer, Bernard", role: "Cartographer" },
     { name: "Kitchin, Thomas, 1718-1784", role: "Engraver" },
   ];
+  static readonly EXPECTED_PHYSICAL_EXTENT_VALUE =
+    "Extent: 1 map ; 59 x 89 cm.";
 
   constructor(page: Page) {
     this.page = page;
@@ -160,12 +191,6 @@ export default class ItemMetadataPage {
     // Type of Resource
     this.typeHeading = this.page.getByText("Type of Resource", { exact: true });
     this.typeText = this.typeHeading.locator("+ p");
-
-    // Identifiers
-    this.identifiersHeading = this.page.getByText("Identifiers", {
-      exact: true,
-    });
-    this.identifiersText = this.identifiersHeading.locator("+ p");
 
     // Rights Statement
     this.rightsHeading = this.page.getByText("Rights Statement", {

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -115,6 +115,11 @@ export default class ItemMetadataPage {
   static readonly EXPECTED_PHYSICAL_DESCRIPTION_VALUE =
     "Extent: 1 map ; 59 x 89 cm.";
 
+  static readonly EXPECTED_NOTES = [
+    'Content: Black/white, 20" x 30"',
+    "Content: 1577340, 1577402",
+  ];
+
   constructor(page: Page) {
     this.page = page;
 
@@ -320,6 +325,28 @@ export default class ItemMetadataPage {
       // Verify the full text (including the non-clickable role) is present.
       await expect(nameContainer).toHaveText(fullExpectedPattern);
     }
+  }
+
+  async verifyNotesCount(): Promise<void> {
+    const rawText = await this.notesText.innerText();
+    // Playwright's innerText() converts <br> tags to newlines
+    const actualNotes = rawText
+      .split("\n")
+      .filter((line) => line.trim().length > 0);
+
+    expect(actualNotes.length).toEqual(ItemMetadataPage.EXPECTED_NOTES.length);
+  }
+
+  async verifyNotesValues(): Promise<void> {
+    const rawText = await this.notesText.innerText();
+
+    // Normalize whitespace and split by newline to verify each distinct note
+    const actualNotes = rawText
+      .split("\n")
+      .map((val) => val.trim().replace(/\s+/g, " "))
+      .filter((val) => val.length > 0);
+
+    expect(actualNotes).toEqual(ItemMetadataPage.EXPECTED_NOTES);
   }
 
   async verifyRightsContent(): Promise<void> {

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -112,7 +112,7 @@ export default class ItemMetadataPage {
     { name: "Ratzer, Bernard", role: "Cartographer" },
     { name: "Kitchin, Thomas, 1718-1784", role: "Engraver" },
   ];
-  static readonly EXPECTED_PHYSICAL_EXTENT_VALUE =
+  static readonly EXPECTED_PHYSICAL_DESCRIPTION_VALUE =
     "Extent: 1 map ; 59 x 89 cm.";
 
   constructor(page: Page) {

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -77,6 +77,17 @@ test.describe("Verify Default Test Record", () => {
       await itemMetadataPage.verifyNameDataValues();
     });
   });
+  test.describe("Physical Description", () => {
+    test.beforeEach(async () => {
+      // Verify identifiers heading and containers before checking content
+      await expect(itemMetadataPage.physicalHeading).toBeVisible();
+      await expect(itemMetadataPage.physicalText).toBeVisible();
+    });
+
+    test("should display correct physical description values", async () => {
+      await itemMetadataPage.verifyPhysicalDescriptionContent();
+    });
+  });
 });
 
 test.describe("Verify Sample Record 1", () => {
@@ -102,27 +113,14 @@ test.describe("Verify Sample Record 1", () => {
       await itemMetadataPage.verifyTopicText();
     });
   });
-
-  test.describe("Physical Description", () => {
-    test.beforeEach(async () => {
-      // Verify identifiers heading and containers before checking content
-      await expect(itemMetadataPage.physicalHeading).toBeVisible();
-      await expect(itemMetadataPage.physicalText).toBeVisible();
-    });
-
-    test("should display correct physical description values", async () => {
-      await itemMetadataPage.verifyPhysicalDescriptionContent();
-    });
-  });
 });
 
 test.describe("Verify Sample Record 2", () => {
-  test.describe("Notes", () => {
-    test.beforeEach(async ({ page }) => {
-      // Load the SPECIFIC NOTES-modified URL before each test in this block
-      await itemMetadataPage.loadScenario("SAMPLE2");
-    });
+  test.beforeEach(async ({ page }) => {
+    await itemMetadataPage.loadScenario("SAMPLE2");
+  });
 
+  test.describe("Notes", () => {
     test("should include correct notes values", async () => {
       await itemMetadataPage.verifyNotesText();
     });

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -5,10 +5,13 @@ let itemMetadataPage: ItemMetadataPage;
 
 test.beforeEach(async ({ page }) => {
   itemMetadataPage = new ItemMetadataPage(page);
-  await itemMetadataPage.loadPage(ItemMetadataPage.itemResultURL);
 });
 
-test.describe("Verify Metadata Fields", () => {
+test.describe("Verify Default Test Record", () => {
+  test.beforeEach(async ({ page }) => {
+    await itemMetadataPage.loadScenario("DEFAULT");
+  });
+
   test("should display Title heading and corresponding text", async () => {
     await expect(itemMetadataPage.titleHeading).toBeVisible();
     await itemMetadataPage.verifyTitleTextContent();
@@ -49,29 +52,58 @@ test.describe("Verify Metadata Fields", () => {
       await itemMetadataPage.verifyCatalogLinkIsPresent();
     });
   });
-});
 
-test.describe("Other Identifiers", () => {
-  test("should include Shelf Locator", async () => {
-    await itemMetadataPage.verifyShelfLocatorIsPresent();
+  test.describe("Other Identifiers", () => {
+    test("should include Shelf Locator", async () => {
+      await itemMetadataPage.verifyShelfLocatorIsPresent();
+    });
+  });
+
+  test.describe("Names", () => {
+    test.beforeEach(async ({ page }) => {
+      await expect(itemMetadataPage.nameHeading).toBeVisible();
+      await expect(itemMetadataPage.nameText).toBeVisible();
+    });
+
+    test("should display the correct number of expected name fields", async () => {
+      await itemMetadataPage.verifyNameCount();
+    });
+
+    test("should display link for name and text for Role", async () => {
+      await itemMetadataPage.verifyNameLinks();
+    });
+
+    test("should display correct name and role values", async () => {
+      await itemMetadataPage.verifyNameDataValues();
+    });
+  });
+
+  test.describe("Physical Description", () => {
+    test.beforeEach(async () => {
+      // Verify identifiers heading and containers before checking content
+      await expect(itemMetadataPage.physicalHeading).toBeVisible();
+      await expect(itemMetadataPage.physicalText).toBeVisible();
+    });
+
+    test("should display correct physical description values", async () => {
+      await itemMetadataPage.verifyPhysicalDescriptionContent();
+    });
   });
 });
 
-test.describe("Names", () => {
-  test.beforeEach(async ({ page }) => {
-    await expect(itemMetadataPage.nameHeading).toBeVisible();
-    await expect(itemMetadataPage.nameText).toBeVisible();
-  });
+test.describe("Verify Sample Record 2", () => {
+  test.describe("Notes", () => {
+    test.beforeEach(async ({ page }) => {
+      // Load the SPECIFIC NOTES-modified URL before each test in this block
+      await itemMetadataPage.loadScenario("SAMPLE2");
+    });
 
-  test("should display the correct number of expected name fields", async () => {
-    await itemMetadataPage.verifyNameCount();
-  });
+    test("should include correct notes values", async () => {
+      await itemMetadataPage.verifyNotesText();
+    });
 
-  test("should display link for name and text for Role", async () => {
-    await itemMetadataPage.verifyNameLinks();
-  });
-
-  test("should display correct name and role values", async () => {
-    await itemMetadataPage.verifyNameDataValues();
+    test("should contain the correct number of notes", async () => {
+      await itemMetadataPage.verifyNotesCount();
+    });
   });
 });


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3900](https://newyorkpubliclibrary.atlassian.net/browse/DR-3900)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

Adds Physical Description and Notes fields tests to POM and Spec files.

Most of this is based on the same framework that name, genre, etc. use:  it allows checking multi-valued fields, and uses a `scenario()` method to handle different sample records instead of hardcoding the UUIDs into the field var names.  This also allows one spec (item-metadata.spec) to easily access the different sample items that are required for various fields.

## Open questions

There are many, many different types of Notes, but the display of them  ("`<type>: <note-text>`") is the same: one note per new line-break on the front-end.   At a later date, we should return to this if we want to verify that all of the various "note-types" display their correct "type" and values.  This would also be checked in the API upstream, and since the note is handed off to the front-end intact, there might not be be any parsing/decision-trees in the UX for various note-types.  If the entire Notes "blob" is just being passed to the UX, then checking the various types, imo, would be overkill for the front-end playwright tests.

The Physical Description test/check is much more straightforward.  And since the sample record is showing only one, we are just checking for that value.

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?
All tests were run locally against the production build.

`npm run build`
`npx playwright test --workers=2`

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3900]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ