### PR TITLE
DRAFT: NO_REF / Add slow-flag to media-asset check that consistently has to retry in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,8 @@ import { defineConfig, devices } from "@playwright/test";
  * See https://playwright.dev/docs/test-configuration.
  */
 
+process.env.IIIF_URL = process.env.IIIF_URL || "https://iiif.nypl.org";
+
 export default defineConfig({
   testDir: "./playwright",
   timeout: 30000, // default timeout for each test

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,10 +40,16 @@ export default defineConfig({
   /* Configure projects for major browsers */
   projects: [
     {
+      name: "setup",
+      testMatch: /setup\/warmup-media\.ts/,
+    },
+    {
       name: "chromium",
       use: {
         ...devices["Desktop Chrome"],
       },
+      dependencies: ["setup"],
+      testIgnore: /setup\/.*/,
     },
 
     // {

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -6,6 +6,8 @@ export default class ItemMediaPage {
   static readonly IMAGE_UUID = "4387c9f0-c53c-012f-9924-58d385a7bc34";
   static readonly VIDEO_UUID = "09a14bf0-0382-0131-8ec7-3c075448cc4b";
   static readonly PUBLICDOMAIN_UUID = "ddaef250-c54d-012f-2b56-58d385a7bc34";
+  static readonly IMAGE_IMAGEID = "821487";
+
   // Store the expected content-types
   readonly expectedContentType: "IMAGE" | "VIDEO";
 
@@ -29,6 +31,23 @@ export default class ItemMediaPage {
 
   static getItemURL(uuid: string): string {
     return `/items/${uuid}`;
+  }
+
+  // Setup iiif warm-up
+  static get IIIF_BASE_URL(): string {
+    const url = process.env.IIIF_URL;
+    if (!url) {
+      throw new Error(
+        "\n\n [ENV ERROR]: IIIF_URL is undefined. \n" +
+          "Run 'export locally or check CI.\n"
+      );
+    }
+    return url;
+  }
+
+  // Construct IIIF url
+  static getIIIFWarmupURL(): string {
+    return `${this.IIIF_BASE_URL}/iiif/3/${this.IMAGE_IMAGEID}/full/200,/0/default.jpg`;
   }
 
   constructor(page: Page, expectedType: "IMAGE" | "VIDEO") {

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -8,10 +8,26 @@ export default class ItemMediaPage {
   // static readonly PUBLICDOMAIN_UUID = "ddaef250-c54d-012f-2b56-58d385a7bc34";
   // static readonly IMAGE_IMAGEID = "821487";
 
-  static readonly IMAGE_UUID = "9ed6a200-c5fe-012f-51eb-58d385a7bc34";
-  static readonly IMAGE_IMAGEID = "404083";
-  static readonly VIDEO_UUID = "9d0b0200-e378-0130-c01b-3c075448cc4b";
-  static readonly PUBLICDOMAIN_UUID = "c4649390-c6df-012f-fcd9-58d385a7bc34";
+  // static readonly IMAGE_UUID = "9ed6a200-c5fe-012f-51eb-58d385a7bc34";
+  // static readonly IMAGE_IMAGEID = "404083";
+  // static readonly VIDEO_UUID = "9d0b0200-e378-0130-c01b-3c075448cc4b";
+  // static readonly PUBLICDOMAIN_UUID = "c4649390-c6df-012f-fcd9-58d385a7bc34";
+
+  // static readonly IMAGE_UUID = "f2416750-5530-0135-9b00-1bd2ebeab8de";
+  // static readonly IMAGE_IMAGEID = "57366147";
+  // static readonly VIDEO_UUID = "27e5bd00-e378-0130-2025-3c075448cc4b";
+  // static readonly PUBLICDOMAIN_UUID = "79149800-ea2a-0133-d30f-00505686d14e";
+
+  // static readonly IMAGE_UUID = "1235c2d0-e8ff-0131-dd75-58d385a7b928";
+  // static readonly IMAGE_IMAGEID = "5146225";
+  // static readonly VIDEO_UUID = "93547140-f876-0130-3a9e-3c075448cc4b";
+  // static readonly PUBLICDOMAIN_UUID = "100d2590-996a-0139-4432-0242ac11000";
+
+  static readonly IMAGE_UUID = "2908e770-93e9-0130-c6a3-58d385a7b928";
+  static readonly IMAGE_IMAGEID = "5051201";
+  static readonly VIDEO_UUID = "93547140-f876-0130-3a9e-3c075448cc4b";
+  static readonly PUBLICDOMAIN_UUID = "d583c9f0-c5ed-012f-714b-58d385a7bc34";
+  static readonly PUBLICDOMAIN_IMAGEID = "433682";
 
   // Store the expected content-types
   readonly expectedContentType: "IMAGE" | "VIDEO";
@@ -50,10 +66,14 @@ export default class ItemMediaPage {
     return url;
   }
 
-  // Construct IIIF url
-  static getIIIFWarmupURL(): string {
-    return `${this.IIIF_BASE_URL}/iiif/3/${this.IMAGE_IMAGEID}/full/200,/0/default.jpg`;
+  static getIIIFWarmupURL(imageId: string = this.IMAGE_IMAGEID): string {
+    return `${this.IIIF_BASE_URL}/iiif/3/${imageId}/full/200,/0/default.jpg`;
   }
+
+  // // Construct IIIF url
+  // static getIIIFWarmupURL(): string {
+  //   return `${this.IIIF_BASE_URL}/iiif/3/${this.IMAGE_IMAGEID}/full/200,/0/default.jpg`;
+  // }
 
   constructor(page: Page, expectedType: "IMAGE" | "VIDEO") {
     this.page = page;

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -23,11 +23,11 @@ export default class ItemMediaPage {
   // static readonly VIDEO_UUID = "93547140-f876-0130-3a9e-3c075448cc4b";
   // static readonly PUBLICDOMAIN_UUID = "100d2590-996a-0139-4432-0242ac11000";
 
-  static readonly IMAGE_UUID = "2908e770-93e9-0130-c6a3-58d385a7b928";
-  static readonly IMAGE_IMAGEID = "5051201";
+  static readonly IMAGE_UUID = "d336d020-75dd-0133-612e-00505686d14e";
+  static readonly IMAGE_IMAGEID = "57273250";
   static readonly VIDEO_UUID = "93547140-f876-0130-3a9e-3c075448cc4b";
-  static readonly PUBLICDOMAIN_UUID = "d583c9f0-c5ed-012f-714b-58d385a7bc34";
-  static readonly PUBLICDOMAIN_IMAGEID = "433682";
+  static readonly PUBLICDOMAIN_UUID = "d94c9eb0-c5fe-012f-36ea-58d385a7bc34";
+  static readonly PUBLICDOMAIN_IMAGEID = "1811136";
 
   // Store the expected content-types
   readonly expectedContentType: "IMAGE" | "VIDEO";
@@ -54,9 +54,8 @@ export default class ItemMediaPage {
     return `/items/${uuid}`;
   }
 
-  // Setup iiif warm-up
   static get IIIF_BASE_URL(): string {
-    const url = process.env.IIIF_URL;
+    const url = process.env.IIIF_URL || "https://iiif.nypl.org";
     if (!url) {
       throw new Error(
         "\n\n [ENV ERROR]: IIIF_URL is undefined. \n" +
@@ -67,13 +66,10 @@ export default class ItemMediaPage {
   }
 
   static getIIIFWarmupURL(imageId: string = this.IMAGE_IMAGEID): string {
-    return `${this.IIIF_BASE_URL}/iiif/3/${imageId}/full/200,/0/default.jpg`;
+    const baseUrl = this.IIIF_BASE_URL;
+    const warmupUrl = `${this.IIIF_BASE_URL}/iiif/3/${imageId}/full/200,/0/default.jpg`;
+    return warmupUrl;
   }
-
-  // // Construct IIIF url
-  // static getIIIFWarmupURL(): string {
-  //   return `${this.IIIF_BASE_URL}/iiif/3/${this.IMAGE_IMAGEID}/full/200,/0/default.jpg`;
-  // }
 
   constructor(page: Page, expectedType: "IMAGE" | "VIDEO") {
     this.page = page;

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -3,10 +3,15 @@ import { Locator, Page, expect } from "@playwright/test";
 export default class ItemMediaPage {
   readonly page: Page;
 
-  static readonly IMAGE_UUID = "4387c9f0-c53c-012f-9924-58d385a7bc34";
-  static readonly VIDEO_UUID = "09a14bf0-0382-0131-8ec7-3c075448cc4b";
-  static readonly PUBLICDOMAIN_UUID = "ddaef250-c54d-012f-2b56-58d385a7bc34";
-  static readonly IMAGE_IMAGEID = "821487";
+  // static readonly IMAGE_UUID = "4387c9f0-c53c-012f-9924-58d385a7bc34";
+  // static readonly VIDEO_UUID = "09a14bf0-0382-0131-8ec7-3c075448cc4b";
+  // static readonly PUBLICDOMAIN_UUID = "ddaef250-c54d-012f-2b56-58d385a7bc34";
+  // static readonly IMAGE_IMAGEID = "821487";
+
+  static readonly IMAGE_UUID = "9ed6a200-c5fe-012f-51eb-58d385a7bc34";
+  static readonly IMAGE_IMAGEID = "404083";
+  static readonly VIDEO_UUID = "9d0b0200-e378-0130-c01b-3c075448cc4b";
+  static readonly PUBLICDOMAIN_UUID = "c4649390-c6df-012f-fcd9-58d385a7bc34";
 
   // Store the expected content-types
   readonly expectedContentType: "IMAGE" | "VIDEO";
@@ -39,7 +44,7 @@ export default class ItemMediaPage {
     if (!url) {
       throw new Error(
         "\n\n [ENV ERROR]: IIIF_URL is undefined. \n" +
-          "Run 'export locally or check CI.\n"
+          "Run export locally or check CI.\n"
       );
     }
     return url;

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -3,11 +3,11 @@ import { Locator, Page, expect } from "@playwright/test";
 export default class ItemMediaPage {
   readonly page: Page;
 
-  static readonly IMAGE_UUID = "072bf850-7692-0137-124d-0e5a0d71995d";
-  static readonly IMAGE_IMAGEID = "58053562";
+  static readonly IMAGE_UUID = "d2e96310-c614-012f-8c44-58d385a7bc34";
+  static readonly IMAGE_IMAGEID = "487528";
   static readonly VIDEO_UUID = "93547140-f876-0130-3a9e-3c075448cc4b";
-  static readonly PUBLICDOMAIN_UUID = "b1cde9f0-8bd2-0133-8b81-00505686a51c";
-  static readonly PUBLICDOMAIN_IMAGEID = "57231531";
+  static readonly PUBLICDOMAIN_UUID = "63a24db0-c5f9-012f-ac43-58d385a7bc34";
+  static readonly PUBLICDOMAIN_IMAGEID = "108541";
 
   // Store the expected content-types
   readonly expectedContentType: "IMAGE" | "VIDEO";

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -3,26 +3,6 @@ import { Locator, Page, expect } from "@playwright/test";
 export default class ItemMediaPage {
   readonly page: Page;
 
-  // static readonly IMAGE_UUID = "4387c9f0-c53c-012f-9924-58d385a7bc34";
-  // static readonly VIDEO_UUID = "09a14bf0-0382-0131-8ec7-3c075448cc4b";
-  // static readonly PUBLICDOMAIN_UUID = "ddaef250-c54d-012f-2b56-58d385a7bc34";
-  // static readonly IMAGE_IMAGEID = "821487";
-
-  // static readonly IMAGE_UUID = "9ed6a200-c5fe-012f-51eb-58d385a7bc34";
-  // static readonly IMAGE_IMAGEID = "404083";
-  // static readonly VIDEO_UUID = "9d0b0200-e378-0130-c01b-3c075448cc4b";
-  // static readonly PUBLICDOMAIN_UUID = "c4649390-c6df-012f-fcd9-58d385a7bc34";
-
-  // static readonly IMAGE_UUID = "f2416750-5530-0135-9b00-1bd2ebeab8de";
-  // static readonly IMAGE_IMAGEID = "57366147";
-  // static readonly VIDEO_UUID = "27e5bd00-e378-0130-2025-3c075448cc4b";
-  // static readonly PUBLICDOMAIN_UUID = "79149800-ea2a-0133-d30f-00505686d14e";
-
-  // static readonly IMAGE_UUID = "1235c2d0-e8ff-0131-dd75-58d385a7b928";
-  // static readonly IMAGE_IMAGEID = "5146225";
-  // static readonly VIDEO_UUID = "93547140-f876-0130-3a9e-3c075448cc4b";
-  // static readonly PUBLICDOMAIN_UUID = "100d2590-996a-0139-4432-0242ac11000";
-
   static readonly IMAGE_UUID = "072bf850-7692-0137-124d-0e5a0d71995d";
   static readonly IMAGE_IMAGEID = "58053562";
   static readonly VIDEO_UUID = "93547140-f876-0130-3a9e-3c075448cc4b";

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -23,11 +23,11 @@ export default class ItemMediaPage {
   // static readonly VIDEO_UUID = "93547140-f876-0130-3a9e-3c075448cc4b";
   // static readonly PUBLICDOMAIN_UUID = "100d2590-996a-0139-4432-0242ac11000";
 
-  static readonly IMAGE_UUID = "d336d020-75dd-0133-612e-00505686d14e";
-  static readonly IMAGE_IMAGEID = "57273250";
+  static readonly IMAGE_UUID = "072bf850-7692-0137-124d-0e5a0d71995d";
+  static readonly IMAGE_IMAGEID = "58053562";
   static readonly VIDEO_UUID = "93547140-f876-0130-3a9e-3c075448cc4b";
-  static readonly PUBLICDOMAIN_UUID = "d94c9eb0-c5fe-012f-36ea-58d385a7bc34";
-  static readonly PUBLICDOMAIN_IMAGEID = "1811136";
+  static readonly PUBLICDOMAIN_UUID = "b1cde9f0-8bd2-0133-8b81-00505686a51c";
+  static readonly PUBLICDOMAIN_IMAGEID = "57231531";
 
   // Store the expected content-types
   readonly expectedContentType: "IMAGE" | "VIDEO";

--- a/playwright/setup/warmup-media.ts
+++ b/playwright/setup/warmup-media.ts
@@ -3,6 +3,12 @@ import ItemMediaPage from "../pages/item-media.page";
 
 setup("warmup: media assets", async ({ request }) => {
   setup.setTimeout(90000);
+  // since we are using a test-type framework in this utility,
+  // the 90 sec should ensure that there is a long enough timeout
+  // for one of the CI's limited wokers to first poke IIIF, then
+  // still have enough time to land on the item-media test before
+  // playwright calls finish line.  The default timeout of
+  // 30 sec wasn't allowing this sometimes on slower cold starts.
 
   const urls = [
     ItemMediaPage.IMAGE_IMAGEID,

--- a/playwright/setup/warmup-media.ts
+++ b/playwright/setup/warmup-media.ts
@@ -2,12 +2,25 @@ import { test as setup } from "@playwright/test";
 import ItemMediaPage from "../pages/item-media.page";
 
 setup("warmup: media assets", async ({ request }) => {
-  const url = ItemMediaPage.getIIIFWarmupURL();
+  setup.setTimeout(90000);
 
-  //request.get(url).catch(() => {});
+  const urls = [
+    ItemMediaPage.IMAGE_IMAGEID,
+    ItemMediaPage.PUBLICDOMAIN_IMAGEID,
+  ];
 
-  request.get(url).catch((e) => console.log(e));
+  for (const id of urls) {
+    // Pass the to POM for url
+    const url = ItemMediaPage.getIIIFWarmupURL(id);
 
-  // give IIIF a running-start to warm before site kicks off
+    console.log(`[START-CONNECT]: ${id}`);
+
+    await request
+      .get(url)
+      .then((res) => console.log(`[CONNECT] ${id} Status: ${res.status()}`))
+      .catch((e) => console.log(`[ERROR] ${id}: ${e.message}`));
+  }
+
+  // give IIIF a running-start to warm before suite kicks off
   await new Promise((resolve) => setTimeout(resolve, 10000));
 });

--- a/playwright/setup/warmup-media.ts
+++ b/playwright/setup/warmup-media.ts
@@ -1,0 +1,10 @@
+import { test as setup } from "@playwright/test";
+import ItemMediaPage from "../pages/item-media.page";
+
+setup("warmup: media assets", async ({ request }) => {
+  const url = ItemMediaPage.getIIIFWarmupURL();
+
+  request.get(url).catch(() => {});
+  // give IIIF a running-start to warm before site kicks off
+  await new Promise((resolve) => setTimeout(resolve, 10000));
+});

--- a/playwright/setup/warmup-media.ts
+++ b/playwright/setup/warmup-media.ts
@@ -19,6 +19,8 @@ setup("warmup: media assets", async ({ request }) => {
     // Pass the to POM for url
     const url = ItemMediaPage.getIIIFWarmupURL(id);
 
+    console.log(`[START-DOMAIN]: ${url}`);
+
     console.log(`[START-CONNECT]: ${id}`);
 
     await request

--- a/playwright/setup/warmup-media.ts
+++ b/playwright/setup/warmup-media.ts
@@ -1,5 +1,6 @@
 import { test as setup } from "@playwright/test";
 import ItemMediaPage from "../pages/item-media.page";
+import { applyRouteFilters } from "../utils/routeFilters";
 
 setup("warmup: media assets", async ({ request }) => {
   setup.setTimeout(90000);
@@ -16,9 +17,9 @@ setup("warmup: media assets", async ({ request }) => {
   ];
 
   for (const id of urls) {
-    // Pass the to POM for url
     const url = ItemMediaPage.getIIIFWarmupURL(id);
 
+    // Your original log line, now with the truth revealed
     console.log(`[START-DOMAIN]: ${url}`);
 
     console.log(`[START-CONNECT]: ${id}`);

--- a/playwright/setup/warmup-media.ts
+++ b/playwright/setup/warmup-media.ts
@@ -4,7 +4,10 @@ import ItemMediaPage from "../pages/item-media.page";
 setup("warmup: media assets", async ({ request }) => {
   const url = ItemMediaPage.getIIIFWarmupURL();
 
-  request.get(url).catch(() => {});
+  //request.get(url).catch(() => {});
+
+  request.get(url).catch((e) => console.log(e));
+
   // give IIIF a running-start to warm before site kicks off
   await new Promise((resolve) => setTimeout(resolve, 10000));
 });

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -2,12 +2,29 @@ import { test, expect } from "../base";
 import ItemMediaPage from "../pages/item-media.page";
 
 let itemMediaPage: ItemMediaPage;
+let actualCluster = "No IIIF traffic detected";
 
 test.describe("Verify Image Viewer Controls", () => {
   test.beforeEach(async ({ page }) => {
     itemMediaPage = new ItemMediaPage(page, "IMAGE");
 
+    // Attach passive listener to confirm image media source
+    page.on("request", (request) => {
+      const url = request.url();
+      if (url.includes("/iiif/")) {
+        try {
+          actualCluster = new URL(url).hostname;
+        } catch (e) {
+          // Fallback if URL can't be parsed
+          actualCluster = url;
+        }
+      }
+    });
     await itemMediaPage.loadPage(ItemMediaPage.IMAGE_UUID);
+  });
+
+  test.afterAll(async () => {
+    console.log(`\n IIIF-URL: [ ${actualCluster} ]\n`);
   });
 
   test("primary image-specific controls are visible", async () => {

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -1,6 +1,25 @@
 import { test, expect } from "../base";
 import ItemMediaPage from "../pages/item-media.page";
 
+test.beforeAll(async ({ playwright, baseURL }) => {
+  if (process.env.CI) {
+    const context = await playwright.request.newContext();
+
+    const targets = [
+      ItemMediaPage.IMAGE_UUID,
+      ItemMediaPage.VIDEO_UUID,
+      ItemMediaPage.PUBLICDOMAIN_UUID,
+    ].map((uuid) => `${baseURL}${ItemMediaPage.getItemURL(uuid)}`);
+
+    // hit media to warm-up but don't wait for results
+    targets.forEach((url) => {
+      context.get(url).catch(() => {});
+    });
+
+    console.log("pre-warm requests for media assets...");
+  }
+});
+
 let itemMediaPage: ItemMediaPage;
 
 test.describe("Verify Image Viewer Controls", () => {

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -47,6 +47,7 @@ test.describe("Verify Download Actions", () => {
   });
 
   test("should display all available download options", async () => {
+    test.slow();
     await itemMediaPage.getViewerControls();
     await itemMediaPage.openDownloadMenu();
 

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -66,7 +66,7 @@ test.describe("Verify Download Actions", () => {
   });
 
   test("should display all available download options", async () => {
-    test.slow();
+    // test.slow();
     await itemMediaPage.getViewerControls();
     await itemMediaPage.openDownloadMenu();
 

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -1,25 +1,6 @@
 import { test, expect } from "../base";
 import ItemMediaPage from "../pages/item-media.page";
 
-test.beforeAll(async ({ playwright, baseURL }) => {
-  if (process.env.CI) {
-    const context = await playwright.request.newContext();
-
-    const targets = [
-      ItemMediaPage.IMAGE_UUID,
-      ItemMediaPage.VIDEO_UUID,
-      ItemMediaPage.PUBLICDOMAIN_UUID,
-    ].map((uuid) => `${baseURL}${ItemMediaPage.getItemURL(uuid)}`);
-
-    // hit media to warm-up but don't wait for results
-    targets.forEach((url) => {
-      context.get(url).catch(() => {});
-    });
-
-    console.log("pre-warm requests for media assets...");
-  }
-});
-
 let itemMediaPage: ItemMediaPage;
 
 test.describe("Verify Image Viewer Controls", () => {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-xxxx](url)

## This PR does the following:

<!-- What has been updated or added in this PR? -->
Noticed one of the test-blocks in the check-media spec consistently has to re-run on CI, or even fails outright the first time, then works on a hard, manual kick.

Adding playwright's `test(slow);` flag to the offending block, to see if this increases the chance of the retry being successful when running the whole suite.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?
Testing will mainly be checked in the CI itself, since various flags can be added locally to the cmd-line etc to try out various retry strategies for slow or flakey test scenarios.  

This approach, `test(slow);`, is at least file-specific, and doesn't mess with existing global CI settings.  It's worked as expected on my localhost when running the whole suite at the `--workers=2` setting.  Which is to say it pauses the offending block long enough, it seems, that the inevitable retry has been successful on localhost.

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
