### PR TITLE
DR-3900 - item fields: Rights test

### DIFF
--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -145,6 +145,7 @@ export default class ItemMetadataPage {
       linkCount: 1,
     },
   ];
+  static readonly EXPECTED_RESOURCE_TYPES = ["Still Image", "Text"];
 
   constructor(page: Page) {
     this.page = page;
@@ -575,6 +576,33 @@ export default class ItemMetadataPage {
     // Final check for total link integrity
     const actualTotalLinksFound = await allLinks.count();
     expect(actualTotalLinksFound).toEqual(expectedTotalLinkCount);
+  }
+
+  // Check Type of Resource links count
+  async verifyTypeCount(): Promise<void> {
+    const typeLinks = this.typeText.getByRole("link");
+    await expect(typeLinks).toHaveCount(
+      ItemMetadataPage.EXPECTED_RESOURCE_TYPES.length
+    );
+  }
+
+  // Check Type or Resource text values
+  async verifyTypeValues(): Promise<void> {
+    const actualTypes = await this.getNormalizedLinesFromLocator(this.typeText);
+    expect(actualTypes).toEqual(ItemMetadataPage.EXPECTED_RESOURCE_TYPES);
+  }
+
+  // Verify correct links for Type of Resource text
+  async verifyTypeLinks(): Promise<void> {
+    const typeLinks = this.typeText.getByRole("link");
+
+    for (let i = 0; i < ItemMetadataPage.EXPECTED_RESOURCE_TYPES.length; i++) {
+      const expectedText = ItemMetadataPage.EXPECTED_RESOURCE_TYPES[i];
+      const currentLink = typeLinks.nth(i);
+
+      await expect(currentLink).toBeVisible();
+      await expect(currentLink).toHaveText(expectedText);
+    }
   }
 
   async verifyRightsContent(): Promise<void> {

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -599,9 +599,8 @@ export default class ItemMetadataPage {
     for (let i = 0; i < ItemMetadataPage.EXPECTED_RESOURCE_TYPES.length; i++) {
       const expectedText = ItemMetadataPage.EXPECTED_RESOURCE_TYPES[i];
       const currentLink = typeLinks.nth(i);
-
-      await expect(currentLink).toBeVisible();
       await expect(currentLink).toHaveText(expectedText);
+      await expect(currentLink).toBeVisible();
     }
   }
 

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -1,7 +1,7 @@
 import { Locator, Page, expect } from "@playwright/test";
 
 // sets which UUID is to be used for sample record navigation
-export type MetadataScenario = "DEFAULT" | "SAMPLE1" | "SAMPLE2";
+export type MetadataScenario = "DEFAULT" | "SAMPLE1" | "SAMPLE2" | "SAMPLE3";
 
 class FieldLocatorService {
   // Method returns an object containing both the Locator and the content/text Pattern
@@ -54,6 +54,7 @@ export default class ItemMetadataPage {
     DEFAULT: "8b2b3160-c5d5-012f-d95c-58d385a7bc34",
     SAMPLE1: "25a47180-c55f-012f-3759-58d385a7bc34", // Topics
     SAMPLE2: "4649be20-9890-0138-2359-2360945aaf51", // Genres
+    SAMPLE3: "52ec6dd0-ff9e-012f-fa96-58d385a7bc34", // Type of Resource
   };
 
   async loadScenario(scenario: MetadataScenario): Promise<void> {

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -606,29 +606,12 @@ export default class ItemMetadataPage {
     }
   }
 
-  // async verifyRightsContent(): Promise<void> {
-  //   await expect(this.rightsHeading).toBeVisible();
-
-  //   // Content check: assert specific expected text
-  //   await expect(this.rightsText).toHaveText(ItemMetadataPage.EXPECTED_RIGHTS_VALUE);
-  // }
-
   async verifyRightsContent(): Promise<void> {
     await expect(this.rightsHeading).toBeVisible();
     await expect(this.rightsText).toContainText(
       ItemMetadataPage.EXPECTED_RIGHTS_VALUE
     );
   }
-
-  // async verifyRightsContent(): Promise<void> {
-  //   // Structural check: Ensure the element exists and is visible
-  //   await expect(this.rightsHeading).toBeVisible();
-
-  //   // Content check: Assert the specific expected text
-  //   await expect(this.rightsText).toHaveText(
-  //     "SOME RIGHTS TEXT WILL GO HERE, AND IT VARIES"
-  //   );
-  // }
 
   async loadPage(gotoPage: string): Promise<void> {
     await this.page.goto(gotoPage);

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -146,6 +146,8 @@ export default class ItemMetadataPage {
     },
   ];
   static readonly EXPECTED_RESOURCE_TYPES = ["Still Image", "Text"];
+  static readonly EXPECTED_RIGHTS_VALUE =
+    'The New York Public Library believes that this item is in the public domain under the laws of the United States, but did not make a determination as to its copyright status under the copyright laws of other countries. This item may not be in the public domain under the laws of other countries. Though not required, if you want to credit us as the source, please use the following statement, "From The New York Public Library," and provide a link back to the item on our Digital Collections site. Doing so helps us track how our collection is used and helps justify freely releasing even more content in the future.';
 
   constructor(page: Page) {
     this.page = page;
@@ -229,7 +231,7 @@ export default class ItemMetadataPage {
     this.languageText = this.languageHeading.locator("+ p");
 
     // Rights Statement
-    this.rightsHeading = this.page.getByText("Rights Statement", {
+    this.rightsHeading = this.page.getByText("Rights", {
       exact: true,
     });
     this.rightsText = this.rightsHeading.locator("+ p");
@@ -604,15 +606,29 @@ export default class ItemMetadataPage {
     }
   }
 
-  async verifyRightsContent(): Promise<void> {
-    // Structural check: Ensure the element exists and is visible
-    await expect(this.rightsHeading).toBeVisible();
+  // async verifyRightsContent(): Promise<void> {
+  //   await expect(this.rightsHeading).toBeVisible();
 
-    // Content check: Assert the specific expected text
-    await expect(this.rightsText).toHaveText(
-      "SOME RIGHTS TEXT WILL GO HERE, AND IT VARIES"
+  //   // Content check: assert specific expected text
+  //   await expect(this.rightsText).toHaveText(ItemMetadataPage.EXPECTED_RIGHTS_VALUE);
+  // }
+
+  async verifyRightsContent(): Promise<void> {
+    await expect(this.rightsHeading).toBeVisible();
+    await expect(this.rightsText).toContainText(
+      ItemMetadataPage.EXPECTED_RIGHTS_VALUE
     );
   }
+
+  // async verifyRightsContent(): Promise<void> {
+  //   // Structural check: Ensure the element exists and is visible
+  //   await expect(this.rightsHeading).toBeVisible();
+
+  //   // Content check: Assert the specific expected text
+  //   await expect(this.rightsText).toHaveText(
+  //     "SOME RIGHTS TEXT WILL GO HERE, AND IT VARIES"
+  //   );
+  // }
 
   async loadPage(gotoPage: string): Promise<void> {
     await this.page.goto(gotoPage);

--- a/playwright/pages/item-metadata.page.ts
+++ b/playwright/pages/item-metadata.page.ts
@@ -221,7 +221,7 @@ export default class ItemMetadataPage {
     this.descriptionText = this.descriptionHeading.locator("+ p");
 
     // Type of Resource
-    this.typeHeading = this.page.getByText("Type of Resource", { exact: true });
+    this.typeHeading = this.page.getByText("Type of Resource");
     this.typeText = this.typeHeading.locator("+ p");
 
     // Languages

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -77,6 +77,7 @@ test.describe("Verify Default Test Record", () => {
       await itemMetadataPage.verifyNameDataValues();
     });
   });
+
   test.describe("Physical Description", () => {
     test.beforeEach(async () => {
       // Verify identifiers heading and containers before checking content
@@ -86,6 +87,17 @@ test.describe("Verify Default Test Record", () => {
 
     test("should display correct physical description values", async () => {
       await itemMetadataPage.verifyPhysicalDescriptionContent();
+    });
+  });
+
+  test.describe("Rights Statement", () => {
+    test.beforeEach(async () => {
+      await expect(itemMetadataPage.rightsHeading).toBeVisible();
+      await expect(itemMetadataPage.rightsText).toBeVisible();
+    });
+
+    test("should display correct rights statement text", async () => {
+      await itemMetadataPage.verifyRightsContent();
     });
   });
 });

--- a/playwright/tests/item-metadata.spec.ts
+++ b/playwright/tests/item-metadata.spec.ts
@@ -154,3 +154,23 @@ test.describe("Verify Sample Record 2", () => {
     });
   });
 });
+
+test.describe("Verify Sample Record 3", () => {
+  test.beforeEach(async ({ page }) => {
+    await itemMetadataPage.loadScenario("SAMPLE3");
+  });
+
+  test.describe("Type of Resource", () => {
+    test("should include correct resource type values", async () => {
+      await itemMetadataPage.verifyTypeValues();
+    });
+
+    test("should contain the correct number of resource types", async () => {
+      await itemMetadataPage.verifyTypeCount();
+    });
+
+    test("should display resource types as links", async () => {
+      await itemMetadataPage.verifyTypeLinks();
+    });
+  });
+});


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3900](https://newyorkpubliclibrary.atlassian.net/browse/DR-3900)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

Adds Rights (single-valued field) test/check.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

This branch was forked from the pending [item-fields: type](https://github.com/NYPL/digital-collections/pull/512) work, so you'll see those changes in the diff until that first PR is merged. The only new logic here is the Rights field value, assertions, and Spec `describe.block`.


## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->
Ran on localhost via production build.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3900]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ