### PR TITLE
Make selecting already selected layout no-op 

### DIFF
--- a/app/src/components/viewingOptionsMenu/viewingOptionsMenu.tsx
+++ b/app/src/components/viewingOptionsMenu/viewingOptionsMenu.tsx
@@ -24,6 +24,20 @@ const ViewingOptionsMenu = ({
   sort,
   showViewModeButtons = true,
 }: ViewingOptionsMenuProps) => {
+  const layoutSelectHandler = (viewMode: "grid" | "list"): (() => void) => {
+    return () => {
+      if (searchManager.viewMode == viewMode) {
+        return;
+      }
+      sendLayoutSelectedEvent(viewMode);
+      if (setFiltersExpanded) {
+        setFiltersExpanded(false);
+      }
+      searchManager.setLastFilter(`${viewMode}-view-button`);
+      const queryString = searchManager.handleViewModeChange(viewMode);
+      updateURL(queryString);
+    };
+  };
   return (
     <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
       <Menu
@@ -60,15 +74,7 @@ const ViewingOptionsMenu = ({
           <Button
             variant={searchManager.viewMode == "grid" ? "primary" : "text"}
             aria-pressed={searchManager.viewMode == "grid" ? true : false}
-            onClick={() => {
-              sendLayoutSelectedEvent("grid");
-              if (setFiltersExpanded) {
-                setFiltersExpanded(false);
-              }
-              searchManager.setLastFilter("grid-view-button");
-              const queryString = searchManager.handleViewModeChange("grid");
-              updateURL(queryString);
-            }}
+            onClick={layoutSelectHandler("grid")}
             sx={{
               padding: "inherit",
               height: "auto",
@@ -89,14 +95,7 @@ const ViewingOptionsMenu = ({
           <Button
             variant={searchManager.viewMode == "list" ? "primary" : "text"}
             aria-pressed={searchManager.viewMode == "list" ? true : false}
-            onClick={() => {
-              sendLayoutSelectedEvent("list");
-              if (setFiltersExpanded) {
-                setFiltersExpanded(false);
-              }
-              searchManager.setLastFilter("list-view-button");
-              updateURL(searchManager.handleViewModeChange("list"));
-            }}
+            onClick={layoutSelectHandler("list")}
             sx={{
               padding: "inherit",
               height: "auto",


### PR DESCRIPTION
## Ticket:

NOREF

## This PR does the following:

If clicking the already selected view mode, just make the button no-op,
as that's probably what a user would expect anyway, and we don't want to
send dummy ga4 events or reload the search results.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
