### PR TITLE
fix: Fix canvasIndex / imageId state

### DIFF
--- a/app/src/components/items/uv/universalViewer.tsx
+++ b/app/src/components/items/uv/universalViewer.tsx
@@ -288,7 +288,8 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
         />
       </>
     );
-  }
+  },
+  (prevProps, nextProps) => prevProps.manifestId === nextProps.manifestId
 );
 
 UniversalViewer.displayName = "UniversalViewer";

--- a/app/src/components/items/uv/universalViewerLazy.tsx
+++ b/app/src/components/items/uv/universalViewerLazy.tsx
@@ -1,5 +1,0 @@
-import dynamic from "next/dynamic";
-
-export const UniversalViewer = dynamic(() => import("./universalViewer"), {
-  ssr: false,
-});

--- a/app/src/components/items/viewer/viewer.tsx
+++ b/app/src/components/items/viewer/viewer.tsx
@@ -2,7 +2,7 @@
 
 import { ItemModel } from "../../../models/item";
 import React from "react";
-import { UniversalViewer } from "../uv/universalViewerLazy";
+import UniversalViewer from "../uv/universalViewer";
 import "universalviewer/dist/esm/index.css";
 import { PlyrPlayer } from "../plyr/dynamic";
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-xxxx](url)

## This PR does the following:

Did a buncha console logging and figured out that when reloading the viewer, we often run into some sorta cache / bypass where the UV's `init` function doesn't get run, preventing it from processing any events, attaching event listeners.

The result is that the canvas id never gets published, the download option pruning doesn't persist, other shenanigans.

Playing around with it, I realized that the way we lazy import the viewer component seems to be the cause. It's not clear that this does much for us, and seems to have been an approach copied from a codesandbox uv example, so I'm comfortable getting rid of it. I also refined a memoization approach, but I'm not sure if that part is really required.
## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
