### PR TITLE
NOREF - Remove unused API calls / repoAPI checks

### DIFF
--- a/app/api/collectionchildren/[slug]/route.tsx
+++ b/app/api/collectionchildren/[slug]/route.tsx
@@ -69,7 +69,7 @@ async function fetchPage(
   const apiUrl = `${process.env.COLLECTIONS_API_URL}/collections/${uuid}/children?page=${page}&perPage=${PAGESIZE}`;
   const response = await fetchApi({
     apiUrl,
-    options: { isRepoApi: false, next: { revalidate: oneMonth } },
+    options: { next: { revalidate: oneMonth } },
   });
   return response;
 }

--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -20,12 +20,6 @@ type ItemProps = {
 
 let item;
 
-const getItemManifest = async (uuid: string) => {
-  const clientIP = await getClientIP();
-  const data = await CollectionsApi.getManifestForItemUUID(uuid, clientIP);
-  return data;
-};
-
 const getItemData = async (uuid: string) => {
   const clientIP = await getClientIP();
   try {

--- a/app/src/utils/apiClients/apiClients.tsx
+++ b/app/src/utils/apiClients/apiClients.tsx
@@ -23,7 +23,6 @@ export class CollectionsApi {
     const apiUrl = `${process.env.COLLECTIONS_API_URL}/captures/${uuid}/metadata`;
     return await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false },
     });
   }
 
@@ -31,7 +30,6 @@ export class CollectionsApi {
     const apiUrl = `${process.env.COLLECTIONS_API_URL}/items/${uuid}/citations`;
     return await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false },
     });
   }
 
@@ -49,7 +47,6 @@ export class CollectionsApi {
     let apiUrl = `${process.env.COLLECTIONS_API_URL}/collections?page=${page}&perPage=${perPage}&sort=${sort}&keyword=${keyword}`;
     const response = await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false },
     });
     return response;
   }
@@ -58,7 +55,6 @@ export class CollectionsApi {
     let apiUrl = `${process.env.COLLECTIONS_API_URL}/collections/${uuid}`;
     const response = await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false },
     });
     return response;
   }
@@ -67,7 +63,6 @@ export class CollectionsApi {
     let apiUrl = `${process.env.COLLECTIONS_API_URL}/collections/${uuid}/children`;
     const response = await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false },
     });
     return response;
   }
@@ -88,7 +83,6 @@ export class CollectionsApi {
     }
     return await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false },
     });
   }
 
@@ -96,7 +90,6 @@ export class CollectionsApi {
     const apiUrl = `${process.env.COLLECTIONS_API_URL}/items/total`;
     const response = await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false },
     });
 
     const fallbackCount = defaultFeaturedItems.numberOfDigitizedItems;
@@ -148,9 +141,6 @@ export class CollectionsApi {
     const apiUrl = `${process.env.COLLECTIONS_API_URL}/items/featured`;
     return await fetchApi({
       apiUrl: apiUrl,
-      options: {
-        isRepoApi: false,
-      },
     });
   }
 
@@ -160,7 +150,7 @@ export class CollectionsApi {
   ): Promise<APIItem> {
     return await fetchApi({
       apiUrl: `${process.env.COLLECTIONS_API_URL}/items/${uuid}`,
-      options: { isRepoApi: false, clientIP: clientIP },
+      options: { clientIP: clientIP },
     });
   }
 
@@ -178,9 +168,6 @@ export class CollectionsApi {
     const apiUrl = `${process.env.COLLECTIONS_API_URL}/collections?genre=${slug}&sort=${sort}&page=${pageNum}&perPage=${perPage}`;
     return await fetchApi({
       apiUrl: apiUrl,
-      options: {
-        isRepoApi: false,
-      },
     });
   }
 
@@ -188,7 +175,6 @@ export class CollectionsApi {
     const apiUrl = `${process.env.COLLECTIONS_API_URL}/shuffle`;
     return await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false },
     });
   }
 
@@ -231,7 +217,6 @@ export class CollectionsApi {
 
     const response = await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false },
     });
     return response;
   }
@@ -240,7 +225,7 @@ export class CollectionsApi {
     let apiUrl = `${process.env.COLLECTIONS_API_URL}/manifests/${uuid}`;
     const response = await fetchApi({
       apiUrl: apiUrl,
-      options: { isRepoApi: false, clientIP: clientIP },
+      options: { clientIP: clientIP },
     });
     return response;
   }
@@ -256,7 +241,6 @@ export class CollectionsApi {
     const response = await fetchApi({
       apiUrl: apiUrl,
       options: {
-        isRepoApi: false,
         method: "POST",
         body: { uuids },
       },

--- a/app/src/utils/apiClients/apiClients.tsx
+++ b/app/src/utils/apiClients/apiClients.tsx
@@ -221,15 +221,6 @@ export class CollectionsApi {
     return response;
   }
 
-  static async getManifestForItemUUID(uuid: string, clientIP: string | null) {
-    let apiUrl = `${process.env.COLLECTIONS_API_URL}/manifests/${uuid}`;
-    const response = await fetchApi({
-      apiUrl: apiUrl,
-      options: { clientIP: clientIP },
-    });
-    return response;
-  }
-
   /**
    * Returns mapping of given collection UUIDs to their item counts.
    * @param {string[]} uuids - Array of collection UUIDs

--- a/app/src/utils/apiClients/collectionsApiClient.test.tsx
+++ b/app/src/utils/apiClients/collectionsApiClient.test.tsx
@@ -18,11 +18,9 @@ describe("Collections API methods", () => {
       expect(fetchApi as jest.Mock).toHaveBeenCalledTimes(2);
       expect(fetchApi as jest.Mock).toHaveBeenNthCalledWith(1, {
         apiUrl: `${process.env.COLLECTIONS_API_URL}/items/featured`,
-        options: { isRepoApi: false },
       });
       expect(fetchApi as jest.Mock).toHaveBeenNthCalledWith(2, {
         apiUrl: `${process.env.COLLECTIONS_API_URL}/items/total`,
-        options: { isRepoApi: false },
       });
       // Fallback data.
       expect(result.numberOfDigitizedItems).toEqual("1,059,731");
@@ -44,7 +42,6 @@ describe("Collections API methods", () => {
 
       expect(fetchApi).toHaveBeenCalledWith({
         apiUrl: `${process.env.COLLECTIONS_API_URL}/collections?page=2&perPage=48&sort=date-asc&keyword=cat`,
-        options: { isRepoApi: false },
       });
 
       expect(collections).toEqual(mockCollectionsResponse);
@@ -61,7 +58,6 @@ describe("Collections API methods", () => {
 
       expect(fetchApi).toHaveBeenCalledWith({
         apiUrl: `${process.env.COLLECTIONS_API_URL}/collections?page=1&perPage=48&sort=relevance&keyword=`,
-        options: { isRepoApi: false },
       });
 
       expect(collections).toEqual(mockCollectionsResponse);
@@ -82,7 +78,6 @@ describe("Collections API methods", () => {
 
       expect(fetchApi as jest.Mock).toHaveBeenCalledWith({
         apiUrl: `${process.env.COLLECTIONS_API_URL}/divisions/testSlug?page=1&per_page=3`,
-        options: { isRepoApi: false },
       });
     });
 
@@ -91,7 +86,6 @@ describe("Collections API methods", () => {
 
       expect(fetchApi as jest.Mock).toHaveBeenCalledWith({
         apiUrl: `${process.env.COLLECTIONS_API_URL}/divisions`,
-        options: { isRepoApi: false },
       });
     });
 
@@ -157,7 +151,6 @@ describe("Collections API methods", () => {
       const item = await CollectionsApi.getRandomFeaturedItem();
       expect(fetchApi as jest.Mock).toHaveBeenCalledWith({
         apiUrl: `${process.env.COLLECTIONS_API_URL}/items/featured`,
-        options: { isRepoApi: false },
       });
       expect(item).toEqual(mockFeaturedItemResponse);
       expect(item).toHaveProperty("title");
@@ -176,7 +169,6 @@ describe("Collections API methods", () => {
       const imageData = await CollectionsApi.getFeaturedImage();
       expect(fetchApi as jest.Mock).toHaveBeenCalledWith({
         apiUrl: `${process.env.COLLECTIONS_API_URL}/items/featured`,
-        options: { isRepoApi: false },
       });
 
       expect(imageData.imageID).toEqual("482815");
@@ -242,7 +234,6 @@ describe("Collections API methods", () => {
       const result = await CollectionsApi.getNumDigitizedItems();
       expect(fetchApi as jest.Mock).toHaveBeenCalledWith({
         apiUrl: `${process.env.COLLECTIONS_API_URL}/items/total`,
-        options: { isRepoApi: false },
       });
       expect(result).toEqual("78");
     });
@@ -340,9 +331,6 @@ describe("Collections API methods", () => {
 
       expect(fetchApi as jest.Mock).toHaveBeenCalledWith({
         apiUrl: `${process.env.COLLECTIONS_API_URL}/collections?genre=testSlug&sort=items-count&page=1&perPage=3`,
-        options: {
-          isRepoApi: false,
-        },
       });
     });
 
@@ -368,9 +356,6 @@ describe("Collections API methods", () => {
       await CollectionsApi.getLaneData({ slug: "testSlug" });
       expect(fetchApi as jest.Mock).toHaveBeenCalledWith({
         apiUrl: `${process.env.COLLECTIONS_API_URL}/collections?genre=testSlug&sort=items-count&page=1&perPage=48`,
-        options: {
-          isRepoApi: false,
-        },
       });
     });
   });

--- a/app/src/utils/fetchApi/fetchApi.test.tsx
+++ b/app/src/utils/fetchApi/fetchApi.test.tsx
@@ -2,11 +2,9 @@ import { fetchApi } from "./fetchApi";
 
 describe("fetchApi", () => {
   const mockApiUrl = "mockurl.org";
-  const mockAuthToken = "mockAuthToken";
   const mockCollectionsAuthToken = "mockCollectionsAuthToken";
 
   beforeEach(() => {
-    process.env.AUTH_TOKEN = mockAuthToken;
     process.env.COLLECTIONS_API_AUTH_TOKEN = mockCollectionsAuthToken;
   });
 
@@ -24,7 +22,7 @@ describe("fetchApi", () => {
     expect(fetch).toHaveBeenCalledWith(mockApiUrl, {
       method: "GET",
       headers: {
-        Authorization: `Token token=${mockAuthToken}`,
+        "x-nypl-collections-api-key": mockCollectionsAuthToken,
       },
       body: undefined,
     });
@@ -53,34 +51,10 @@ describe("fetchApi", () => {
     expect(fetch).toHaveBeenCalledWith(mockApiUrl, {
       method: "POST",
       headers: {
-        Authorization: `Token token=${mockAuthToken}`,
+        "x-nypl-collections-api-key": mockCollectionsAuthToken,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(mockBody),
-    });
-    expect(response).toEqual(mockResponse);
-  });
-
-  it("passes Collections API auth if isRepoApi option is false", async () => {
-    const mockResponse = { response: "mockResponse" };
-    (global as any).fetch = jest.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        json: async () => mockResponse,
-      })
-    ) as jest.Mock;
-
-    const response = await fetchApi({
-      apiUrl: mockApiUrl,
-      options: { isRepoApi: false },
-    });
-    expect(fetch).toHaveBeenCalledWith(mockApiUrl, {
-      method: "GET",
-      headers: {
-        "x-nypl-collections-api-key": `${mockCollectionsAuthToken}`,
-      },
-      body: undefined,
     });
     expect(response).toEqual(mockResponse);
   });
@@ -108,7 +82,7 @@ describe("fetchApi", () => {
       {
         method: "GET",
         headers: {
-          Authorization: `Token token=${mockAuthToken}`,
+          "x-nypl-collections-api-key": mockCollectionsAuthToken,
         },
         body: undefined,
       }
@@ -131,7 +105,6 @@ describe("fetchApi", () => {
       fetchApi({
         apiUrl: mockApiUrl,
         options: {
-          isRepoApi: false,
           params: mockBadParams,
         },
       })

--- a/app/src/utils/fetchApi/fetchApi.ts
+++ b/app/src/utils/fetchApi/fetchApi.ts
@@ -9,7 +9,6 @@ import logger from "logger";
  *   - params: URL parameters for GET requests.
  *   - body: Body data for POST requests.
  *   - clientIP: IP address of the requester
- *   - isRepoApi: Boolean flag to determine if Repo API or Collections API authorization should be included.
  *   - next: Next.js-specific options (revalidate, tags)
  * @returns {Promise<any>} - The API response.
  */
@@ -23,27 +22,15 @@ export const fetchApi = async ({
     params?: { [key: string]: any };
     body?: any;
     clientIP?: string | null;
-    isRepoApi?: boolean;
     next?;
   };
 }) => {
-  const {
-    method = "GET",
-    params,
-    body,
-    clientIP = null,
-    isRepoApi = true,
-    next,
-  } = options;
+  const { method = "GET", params, body, clientIP = null, next } = options;
 
   const headers: Record<string, string> = {};
 
-  if (isRepoApi) {
-    headers["Authorization"] = `Token token=${process.env.AUTH_TOKEN || ""}`;
-  } else {
-    headers["x-nypl-collections-api-key"] =
-      process.env.COLLECTIONS_API_AUTH_TOKEN || "";
-  }
+  headers["x-nypl-collections-api-key"] =
+    process.env.COLLECTIONS_API_AUTH_TOKEN || "";
   if (method === "POST") {
     headers["Content-Type"] = "application/json";
   }


### PR DESCRIPTION
## Ticket:

NOREF

## This PR does the following:

Was digging into another thing and realized we have some dead code. This gets rid of the `isRepoApi` flag and also removes the unused `getItemManifest` function, since we only get manifests from UV now.
## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
