### PR TITLE
Add alt title to items page

### DIFF
--- a/app/src/components/items/overview/metadata/overview.tsx
+++ b/app/src/components/items/overview/metadata/overview.tsx
@@ -14,6 +14,10 @@ import { Fragment } from "react";
 import parse from "html-react-parser";
 import { metadataFieldToDisplay } from "@/src/utils/metadata/filterRenderableMetadata";
 
+interface MetadataOverviewProps {
+  metadata: Record<string, string>;
+}
+
 // Designs use DS Link component but I wonder if we can get away with not using them for the
 // Items page since the manifests are returning the links
 const StructuredCollectionsList = (rawCollections) => {
@@ -35,16 +39,14 @@ const StructuredCollectionsList = (rawCollections) => {
   );
 };
 
-const MetadataOverview = ({ metadata }) => {
-  const typedMetadata = metadata as Record<string, string>;
-
+const MetadataOverview = ({ metadata }: MetadataOverviewProps) => {
   return (
     <>
       <Box>
         <Heading size="heading6" marginBottom="xs">
           Item data
         </Heading>
-        {Object.entries(typedMetadata).map(([field, value]) => {
+        {Object.entries(metadata).map(([field, value]) => {
           if (field === "collection") {
             const collections = value.split("<br>");
             return (

--- a/app/src/components/items/overview/overview.tsx
+++ b/app/src/components/items/overview/overview.tsx
@@ -8,8 +8,13 @@ import ExternalLinksOverview from "./external/overview";
 import PrintOverview from "./print/overview";
 import CitationsOverview from "./citations/overview";
 import AVMaterialManifest from "./audiovisual/manifest";
+import { ItemModel } from "@/src/models/item";
 
-const ItemOverview = ({ item }) => {
+interface ItemOverviewProps {
+  item: ItemModel;
+}
+
+const ItemOverview = ({ item }: ItemOverviewProps) => {
   return (
     <>
       <ChakraSimpleGrid

--- a/app/src/types/NormalizedItemMetadata.ts
+++ b/app/src/types/NormalizedItemMetadata.ts
@@ -1,5 +1,6 @@
 export type NormalizedItemMetadata = {
   title: string;
+  altTitle?: string;
   names?: string;
   collection?: string;
   origin: string;

--- a/app/src/utils/metadata/filterRenderableMetadata.ts
+++ b/app/src/utils/metadata/filterRenderableMetadata.ts
@@ -1,5 +1,6 @@
 export const metadataFieldToDisplay: Record<string, string> = {
   title: "Title",
+  altTitle: "Alt Title",
   collection: "Collection",
   names: "Names",
   origin: "Date / Origin",

--- a/app/src/utils/metadata/normalizeItemMetdata.ts
+++ b/app/src/utils/metadata/normalizeItemMetdata.ts
@@ -10,6 +10,7 @@ export function normalizeItemMetadataFromManifest(
 ): NormalizedItemMetadata {
   return {
     title: raw["Title"]?.[0] || "",
+    altTitle: joinWithBr(raw["Alt Title"]),
     collection: joinWithBr(raw["Collection"]),
     names: joinWithBr(raw["Names"]),
     origin: joinWithBr(raw["Dates / Origin"]),


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3865](https://newyorkpubliclibrary.atlassian.net/browse/DR-3865)

## This PR does the following:

First commit just adds some types. Second adds the field.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Loaded an item with an alt title:
<img width="1383" height="498" alt="Screenshot 2026-03-04 at 8 46 11 AM" src="https://github.com/user-attachments/assets/83e9c2d2-2c86-4ee1-8591-d7a82c0fa588" />

and without:
<img width="1406" height="540" alt="Screenshot 2026-03-04 at 8 46 26 AM" src="https://github.com/user-attachments/assets/c3d4c96d-7bbd-4fd0-a51a-1d0a7187cd51" />

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3865]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ