### PR TITLE
Add tracking to shuffle links

### DIFF
--- a/app/shuffle/page.tsx
+++ b/app/shuffle/page.tsx
@@ -1,3 +1,4 @@
+import ShufflePage from "@/src/components/pages/shufflePage/shufflePage";
 import { CollectionsApi } from "@/src/utils/apiClients/apiClients";
 import { Metadata } from "next";
 import { headers } from "next/headers";
@@ -13,5 +14,5 @@ export default async function Shuffle() {
   await headers();
 
   const url: string = await CollectionsApi.getRandomCollectionOrItem();
-  return redirect(url);
+  return <ShufflePage redirectPath={url} />;
 }

--- a/app/src/components/pages/shufflePage/shufflePage.tsx
+++ b/app/src/components/pages/shufflePage/shufflePage.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+interface ShufflePageProps {
+  redirectPath: string;
+}
+
+export default function ShufflePage({ redirectPath }: ShufflePageProps) {
+  const router = useRouter();
+  useEffect(() => {
+    router.push(redirectPath);
+  });
+  return null;
+}

--- a/app/src/components/pages/shufflePage/shufflePage.tsx
+++ b/app/src/components/pages/shufflePage/shufflePage.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { trackCTA } from "@/src/utils/ga4Utils";
 
 interface ShufflePageProps {
   redirectPath: string;
@@ -9,6 +10,7 @@ interface ShufflePageProps {
 export default function ShufflePage({ redirectPath }: ShufflePageProps) {
   const router = useRouter();
   useEffect(() => {
+    trackCTA("Shuffle", redirectPath, "Digital Collections Shuffle");
     router.push(redirectPath);
   });
   return null;

--- a/app/src/utils/ga4Utils.ts
+++ b/app/src/utils/ga4Utils.ts
@@ -58,6 +58,16 @@ export const trackAVProgress = (
   });
 };
 
+export const trackCTA = (text: string, url: string, type: string) => {
+  const dataLayer = window["dataLayer"] || [];
+  dataLayer.push({
+    event: "cta_click",
+    click_text: text,
+    click_url: url,
+    click_type: type,
+  });
+};
+
 export const trackSearchResults = (
   searchResultsLayout: "grid" | "list",
   filterNames: string[],


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-4056](https://newyorkpubliclibrary.atlassian.net/browse/DR-4056)

## This PR does the following:

- Refactors shuffle to be a client side redirect
- Adds a ga4 event to track the destination url

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Hit the shuffle button, check the value of `window.dataLayer` in the console to see the event

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4056]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ