### PR TITLE
Explicitly disable newrelic during playwright - NOREF

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,6 +12,7 @@ jobs:
       #COLLECTIONS_API_AUTH_TOKEN: ${{ secrets.COLLECTIONS_API_AUTH_TOKEN }}
       COLLECTIONS_API_URL: ${{ secrets.QA_COLLECTIONS_API_URL }}
       COLLECTIONS_API_AUTH_TOKEN: ${{ secrets.QA_COLLECTIONS_API_AUTH_TOKEN }}
+      NEW_RELIC_ENABLED: false
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Ticket:

- NOREF 

## This PR does the following:

I believe all the dependabot PRs are breaking due to this - the static pages are not being built, I'm guessing because of the newrelic stuff we inject into the DOM?  The error messages seem to suggest that.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
