### PR TITLE
Generate env specific robots.txt

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,30 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  if (process.env.APP_ENV === "production") {
+    return {
+      rules: [
+        {
+          userAgent: "Bytedance",
+          disallow: "/",
+        },
+        {
+          userAgent: "Bytespider",
+          disallow: "/",
+        },
+        {
+          userAgent: "GPTBot",
+          disallow: "/",
+        },
+      ],
+    };
+  }
+
+  // No bot access for non-prod environments
+  return {
+    rules: {
+      userAgent: "*",
+      disallow: "/",
+    },
+  };
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,0 @@
-User-agent: Bytedance
-Disallow: /
-
-User-agent: Bytespider
-Disallow: /
-
-User-agent: GPTBot
-Disallow: / 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3986](https://newyorkpubliclibrary.atlassian.net/browse/DR-3986)

## This PR does the following:

Use the nextJS `robots.ts` setup to create separate `robots.txt` files per environment. For non-prod environments, set a disallow on everything to prevent google from indexing qa.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

See the generated robots file on vercel: https://digital-collections-git-robots-ts-nypl.vercel.app/robots.txt

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3986]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ