### PR TITLE
DR-3900 - item fields: genre refactor

### DIFF
--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -356,6 +356,39 @@ export default class ItemMetadataPage {
     }
   }
 
+  async verifyGenreCount(): Promise<void> {
+    const genreLinks = this.genreText.getByRole("link");
+    await expect(genreLinks).toHaveCount(
+      ItemMetadataPage.EXPECTED_GENRES.length
+    );
+  }
+
+  async verifyGenreValues(): Promise<void> {
+    // innerText() converts the <br> tags into newlines (\n)
+    const rawText = await this.genreText.innerText();
+
+    // Split by newline, trim whitespace, and remove empty strings
+    const actualGenres = rawText
+      .split("\n")
+      .map((val) => val.trim())
+      .filter((val) => val.length > 0);
+
+    // Check expected content
+    expect(actualGenres).toEqual(ItemMetadataPage.EXPECTED_GENRES);
+  }
+
+  async verifyGenreLinks(): Promise<void> {
+    // Get all genre links
+    const genreLinks = this.genreText.getByRole("link");
+
+    for (let i = 0; i < ItemMetadataPage.EXPECTED_GENRES.length; i++) {
+      const expectedText = ItemMetadataPage.EXPECTED_GENRES[i];
+      const currentLink = genreLinks.nth(i);
+      await expect(currentLink).toHaveText(expectedText);
+      await expect(currentLink).toBeVisible();
+    }
+  }
+
   async verifyPhysicalDescriptionContent(): Promise<void> {
     await expect(this.physicalHeading).toBeVisible();
     await expect(this.physicalText).toContainText(

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -356,6 +356,17 @@ export default class ItemMetadataPage {
     }
   }
 
+  private async getNormalizedLinesFromLocator(
+    locator: Locator
+  ): Promise<string[]> {
+    // Playwright's innerText() converts the <br> tags into newlines (\n)
+    const rawText = await locator.innerText();
+    return rawText
+      .split("\n")
+      .map((val) => val.trim().replace(/\s+/g, " "))
+      .filter((val) => val.length > 0);
+  }
+
   async verifyGenreCount(): Promise<void> {
     const genreLinks = this.genreText.getByRole("link");
     await expect(genreLinks).toHaveCount(
@@ -364,14 +375,9 @@ export default class ItemMetadataPage {
   }
 
   async verifyGenreValues(): Promise<void> {
-    // innerText() converts the <br> tags into newlines (\n)
-    const rawText = await this.genreText.innerText();
-
-    // Split by newline, trim whitespace, and remove empty strings
-    const actualGenres = rawText
-      .split("\n")
-      .map((val) => val.trim())
-      .filter((val) => val.length > 0);
+    const actualGenres = await this.getNormalizedLinesFromLocator(
+      this.genreText
+    );
 
     // Check expected content
     expect(actualGenres).toEqual(ItemMetadataPage.EXPECTED_GENRES);
@@ -397,24 +403,17 @@ export default class ItemMetadataPage {
   }
 
   async verifyNotesText(): Promise<void> {
-    const rawText = await this.notesText.innerText();
-
     // Normalize whitespace and split by newline to verify each distinct note
-    const actualNotes = rawText
-      .split("\n")
-      .map((val) => val.trim().replace(/\s+/g, " "))
-      .filter((val) => val.length > 0);
-
+    const actualNotes = await this.getNormalizedLinesFromLocator(
+      this.notesText
+    );
     expect(actualNotes).toEqual(ItemMetadataPage.EXPECTED_NOTES);
   }
 
   async verifyNotesCount(): Promise<void> {
-    const rawText = await this.notesText.innerText();
-    // Playwright's innerText() converts <br> tags to newlines
-    const actualNotes = rawText
-      .split("\n")
-      .filter((line) => line.trim().length > 0);
-
+    const actualNotes = await this.getNormalizedLinesFromLocator(
+      this.notesText
+    );
     expect(actualNotes.length).toEqual(ItemMetadataPage.EXPECTED_NOTES.length);
   }
 

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -116,6 +116,10 @@ export default class ItemMetadataPage {
     { name: "Ratzer, Bernard", role: "Cartographer" },
     { name: "Kitchin, Thomas, 1718-1784", role: "Engraver" },
   ];
+  static readonly EXPECTED_GENRES = [
+    "Posters",
+    "Placards (Information Artifacts)",
+  ];
   static readonly EXPECTED_PHYSICAL_DESCRIPTION_VALUE =
     "Extent: 1 map ; 59 x 89 cm.";
 

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -130,6 +130,20 @@ test.describe("Verify Sample Record 2", () => {
     });
   });
 
+  test.describe("Genres", () => {
+    test("should include correct genre values", async () => {
+      await itemMetadataPage.verifyGenreValues();
+    });
+
+    test("should contain the correct number of genres", async () => {
+      await itemMetadataPage.verifyGenreCount();
+    });
+
+    test("should display genres as links", async () => {
+      await itemMetadataPage.verifyGenreLinks();
+    });
+  });
+
   test.describe("Languages", () => {
     test("should include correct language values", async () => {
       await itemMetadataPage.verifyLanguageText();


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3900](https://newyorkpubliclibrary.atlassian.net/browse/DR-3900)

## This PR does the following:

<!-- What has been updated or added in this PR? -->
Added Genre fields to the item tests.  

Also there is a small refactor of the line normalization workflow into a helper method (Genres and Notes are using it so far)

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?
 Ran test suite locally on a production guild

<!--- Please describe in detail how you tested your changes. -->
`npm run build`
`npx playwright test`


## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3900]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ