### PR TITLE
DR-4051 Shuffle (random collection or item)

### DIFF
--- a/__tests__/__mocks__/data/repoApi/mockApiResponses.ts
+++ b/__tests__/__mocks__/data/repoApi/mockApiResponses.ts
@@ -232,7 +232,7 @@ export const mockItemResponse = {
     sortString: {
       $: "0000000001|0000000011|0000000430|0000000001",
     },
-    shuffleLink: {
+    itemLink: {
       $: "http://digitalcollections.nypl.org/items/510d47d9-7c7c-a3d9-e040-e00a18064a99",
     },
     highResLink: {

--- a/__tests__/__mocks__/data/repoApi/mockApiResponses.ts
+++ b/__tests__/__mocks__/data/repoApi/mockApiResponses.ts
@@ -232,7 +232,7 @@ export const mockItemResponse = {
     sortString: {
       $: "0000000001|0000000011|0000000430|0000000001",
     },
-    itemLink: {
+    shuffleLink: {
       $: "http://digitalcollections.nypl.org/items/510d47d9-7c7c-a3d9-e040-e00a18064a99",
     },
     highResLink: {

--- a/app/shuffle/page.tsx
+++ b/app/shuffle/page.tsx
@@ -1,0 +1,17 @@
+import { CollectionsApi } from "@/src/utils/apiClients/apiClients";
+import { Metadata } from "next";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+export const metadata: Metadata = {
+  title: "Shuffle",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function Shuffle() {
+  await headers();
+
+  const url: string = await CollectionsApi.getRandomCollectionOrItem();
+  return redirect(url);
+}

--- a/app/src/components/navMenu/mobileNavMenu.test.tsx
+++ b/app/src/components/navMenu/mobileNavMenu.test.tsx
@@ -13,19 +13,19 @@ describe("Mobile nav menu component", () => {
     const { getByTitle, getByText } = render(<MobileNavMenu />);
     fireEvent.click(screen.getByLabelText("Open Navigation"));
     expect(getByTitle("close icon")).toBeInTheDocument();
-    expect(getByText("Items")).toBeInTheDocument();
+    expect(getByText("Shuffle")).toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText("Close Navigation"));
-    const menuItems = screen.queryAllByText("Items");
+    const menuItems = screen.queryAllByText("Shuffle");
     expect(menuItems).toHaveLength(0);
   });
 
   it("has links", () => {
     render(<MobileNavMenu />);
     fireEvent.click(screen.getByLabelText("Open Navigation"));
-    expect(screen.getByLabelText("Items")).toHaveAttribute(
+    expect(screen.getByLabelText("Shuffle")).toHaveAttribute(
       "href",
-      `/search/index`
+      `/shuffle`
     );
     expect(screen.getByLabelText("Divisions")).toHaveAttribute(
       "href",

--- a/app/src/components/navMenu/navMenu.test.tsx
+++ b/app/src/components/navMenu/navMenu.test.tsx
@@ -6,7 +6,7 @@ import NavMenu from "./navMenu";
 describe("Nav menu component", () => {
   it("renders nav menu component", () => {
     render(<NavMenu render={1} />);
-    expect(screen.getByText("Items")).toBeInTheDocument;
+    expect(screen.getByText("Shuffle")).toBeInTheDocument;
     expect(screen.getByText("Collections")).toBeInTheDocument;
     expect(screen.getByText("Divisions")).toBeInTheDocument;
     expect(screen.getByText("About")).toBeInTheDocument;
@@ -14,7 +14,7 @@ describe("Nav menu component", () => {
 
   it("has links", () => {
     const { getByLabelText } = render(<NavMenu render={1} />);
-    expect(getByLabelText("Items")).toHaveAttribute("href", `/search/index`);
+    expect(getByLabelText("Shuffle")).toHaveAttribute("href", `/shuffle`);
     expect(getByLabelText("Divisions")).toHaveAttribute("href", `/divisions`);
     expect(getByLabelText("Collections")).toHaveAttribute(
       "href",

--- a/app/src/data/dcNavLinks.ts
+++ b/app/src/data/dcNavLinks.ts
@@ -4,10 +4,6 @@ export const dcNavLinks = [
     text: "Shuffle",
   },
   {
-    href: `/search/index`,
-    text: "Items",
-  },
-  {
     href: `/collections`,
     text: "Collections",
   },

--- a/app/src/data/dcNavLinks.ts
+++ b/app/src/data/dcNavLinks.ts
@@ -1,5 +1,9 @@
 export const dcNavLinks = [
   {
+    href: `/shuffle`,
+    text: "Shuffle",
+  },
+  {
     href: `/search/index`,
     text: "Items",
   },

--- a/app/src/utils/apiClients/apiClients.tsx
+++ b/app/src/utils/apiClients/apiClients.tsx
@@ -184,6 +184,14 @@ export class CollectionsApi {
     });
   }
 
+  static async getRandomCollectionOrItem(): Promise<string> {
+    const apiUrl = `${process.env.COLLECTIONS_API_URL}/shuffle`;
+    return await fetchApi({
+      apiUrl: apiUrl,
+      options: { isRepoApi: false },
+    });
+  }
+
   /**
    * Fetches search results based on the provided parameters, for /search/index and /collections/[uuid] pages.
    *

--- a/playwright/pages/about.page.ts
+++ b/playwright/pages/about.page.ts
@@ -18,7 +18,7 @@ export class AboutPage {
 
   // links
   readonly searchLink: Locator;
-  readonly shuffleLink: Locator;
+  readonly itemLink: Locator;
   readonly collectionLink: Locator;
   readonly divisionLink: Locator;
   readonly nyplDigitalCollectionsPlatformLink: Locator;
@@ -77,7 +77,7 @@ export class AboutPage {
 
     // links
     this.searchLink = page.getByRole("link", { name: "search", exact: true });
-    this.shuffleLink = page.getByRole("link", { name: "shuffle", exact: true });
+    this.itemLink = page.getByRole("link", { name: "items", exact: true });
     this.collectionLink = page.getByRole("link", {
       name: "collections",
       exact: true,

--- a/playwright/pages/about.page.ts
+++ b/playwright/pages/about.page.ts
@@ -5,7 +5,7 @@ export class AboutPage {
   static aboutUrl: string = "/about";
 
   // navigation menu
-  readonly items: Locator;
+  readonly shuffle: Locator;
   readonly collections: Locator;
   readonly divisions: Locator;
   readonly about: Locator;
@@ -18,7 +18,7 @@ export class AboutPage {
 
   // links
   readonly searchLink: Locator;
-  readonly itemLink: Locator;
+  readonly shuffleLink: Locator;
   readonly collectionLink: Locator;
   readonly divisionLink: Locator;
   readonly nyplDigitalCollectionsPlatformLink: Locator;
@@ -53,8 +53,8 @@ export class AboutPage {
   constructor(page: Page) {
     this.page = page;
     // navigation menu
-    this.items = page.getByRole("link", {
-      name: "Items",
+    this.shuffle = page.getByRole("link", {
+      name: "Shuffle",
       exact: true,
     });
 
@@ -77,7 +77,7 @@ export class AboutPage {
 
     // links
     this.searchLink = page.getByRole("link", { name: "search", exact: true });
-    this.itemLink = page.getByRole("link", { name: "items", exact: true });
+    this.shuffleLink = page.getByRole("link", { name: "shuffle", exact: true });
     this.collectionLink = page.getByRole("link", {
       name: "collections",
       exact: true,

--- a/playwright/pages/divisions.page.ts
+++ b/playwright/pages/divisions.page.ts
@@ -4,7 +4,7 @@ export class DivisionsPage {
   private readonly page: Page;
   readonly seeMore: Locator;
   readonly seeMoreLink: Locator;
-  readonly items: Locator;
+  readonly shuffle: Locator;
   readonly collections: Locator;
   readonly divisions: Locator;
   readonly about: Locator;
@@ -73,9 +73,9 @@ export class DivisionsPage {
     ];
     this.seeMoreLink = this.page.getByRole("link", { name: "See more" });
 
-    this.items = this.page
+    this.shuffle = this.page
       .getByRole("navigation", { name: "Header links" })
-      .getByLabel("Items");
+      .getByLabel("Shuffle");
     this.collections = this.page
       .getByRole("navigation", { name: "Header links" })
       .getByLabel("Collections");

--- a/playwright/pages/homepage.page.ts
+++ b/playwright/pages/homepage.page.ts
@@ -3,7 +3,7 @@ import { Locator, Page } from "@playwright/test";
 export class DCHomepage {
   private readonly page: Page;
   //navigation menu
-  readonly items: Locator;
+  readonly shuffle: Locator;
   readonly collections: Locator;
   readonly divisions: Locator;
   readonly about: Locator;
@@ -66,7 +66,7 @@ export class DCHomepage {
   constructor(page: Page) {
     //navigation menu
     this.page = page;
-    this.items = this.page.getByRole("link", { name: "Items" });
+    this.shuffle = this.page.getByRole("link", { name: "Shuffle" });
     this.collections = this.page.getByRole("link", {
       name: "Collections",
       exact: true,

--- a/playwright/tests/about.spec.ts
+++ b/playwright/tests/about.spec.ts
@@ -7,7 +7,7 @@ test.beforeEach(async ({ page }) => {
 
 test("verify navigation menu on about page", async ({ page }) => {
   const aboutPage = new AboutPage(page);
-  await expect(aboutPage.items).toBeVisible();
+  await expect(aboutPage.shuffle).toBeVisible();
   await expect(aboutPage.collections).toBeVisible();
   await expect(aboutPage.divisions).toBeVisible();
   await expect(aboutPage.about).toBeVisible();
@@ -24,7 +24,7 @@ test("verify search bar, search button, public domain checkbox on about page", a
 
 test("verify links on about page", async ({ page }) => {
   const aboutPage = new AboutPage(page);
-  await expect(aboutPage.itemLink).toBeVisible();
+  await expect(aboutPage.shuffleLink).toBeVisible();
   await expect(aboutPage.collectionLink).toBeVisible();
   await expect(aboutPage.divisionLink).toBeVisible();
   await expect(aboutPage.browseItemsLink).toBeVisible();

--- a/playwright/tests/about.spec.ts
+++ b/playwright/tests/about.spec.ts
@@ -24,7 +24,7 @@ test("verify search bar, search button, public domain checkbox on about page", a
 
 test("verify links on about page", async ({ page }) => {
   const aboutPage = new AboutPage(page);
-  await expect(aboutPage.shuffleLink).toBeVisible();
+  await expect(aboutPage.itemLink).toBeVisible();
   await expect(aboutPage.collectionLink).toBeVisible();
   await expect(aboutPage.divisionLink).toBeVisible();
   await expect(aboutPage.browseItemsLink).toBeVisible();

--- a/playwright/tests/divisions.spec.ts
+++ b/playwright/tests/divisions.spec.ts
@@ -7,7 +7,7 @@ test.beforeEach(async ({ page }) => {
 
 test("verify navigation menu on division page", async ({ page }) => {
   const divisionsPage = new DivisionsPage(page);
-  await expect(divisionsPage.items).toBeVisible();
+  await expect(divisionsPage.shuffle).toBeVisible();
   await expect(divisionsPage.collections).toBeVisible();
   await expect(divisionsPage.divisions).toBeVisible();
   await expect(divisionsPage.about).toBeVisible();

--- a/playwright/tests/homepage.spec.ts
+++ b/playwright/tests/homepage.spec.ts
@@ -11,11 +11,11 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/");
 });
 
-test("verify navigation menu is displayed (items, collections, divisions, about)", async ({
+test("verify navigation menu is displayed (shuffle, collections, divisions, about)", async ({
   page,
 }) => {
   const dchomepage = new DCHomepage(page);
-  await expect(dchomepage.items).toBeVisible();
+  await expect(dchomepage.shuffle).toBeVisible();
   await expect(dchomepage.collections).toBeVisible();
   await expect(dchomepage.divisions).toBeVisible();
   await expect(dchomepage.about).toBeVisible();


### PR DESCRIPTION
## Ticket:
[DR-4051](https://newyorkpubliclibrary.atlassian.net/browse/DR-4051)

## This PR does the following:
<!-- What has been updated or added in this PR? -->
Adds a `Shuffle` link in the top right next to `Items`, `Collections`, `Divisions`, `About`.

## Open questions
<!-- Any questions you want to ask the reviewer? -->
I think this might mess with the links a bit since there's now an additional one. I can re-size my window to cut off the `About` link, this happens right before it snaps into the mobile layout where all these links go in to the hamburger menu. Not sure what the approach here is?
<img width="760" height="179" alt="image" src="https://github.com/user-attachments/assets/cb12ce2c-c1f4-4e94-b4fd-7b987142d18e" />

## How has this been tested? How should a reviewer test this?
<!--- Please describe in detail how you tested your changes. -->
I tested it locally and manually with the corresponding code running in `collections-api`.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4051]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ