### PR TITLE
Dr 3980 - Check grid/list for search results

### DIFF
--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -5,6 +5,7 @@ export default class SearchPage {
   readonly searchKeyword: string;
   readonly searchBar: Locator;
   readonly searchButton: Locator;
+  readonly searchInput: Locator;
 
   // search results
   static searchResultsUrl: string = "/search/index?q=map%20of%20scandinavia";
@@ -83,6 +84,9 @@ export default class SearchPage {
     this.searchKeyword = "map of scandinavia";
     this.searchBar = this.page.getByLabel("Search keyword(s)");
     this.searchButton = this.page.getByRole("button", { name: "Search" });
+    this.searchInput = this.page.getByRole("textbox", {
+      name: "Search keyword(s)",
+    });
 
     // search results
     this.resultsHeading = this.page.getByRole("heading", {
@@ -318,9 +322,54 @@ export default class SearchPage {
       } else {
         // List: Card 2 is displayed below Card 1
         expect(box2.y).toBeGreaterThan(box1.y + box1.height);
-        // And cards align on the left 'x' coordinate
+        // Cards align on the left 'x' coordinate
         expect(box1.x).toBeCloseTo(box2.x, 1);
       }
     }
+  }
+
+  async verifyMultiRowLayout(viewType: "grid" | "list"): Promise<void> {
+    const card1 = this.allCards.nth(0); // Box 1
+    const card4 = this.allCards.nth(3); // The Row/Column Indicator
+    const card5 = this.allCards.nth(4); // The Wrap Indicator
+
+    const box1 = await card1.boundingBox();
+    const box4 = await card4.boundingBox();
+    const box5 = await card5.boundingBox();
+
+    if (box1 && box4 && box5) {
+      if (viewType === "grid") {
+        // Card 4 shares same row as Card 1
+        expect(box4.y).toBeCloseTo(box1.y, 5);
+        // Card 5 must wrap back same column as Card 1
+        expect(box5.x).toBeCloseTo(box1.x, 5);
+        // Card 5 is in row below Card 4
+        expect(box5.y).toBeGreaterThan(box4.y);
+      } else {
+        // Card 4 shares same column as Card 1
+        expect(box4.x).toBeCloseTo(box1.x, 5);
+        // Card 5 shares same column as Card 4
+        expect(box5.x).toBeCloseTo(box1.x, 5);
+        // Cards 1, 4 and 5 are sequentially below each other
+        expect(box4.y).toBeGreaterThan(box1.y);
+        expect(box5.y).toBeGreaterThan(box4.y);
+      }
+    }
+  }
+
+  async verifyLayoutSearch(expectedView: "grid" | "list") {
+    await this.searchInput.clear();
+    await this.searchInput.fill("forest");
+    await this.searchButton.click();
+
+    await this.page.waitForLoadState("networkidle");
+    await this.verifyLayout(expectedView);
+  }
+
+  async verifyLayoutReloadState(expectedView: "grid" | "list") {
+    await this.page.reload();
+    await this.page.waitForLoadState("domcontentloaded");
+
+    await this.verifyLayout(expectedView);
   }
 }

--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -5,7 +5,6 @@ export default class SearchPage {
   readonly searchKeyword: string;
   readonly searchBar: Locator;
   readonly searchButton: Locator;
-  readonly searchInput: Locator;
 
   // search results
   static searchResultsUrl: string = "/search/index?q=map%20of%20scandinavia";
@@ -82,11 +81,8 @@ export default class SearchPage {
 
     // replace with homepage locators
     this.searchKeyword = "map of scandinavia";
-    this.searchBar = this.page.getByLabel("Search keyword(s)");
+    this.searchBar = this.page.getByPlaceholder(/search/i);
     this.searchButton = this.page.getByRole("button", { name: "Search" });
-    this.searchInput = this.page.getByRole("textbox", {
-      name: "Search keyword(s)",
-    });
 
     // search results
     this.resultsHeading = this.page.getByRole("heading", {
@@ -358,8 +354,8 @@ export default class SearchPage {
   }
 
   async verifyLayoutSearch(expectedView: "grid" | "list") {
-    await this.searchInput.clear();
-    await this.searchInput.fill("forest");
+    await this.searchBar.clear();
+    await this.searchBar.fill("forest");
     await this.searchButton.click();
 
     await this.allCards.first().waitFor({ state: "visible" });

--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -341,7 +341,7 @@ export default class SearchPage {
       if (viewType === "grid") {
         // Card 4 shares same row as Card 1
         expect(box4.y).toBeCloseTo(box1.y, 5);
-        // Card 5 must wrap back same column as Card 1
+        // Card 5 must wrap back to same column as Card 1
         expect(box5.x).toBeCloseTo(box1.x, 5);
         // Card 5 is in row below Card 4
         expect(box5.y).toBeGreaterThan(box4.y);

--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -8,6 +8,7 @@ export default class SearchPage {
 
   // search results
   static searchResultsUrl: string = "/search/index?q=map%20of%20scandinavia";
+  static largeResultsUrl: string = "/search/index?q=bridge";
   readonly resultsHeading: Locator;
   readonly firstItemResult: Locator;
   readonly firstKeywordResult: Locator;
@@ -69,6 +70,11 @@ export default class SearchPage {
   readonly sortByCollectionsSelected: Locator;
   readonly sortByItems: Locator;
   readonly sortByItemsSelected: Locator;
+
+  // toggle grid/list views
+  readonly gridViewButton: Locator;
+  readonly listViewButton: Locator;
+  readonly allCards: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -235,6 +241,20 @@ export default class SearchPage {
     this.sortByItemsSelected = this.page.getByRole("button", {
       name: "Sort by: Items first",
     });
+
+    // // just using locators
+    // this.gridViewButton = this.page.locator('button:has(#grid-menu-icon)');
+    // this.listViewButton = this.page.locator('button:has(#list-menu-icon)');
+    // this.allCards = this.page.getByTestId("ds-card");
+
+    // more playwright-y
+    this.gridViewButton = this.page
+      .getByRole("button", { name: /grid/i }) // Matches "Grid View", "Grid", "Grid images", etc.
+      .filter({ has: this.page.locator("#grid-menu-icon") });
+    this.listViewButton = this.page
+      .getByRole("button", { name: /list/i })
+      .filter({ has: this.page.locator("#list-menu-icon") });
+    this.allCards = this.page.getByTestId("ds-card");
   }
 
   async loadPage(gotoPage: string): Promise<void> {
@@ -264,5 +284,43 @@ export default class SearchPage {
     await expect(this.applyFilterButton).toBeVisible();
     await this.applyFilterButton.click();
     await expect(this.publisherSelected).toBeVisible();
+  }
+
+  async toggleView(viewType: "grid" | "list"): Promise<void> {
+    const targetBtn =
+      viewType === "list" ? this.listViewButton : this.gridViewButton;
+    const otherBtn =
+      viewType === "list" ? this.gridViewButton : this.listViewButton;
+
+    await expect(targetBtn).toBeVisible();
+    await targetBtn.click({ force: true });
+
+    // Verify the button is highlighted
+    await expect(targetBtn).toHaveAttribute("aria-pressed", "true");
+    await expect(otherBtn).toHaveAttribute("aria-pressed", "false");
+  }
+
+  async verifyLayout(viewType: "grid" | "list"): Promise<void> {
+    const card1 = this.allCards.first();
+    const card2 = this.allCards.nth(1);
+
+    // Wait for at least one card to be visible before measuring
+    await expect(card1).toBeVisible();
+
+    const box1 = await card1.boundingBox();
+    const box2 = await card2.boundingBox();
+
+    if (box1 && box2) {
+      if (viewType === "grid") {
+        // Grid: Cards share the same 'y' (top) coordinate
+        expect(box1.y).toBeCloseTo(box2.y, 1);
+        expect(box1.x).toBeLessThan(box2.x);
+      } else {
+        // List: Card 2 is displayed below Card 1
+        expect(box2.y).toBeGreaterThan(box1.y + box1.height);
+        // And cards align on the left 'x' coordinate
+        expect(box1.x).toBeCloseTo(box2.x, 1);
+      }
+    }
   }
 }

--- a/playwright/pages/search.page.ts
+++ b/playwright/pages/search.page.ts
@@ -362,7 +362,7 @@ export default class SearchPage {
     await this.searchInput.fill("forest");
     await this.searchButton.click();
 
-    await this.page.waitForLoadState("networkidle");
+    await this.allCards.first().waitFor({ state: "visible" });
     await this.verifyLayout(expectedView);
   }
 

--- a/playwright/tests/search-filters-grid.spec.ts
+++ b/playwright/tests/search-filters-grid.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "../base";
+import SearchPage from "../pages/search.page";
+import { applyRouteFilters } from "../utils/routeFilters";
+
+let searchPage: SearchPage;
+
+test.describe.serial("Verify Grid/List Layouts", () => {
+  test.beforeAll(async ({ browser }) => {
+    // Manually create context/page to force serialization to remain in block
+    const browserContext = await browser.newContext();
+    const page = await browserContext.newPage();
+
+    // Assign to global variable and load the page object
+    searchPage = new SearchPage(page);
+    await searchPage.loadPage(SearchPage.largeResultsUrl);
+  });
+
+  // TEARDOWN: close the entire context.
+  test.afterAll(async () => {
+    // Closes the BrowserContext, freeing up resources.
+    await searchPage.page.context().close();
+  });
+
+  test.describe.serial("Toggle default results to list view", async () => {
+    await test.step("When clicking the list view icon", async () => {
+      await searchPage.listViewButton.click({ force: true });
+    });
+
+    await test.step("list button is highlighted", async () => {
+      await expect(searchPage.listViewButton).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+      await expect(searchPage.gridViewButton).toHaveAttribute(
+        "aria-pressed",
+        "false"
+      );
+    });
+
+    await test.step("results are displayed in a list view", async () => {
+      await searchPage.verifyLayout("list");
+    });
+  });
+
+  test("Toggle search results back to grid view", async () => {
+    await test.step("When clicking the grid view icon", async () => {
+      await searchPage.gridViewButton.click({ force: true });
+    });
+
+    await test.step("grid button is highlighted", async () => {
+      await expect(searchPage.gridViewButton).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+      await expect(searchPage.listViewButton).toHaveAttribute(
+        "aria-pressed",
+        "false"
+      );
+    });
+
+    await test.step("results are displayed in a grid", async () => {
+      await searchPage.verifyLayout("grid");
+    });
+  });
+});
+
+test.describe.serial("toggle results visualization", () => {
+  test.beforeEach(async ({ page }) => {
+    searchPage = new SearchPage(page);
+    await searchPage.loadPage(SearchPage.largeResultsUrl);
+  });
+
+  test("toggles search results to list view", async () => {
+    await test.step("Click the list view icon", async () => {
+      await searchPage.listViewButton.click({ force: true });
+    });
+
+    await test.step("Verify list button shows 'pressed'", async () => {
+      await expect(searchPage.listViewButton).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+      await expect(searchPage.gridViewButton).toHaveAttribute(
+        "aria-pressed",
+        "false"
+      );
+    });
+
+    await test.step("Verify results are displayed in a vertical stack", async () => {
+      // Logic defined in POM: checks that box2.y > box1.y
+      await searchPage.verifyLayout("list");
+    });
+  });
+
+  test("toggles search results back to grid view", async () => {
+    // Because of .serial, we are already in List view from the previous test
+
+    await test.step("Click the grid view icon", async () => {
+      await searchPage.gridViewButton.click({ force: true });
+    });
+
+    await test.step("Verify grid button shows 'pressed'", async () => {
+      await expect(searchPage.gridViewButton).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+      await expect(searchPage.listViewButton).toHaveAttribute(
+        "aria-pressed",
+        "false"
+      );
+    });
+
+    await test.step("Verify results are displayed in a grid", async () => {
+      // Logic defined in POM: checks that box1.y is close to box2.y
+      await searchPage.verifyLayout("grid");
+    });
+  });
+});

--- a/playwright/tests/search-filters-grid.spec.ts
+++ b/playwright/tests/search-filters-grid.spec.ts
@@ -4,50 +4,56 @@ import { applyRouteFilters } from "../utils/routeFilters";
 
 let searchPage: SearchPage;
 
-test.describe.serial("Verify Grid/List Layouts", () => {
+test.describe("Verify Grid and List Layouts", () => {
   test.beforeAll(async ({ browser }) => {
-    // Manually create context/page to force serialization to remain in block
     const browserContext = await browser.newContext();
     const page = await browserContext.newPage();
-
-    // Assign to global variable and load the page object
     searchPage = new SearchPage(page);
     await searchPage.loadPage(SearchPage.largeResultsUrl);
   });
 
-  // TEARDOWN: close the entire context.
   test.afterAll(async () => {
-    // Closes the BrowserContext, freeing up resources.
     await searchPage.page.context().close();
   });
 
-  test.describe.serial("Toggle default results to list view", async () => {
-    await test.step("When clicking the list view icon", async () => {
+  test.describe.serial("List view", () => {
+    test("list button is highlighted", async () => {
+      await searchPage.listViewButton.click({ force: true });
+      await expect(searchPage.listViewButton).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+      await expect(searchPage.gridViewButton).toHaveAttribute(
+        "aria-pressed",
+        "false"
+      );
+    });
+
+    test("results are displayed in a list view", async () => {
+      await searchPage.verifyLayout("list");
+    });
+
+    test("multi-row results retain their list view", async () => {
+      await searchPage.verifyMultiRowLayout("list");
+    });
+
+    test("remains a list after reload", async () => {
+      await searchPage.verifyLayoutReloadState("list");
+    });
+
+    test("remains a list after a new search", async () => {
+      await searchPage.verifyLayoutSearch("list");
+    });
+  });
+
+  test.describe.serial("Grid view", () => {
+    test.beforeAll(async () => {
+      // set up list view first, since grid is default
       await searchPage.listViewButton.click({ force: true });
     });
 
-    await test.step("list button is highlighted", async () => {
-      await expect(searchPage.listViewButton).toHaveAttribute(
-        "aria-pressed",
-        "true"
-      );
-      await expect(searchPage.gridViewButton).toHaveAttribute(
-        "aria-pressed",
-        "false"
-      );
-    });
-
-    await test.step("results are displayed in a list view", async () => {
-      await searchPage.verifyLayout("list");
-    });
-  });
-
-  test("Toggle search results back to grid view", async () => {
-    await test.step("When clicking the grid view icon", async () => {
+    test("grid button is highlighted", async () => {
       await searchPage.gridViewButton.click({ force: true });
-    });
-
-    await test.step("grid button is highlighted", async () => {
       await expect(searchPage.gridViewButton).toHaveAttribute(
         "aria-pressed",
         "true"
@@ -58,61 +64,20 @@ test.describe.serial("Verify Grid/List Layouts", () => {
       );
     });
 
-    await test.step("results are displayed in a grid", async () => {
+    test("results are displayed in a grid", async () => {
       await searchPage.verifyLayout("grid");
     });
-  });
-});
 
-test.describe.serial("toggle results visualization", () => {
-  test.beforeEach(async ({ page }) => {
-    searchPage = new SearchPage(page);
-    await searchPage.loadPage(SearchPage.largeResultsUrl);
-  });
-
-  test("toggles search results to list view", async () => {
-    await test.step("Click the list view icon", async () => {
-      await searchPage.listViewButton.click({ force: true });
+    test("multi-row results retain their grid view", async () => {
+      await searchPage.verifyMultiRowLayout("grid");
     });
 
-    await test.step("Verify list button shows 'pressed'", async () => {
-      await expect(searchPage.listViewButton).toHaveAttribute(
-        "aria-pressed",
-        "true"
-      );
-      await expect(searchPage.gridViewButton).toHaveAttribute(
-        "aria-pressed",
-        "false"
-      );
+    test("remains a grid after reload", async () => {
+      await searchPage.verifyLayoutReloadState("grid");
     });
 
-    await test.step("Verify results are displayed in a vertical stack", async () => {
-      // Logic defined in POM: checks that box2.y > box1.y
-      await searchPage.verifyLayout("list");
-    });
-  });
-
-  test("toggles search results back to grid view", async () => {
-    // Because of .serial, we are already in List view from the previous test
-
-    await test.step("Click the grid view icon", async () => {
-      await searchPage.gridViewButton.click({ force: true });
-    });
-
-    await test.step("Verify grid button shows 'pressed'", async () => {
-      await expect(searchPage.gridViewButton).toHaveAttribute(
-        "aria-pressed",
-        "true"
-      );
-      await expect(searchPage.listViewButton).toHaveAttribute(
-        "aria-pressed",
-        "false"
-      );
-    });
-
-    await test.step("Verify results are displayed in a grid", async () => {
-      // Logic defined in POM: checks that box1.y is close to box2.y
-      await searchPage.verifyLayout("grid");
+    test("remains a grid after a new search", async () => {
+      await searchPage.verifyLayoutSearch("grid");
     });
   });
 });


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3980](https://newyorkpubliclibrary.atlassian.net/browse/DR-3980)

## This PR does the following:

<!-- What has been updated or added in this PR? -->
These playwright tests check the new list and grid views for search results.  Checks if correct button is highlighted, confirms the grid/list views are on the correct coordinates visually, and tests if the layout remains "sticky" during the session after the next search and after reload.

## Open questions

<!-- Any questions you want to ask the reviewer? -->
The grid-layout-part of the test has a "basic" check first, then also a check for multi-rows.   Thinking of combining these into one method, as it looks a little non-DRY in the POM file.  However, this might also be fine for this particular test?

The advantage of having the two separate checks is that I can use the "default" search results of only 4 images for a basic check: (do image 1-4 line up on the x-axis, etc.), and then add the multi-row results to confirm wraps of 5+ images on grid also layout correctly.   Just not sure if both tests are entirely necessary.   I guess something could go wacky with a "1-line" (under 5 images) grid, so the basic test does add guardrails around that.

For the collection grid/list, i will make a separate PR, since that has to handle 3 columns, and is specific only (?) to the collections-browse UI.

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->
ran test suite locally on prod build
## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3980]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ