### PR TITLE
DR-4008 Cache user's viewing preference in session storage

### DIFF
--- a/app/src/components/pages/collectionPage/collectionPage.tsx
+++ b/app/src/components/pages/collectionPage/collectionPage.tsx
@@ -86,6 +86,12 @@ const CollectionPage = ({
   useSubcollectionRedirect();
 
   useEffect(() => {
+    if (searchParams?.viewMode) {
+      localStorage.setItem("viewMode", searchParams.viewMode);
+    }
+  }, [searchParams?.viewMode]);
+
+  useEffect(() => {
     setIsLoaded(true);
     let didFocusElement = false;
 

--- a/app/src/context/SearchProvider.tsx
+++ b/app/src/context/SearchProvider.tsx
@@ -34,13 +34,16 @@ export const SearchProvider = ({
   children: React.ReactNode;
 }) => {
   const urlSearchParams = useSearchParams();
-  const viewModeFromUrl = urlSearchParams.get("viewMode") as
-    | "grid"
-    | "list"
-    | null;
+  const viewModeFromUrl = urlSearchParams.get("viewMode");
+  const validViewMode = (
+    mode: string | null | undefined
+  ): mode is "grid" | "list" => mode === "grid" || mode === "list";
 
-  const initialViewMode =
-    viewModeFromUrl || searchParams?.viewMode || DEFAULT_VIEW_MODE;
+  const initialViewMode = validViewMode(viewModeFromUrl)
+    ? viewModeFromUrl
+    : validViewMode(searchParams?.viewMode)
+    ? searchParams.viewMode
+    : undefined;
 
   const lastFilterRef = useRef<string | null>(null);
 
@@ -77,16 +80,14 @@ export const SearchProvider = ({
       if (cachedViewMode !== viewModeFromUrl) {
         localStorage.setItem("viewMode", viewModeFromUrl);
       }
-    } else if (
-      cachedViewMode &&
-      ["grid", "list"].includes(cachedViewMode) &&
-      searchManager.viewMode !== cachedViewMode
-    ) {
-      searchManager.handleViewModeChange(cachedViewMode);
+    } else if (cachedViewMode && ["grid", "list"].includes(cachedViewMode)) {
+      if (searchManager.viewMode !== cachedViewMode) {
+        searchManager.handleViewModeChange(cachedViewMode);
+      }
     } else {
-      searchManager.handleViewModeChange(initialViewMode);
+      searchManager.handleViewModeChange(initialViewMode || DEFAULT_VIEW_MODE);
     }
-  }, [viewModeFromUrl, searchManager]);
+  }, [viewModeFromUrl, searchManager.viewMode, searchManager]);
 
   return (
     <SearchContext.Provider value={{ searchManager }}>

--- a/app/src/context/SearchProvider.tsx
+++ b/app/src/context/SearchProvider.tsx
@@ -37,7 +37,9 @@ export const SearchProvider = ({
   const viewModeFromUrl = urlSearchParams.get("viewMode");
   const validViewMode = (
     mode: string | null | undefined
-  ): mode is "grid" | "list" => mode === "grid" || mode === "list";
+  ): mode is "grid" | "list" => {
+    return mode === "grid" || mode === "list";
+  };
 
   const initialViewMode = validViewMode(viewModeFromUrl)
     ? viewModeFromUrl

--- a/app/src/context/SearchProvider.tsx
+++ b/app/src/context/SearchProvider.tsx
@@ -41,11 +41,14 @@ export const SearchProvider = ({
     return mode === "grid" || mode === "list";
   };
 
-  const initialViewMode = validViewMode(viewModeFromUrl)
-    ? viewModeFromUrl
-    : validViewMode(searchParams?.viewMode)
-    ? searchParams.viewMode
-    : undefined;
+  let initialViewMode: "grid" | "list" | undefined;
+  if (validViewMode(viewModeFromUrl)) {
+    initialViewMode = viewModeFromUrl;
+  } else if (validViewMode(searchParams?.viewMode)) {
+    initialViewMode = searchParams.viewMode;
+  } else {
+    initialViewMode = undefined;
+  }
 
   const lastFilterRef = useRef<string | null>(null);
 

--- a/app/src/context/SearchProvider.tsx
+++ b/app/src/context/SearchProvider.tsx
@@ -1,11 +1,18 @@
 "use client";
-import React, { createContext, useContext, useRef, useMemo } from "react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useMemo,
+} from "react";
 import { useSearchParams } from "next/navigation";
 import {
   DEFAULT_FILTERS,
   DEFAULT_PAGE_NUM,
   DEFAULT_SEARCH_SORT,
   DEFAULT_SEARCH_TERM,
+  DEFAULT_VIEW_MODE,
 } from "../config/constants";
 import {
   GeneralSearchManager,
@@ -32,6 +39,9 @@ export const SearchProvider = ({
     | "list"
     | null;
 
+  const initialViewMode =
+    viewModeFromUrl || searchParams?.viewMode || DEFAULT_VIEW_MODE;
+
   const lastFilterRef = useRef<string | null>(null);
 
   const searchManager = useMemo(() => {
@@ -44,7 +54,7 @@ export const SearchProvider = ({
       initialAvailableFilters:
         searchParams?.availableFilters || DEFAULT_FILTERS,
       lastFilterRef: lastFilterRef,
-      initialViewMode: viewModeFromUrl || searchParams?.viewMode,
+      initialViewMode: initialViewMode,
     });
     return manager;
   }, [
@@ -55,7 +65,28 @@ export const SearchProvider = ({
     searchParams?.availableFilters,
     searchParams?.viewMode,
     viewModeFromUrl,
+    initialViewMode,
   ]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const cachedViewMode = localStorage.getItem("viewMode") as "grid" | "list";
+
+    if (viewModeFromUrl) {
+      if (cachedViewMode !== viewModeFromUrl) {
+        localStorage.setItem("viewMode", viewModeFromUrl);
+      }
+    } else if (
+      cachedViewMode &&
+      ["grid", "list"].includes(cachedViewMode) &&
+      searchManager.viewMode !== cachedViewMode
+    ) {
+      searchManager.handleViewModeChange(cachedViewMode);
+    } else {
+      searchManager.handleViewModeChange(initialViewMode);
+    }
+  }, [viewModeFromUrl, searchManager]);
 
   return (
     <SearchContext.Provider value={{ searchManager }}>

--- a/app/src/utils/searchManager/searchManager.tsx
+++ b/app/src/utils/searchManager/searchManager.tsx
@@ -39,7 +39,7 @@ abstract class BaseSearchManager implements SearchManager {
   protected defaultSort: string;
   protected currentKeywords: string;
   protected currentFilters: Set<string>;
-  protected currentViewMode: "grid" | "list";
+  protected currentViewMode: "grid" | "list" | undefined;
   protected currentAvailableFilters: AvailableFilter[];
   public lastFilterRef: MutableRefObject<string | null>;
 
@@ -65,7 +65,9 @@ abstract class BaseSearchManager implements SearchManager {
       (config.initialFilters || []).map((filter) => JSON.stringify(filter))
     );
     this.currentKeywords = config.initialKeywords;
-    this.currentViewMode = config.initialViewMode || DEFAULT_VIEW_MODE;
+    this.currentViewMode = config.initialViewMode
+      ? config.initialViewMode
+      : undefined;
     this.currentAvailableFilters = transformToDisplayAvailableFilters(
       config.initialAvailableFilters ?? {}
     );
@@ -96,13 +98,14 @@ abstract class BaseSearchManager implements SearchManager {
 
   get viewMode() {
     if (typeof window !== "undefined") {
-      return (
-        (localStorage.getItem("viewMode") as "grid" | "list") ||
-        this.currentViewMode
-      );
-    } else {
-      return this.currentViewMode;
+      const cachedViewMode = localStorage.getItem("viewMode") as
+        | "grid"
+        | "list";
+      if (!this.currentViewMode && cachedViewMode) {
+        return cachedViewMode;
+      }
     }
+    return this.currentViewMode || DEFAULT_VIEW_MODE;
   }
 
   get availableFilters(): AvailableFilter[] {
@@ -241,7 +244,7 @@ export class GeneralSearchManager extends BaseSearchManager {
           isDefault = value === "";
           break;
         case "viewMode":
-          isDefault = value === DEFAULT_VIEW_MODE;
+          isDefault = false;
           break;
       }
 
@@ -317,7 +320,7 @@ export class CollectionSearchManager extends BaseSearchManager {
           isDefault = value === "";
           break;
         case "viewMode":
-          isDefault = value === DEFAULT_VIEW_MODE;
+          isDefault = false;
           break;
       }
 

--- a/app/src/utils/searchManager/searchManager.tsx
+++ b/app/src/utils/searchManager/searchManager.tsx
@@ -159,7 +159,9 @@ abstract class BaseSearchManager implements SearchManager {
   }
 
   handleViewModeChange(mode: "grid" | "list") {
-    localStorage.setItem("viewMode", mode);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("viewMode", mode);
+    }
     this.currentViewMode = mode;
     return this.getQueryString({
       q: this.currentKeywords,

--- a/app/src/utils/searchManager/searchManager.tsx
+++ b/app/src/utils/searchManager/searchManager.tsx
@@ -95,7 +95,14 @@ abstract class BaseSearchManager implements SearchManager {
   }
 
   get viewMode() {
-    return this.currentViewMode;
+    if (typeof window !== "undefined") {
+      return (
+        (localStorage.getItem("viewMode") as "grid" | "list") ||
+        this.currentViewMode
+      );
+    } else {
+      return this.currentViewMode;
+    }
   }
 
   get availableFilters(): AvailableFilter[] {
@@ -152,6 +159,7 @@ abstract class BaseSearchManager implements SearchManager {
   }
 
   handleViewModeChange(mode: "grid" | "list") {
+    localStorage.setItem("viewMode", mode);
     this.currentViewMode = mode;
     return this.getQueryString({
       q: this.currentKeywords,

--- a/playwright/tests/search-filters-sort.spec.ts
+++ b/playwright/tests/search-filters-sort.spec.ts
@@ -8,9 +8,9 @@ test.describe("choose specific sort options", () => {
     searchPage = new SearchPage(page);
     await searchPage.loadPage(SearchPage.searchResultsUrl);
 
-    await searchPage.sortButton.click();
-
     await expect(searchPage.refineHeading).toBeVisible();
+
+    await searchPage.sortButton.click();
   });
 
   test("sorts search results by relevance", async ({ page }) => {

--- a/playwright/tests/search-filters-sort.spec.ts
+++ b/playwright/tests/search-filters-sort.spec.ts
@@ -8,9 +8,9 @@ test.describe("choose specific sort options", () => {
     searchPage = new SearchPage(page);
     await searchPage.loadPage(SearchPage.searchResultsUrl);
 
-    await expect(searchPage.refineHeading).toBeVisible();
-
     await searchPage.sortButton.click();
+
+    await expect(searchPage.refineHeading).toBeVisible();
   });
 
   test("sorts search results by relevance", async ({ page }) => {

--- a/playwright/tests/search-filters-sort.spec.ts
+++ b/playwright/tests/search-filters-sort.spec.ts
@@ -8,10 +8,6 @@ test.describe("choose specific sort options", () => {
     searchPage = new SearchPage(page);
     await searchPage.loadPage(SearchPage.searchResultsUrl);
 
-    await page.evaluate(() => {
-      localStorage.setItem("viewMode", "grid");
-    });
-
     await searchPage.sortButton.click();
 
     await expect(searchPage.refineHeading).toBeVisible();

--- a/playwright/tests/search-filters-sort.spec.ts
+++ b/playwright/tests/search-filters-sort.spec.ts
@@ -8,6 +8,10 @@ test.describe("choose specific sort options", () => {
     searchPage = new SearchPage(page);
     await searchPage.loadPage(SearchPage.searchResultsUrl);
 
+    await page.evaluate(() => {
+      localStorage.setItem("viewMode", "grid");
+    });
+
     await searchPage.sortButton.click();
 
     await expect(searchPage.refineHeading).toBeVisible();


### PR DESCRIPTION
## Ticket:
[DR-4008](https://newyorkpubliclibrary.atlassian.net/browse/DR-4008)

## This PR does the following:
<!-- What has been updated or added in this PR? -->
Saves the current viewMode to localStorage and tries to retrieve the value from localStorage.

## Open questions
<!-- Any questions you want to ask the reviewer? -->
Is this the correct place for this logic? It seems to work fine when I click around.

## How has this been tested? How should a reviewer test this?
<!--- Please describe in detail how you tested your changes. -->
Tested this locally and can see the stored value in localStorage.
I also manually set the value to something other than `grid` or `list` and the grid view displays by default.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4008]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ