### PR TITLE
Set server side IIIF_URL - NOREF

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,7 +26,7 @@ const nextConfig = {
       },
       {
         protocol: "https",
-        hostname: "iiif-qa.nypl.org",
+        hostname: "qa-iiif.nypl.org",
       },
       {
         protocol: "https",

--- a/next.config.js
+++ b/next.config.js
@@ -13,9 +13,10 @@ const nextConfig = {
   reactStrictMode: false,
   env: {
     APP_ENV: process.env.APP_ENV,
+    COLLECTIONS_API_URL: process.env.COLLECTIONS_API_URL,
+    IIIF_URL: process.env.IIIF_URL,
     NEW_RELIC_LICENSE_KEY: process.env.NEW_RELIC_LICENSE_KEY,
     NEW_RELIC_APP_NAME: `${process.env.NEW_RELIC_APP_NAME}`,
-    COLLECTIONS_API_URL: process.env.COLLECTIONS_API_URL,
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
It looks like for next/image to use the correct value (instead of the fallback) on the server, we need to set this.

## Ticket:

NOREF 

## This PR does the following:

<!-- What has been updated or added in this PR? -->

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
