### PR TITLE
Use CanvasContext / url as source of truth - NOREF

### DIFF
--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -106,8 +106,6 @@ export default async function ItemViewer({ params, searchParams }: ItemProps) {
   // only allow canvasIndex to be in the range of 0...item.imageIds.length (number of canvases)
   const imageIDs = item.imageIDs || [];
   const maxIndex = imageIDs.length - 1;
-  const rawIndex = searchParams.canvasIndex || 0;
-  const clampedCanvasIndex = Math.max(0, Math.min(rawIndex, maxIndex));
   const breadcrumbData = formatItemBreadcrumbs(item);
   return (
     <PageLayout
@@ -127,7 +125,6 @@ export default async function ItemViewer({ params, searchParams }: ItemProps) {
         citationsData={citationsData}
         uuid={params.uuid}
         itemDetail={itemData}
-        canvasIndex={clampedCanvasIndex}
       />
     </PageLayout>
   );

--- a/app/src/components/items/item.tsx
+++ b/app/src/components/items/item.tsx
@@ -20,14 +20,13 @@ import {
 
 interface ItemProps {
   item: ItemModel;
-  canvasIndex: number; //for when/if this is a query param
 }
 
 const renderViewer = (item) => {
   return item.hasItems && !item.isRestricted;
 };
 
-const Item = ({ item, canvasIndex }: ItemProps) => {
+const Item = ({ item }: ItemProps) => {
   return (
     <CanvasProvider>
       <Box marginTop="-3em">
@@ -36,7 +35,7 @@ const Item = ({ item, canvasIndex }: ItemProps) => {
             <Heading level="h1" paddingBottom="s">
               {item.title}
             </Heading>
-            <ItemMediaViewer item={item} canvasIndex={canvasIndex} />
+            <ItemMediaViewer item={item} />
           </>
         ) : (
           <>

--- a/app/src/components/items/plyr/player.tsx
+++ b/app/src/components/items/plyr/player.tsx
@@ -31,14 +31,6 @@ const Player = ({ title, sources, captions, type }: PlyrProps) => {
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const plyrRef = useRef<APITypes>(null);
 
-  function updateCanvasIndex(newCanvasIndex: number) {
-    setCurrentCanvasIndex(newCanvasIndex);
-    const stringifiedParams = searchParams.toString();
-    const urlSearchParams = new URLSearchParams(stringifiedParams);
-    urlSearchParams.set("canvasIndex", newCanvasIndex.toString());
-    window.history.pushState(null, "", `?${urlSearchParams}`);
-  }
-
   let source;
 
   // if query param is present
@@ -115,7 +107,7 @@ const Player = ({ title, sources, captions, type }: PlyrProps) => {
                   id={`item-canvas-${index + 1}-button`}
                   ref={(el) => (buttonRefs.current[index] = el)}
                   onClick={() => {
-                    updateCanvasIndex(index);
+                    setCurrentCanvasIndex(index);
                   }}
                 >
                   {truncateString(title, 20)} ({index + 1})

--- a/app/src/components/items/uv/universalViewer.tsx
+++ b/app/src/components/items/uv/universalViewer.tsx
@@ -11,7 +11,6 @@ import { useCanvasContext } from "../../../context/CanvasProvider";
 export type UniversalViewerProps = {
   config?: any;
   manifestId: string;
-  canvasIndex?: number;
   captureUuidToIdx: { [uuid: string]: number };
   onChangeCanvas?: (manifest: string, canvas: string) => void;
   onChangeManifest?: (manifest: string) => void;
@@ -19,30 +18,22 @@ export type UniversalViewerProps = {
 
 // pulled most of this code from: https://codesandbox.io/p/sandbox/uv-nextjs-example-239ff5?file=%2Fcomponents%2FUniversalViewer.tsx%3A39%2C1-49%2C8
 const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
-  ({ manifestId, captureUuidToIdx, canvasIndex, onChangeCanvas, config }) => {
+  ({ manifestId, captureUuidToIdx, onChangeCanvas, config }) => {
     // Try to parse a capture uuid from the url hash for OG-style capture links
     // These links come with a hash like '#/?uuid=xxxx', so to convert to params,
     // we strip off the first 3 chars
     const hash = window.location.hash.slice(3);
     const captureUuid = new URLSearchParams(hash).get("uuid");
+    const { currentCanvasIndex, setCurrentCanvasIndex } = useCanvasContext();
+    const canvasIndex = currentCanvasIndex;
+
     if (captureUuid) {
       const captureIdx = captureUuidToIdx[captureUuid];
       if (captureIdx) {
-        window.location.replace(
-          window.location.pathname + `?canvasIndex=${captureIdx}`
-        );
+        setCurrentCanvasIndex(captureIdx);
       }
     }
 
-    const searchParams = useSearchParams();
-    const { setCurrentCanvasIndex } = useCanvasContext();
-
-    function updateCanvasIndex(newCanvasIndex: number) {
-      const stringifiedParams = searchParams.toString();
-      const urlSearchParams = new URLSearchParams(stringifiedParams);
-      urlSearchParams.set("canvasIndex", newCanvasIndex.toString());
-      window.history.pushState(null, "", `?${urlSearchParams}`);
-    }
     const handleOnClick = (e) => {
       if (e.target.className === "openseadragon-canvas") {
         const viewPortButtons = Array.from(
@@ -261,7 +252,6 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
 
     useEvent(uv, BaseEvents.CANVAS_INDEX_CHANGE, (i) => {
       if (onChangeCanvas) {
-        updateCanvasIndex(i);
         setCurrentCanvasIndex(i);
 
         if (lastIndex.current !== i) {

--- a/app/src/components/items/uv/universalViewer.tsx
+++ b/app/src/components/items/uv/universalViewer.tsx
@@ -12,13 +12,11 @@ export type UniversalViewerProps = {
   config?: any;
   manifestId: string;
   captureUuidToIdx: { [uuid: string]: number };
-  onChangeCanvas?: (manifest: string, canvas: string) => void;
-  onChangeManifest?: (manifest: string) => void;
 };
 
 // pulled most of this code from: https://codesandbox.io/p/sandbox/uv-nextjs-example-239ff5?file=%2Fcomponents%2FUniversalViewer.tsx%3A39%2C1-49%2C8
 const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
-  ({ manifestId, captureUuidToIdx, onChangeCanvas, config }) => {
+  ({ manifestId, captureUuidToIdx, config }) => {
     // Try to parse a capture uuid from the url hash for OG-style capture links
     // These links come with a hash like '#/?uuid=xxxx', so to convert to params,
     // we strip off the first 3 chars
@@ -51,7 +49,6 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
     console.log("config as component prop is: ", config);
 
     const ref = useRef<HTMLDivElement>(null);
-    const lastIndex = useRef<number>();
     const options = useMemo(
       () => ({
         manifest: manifestId,
@@ -64,24 +61,16 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
     const uv = useUniversalViewer(ref, options);
 
     useEffect(() => {
-      // OPTIONAL: wipe UV prefs in dev so old settings don't override you; I kept having issues making changes.
-      // try {
-      //   Object.keys(localStorage)
-      //     .filter(k => k.toLowerCase().includes("uv") || k.toLowerCase().includes("universal"))
-      //     .forEach(k => localStorage.removeItem(k));
-      // } catch {}
-
-      let mo: MutationObserver | undefined;
-
-      if (uv && (canvasIndex || canvasIndex === 0)) {
-        if (lastIndex.current !== canvasIndex) {
-          uv._assignedContentHandler?.publish(
-            BaseEvents.CANVAS_INDEX_CHANGE,
-            canvasIndex
-          );
-          lastIndex.current = canvasIndex;
-        }
+      if (uv) {
+        uv._assignedContentHandler?.publish(
+          BaseEvents.CANVAS_INDEX_CHANGE,
+          canvasIndex
+        );
       }
+    }, [canvasIndex, uv]);
+
+    useEffect(() => {
+      let mo: MutationObserver | undefined;
 
       if (uv) {
         // Hide specific default download options by button/anchor text. Right now, just "Whole imiage".
@@ -229,7 +218,6 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
             },
             [uv]
           );
-          lastIndex.current = canvasIndex;
 
           // Initial pass (in case the dialog already exists)
           pruneDownloadButtons();
@@ -251,17 +239,7 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
     }, [canvasIndex, uv]);
 
     useEvent(uv, BaseEvents.CANVAS_INDEX_CHANGE, (i) => {
-      if (onChangeCanvas) {
-        setCurrentCanvasIndex(i);
-
-        if (lastIndex.current !== i) {
-          const canvas = (uv as any)?.extension?.helper.getCanvasByIndex(i);
-          if (canvas) {
-            lastIndex.current = i;
-            onChangeCanvas(manifestId, canvas.id);
-          }
-        }
-      }
+      setCurrentCanvasIndex(i);
     });
 
     useEvent(uv, BaseEvents.DOWNLOAD, (i) => {

--- a/app/src/components/items/viewer/viewer.tsx
+++ b/app/src/components/items/viewer/viewer.tsx
@@ -8,7 +8,6 @@ import { PlyrPlayer } from "../plyr/dynamic";
 
 interface ItemProps {
   item: ItemModel;
-  canvasIndex: number;
 }
 
 const uvConfig = {
@@ -57,7 +56,7 @@ const uvConfig = {
   },
 };
 
-const ItemMediaViewer = ({ item, canvasIndex }: ItemProps) => {
+const ItemMediaViewer = ({ item }: ItemProps) => {
   let viewer;
   let contentType = item.contentType;
   const captureUuidToIdx = Object.fromEntries(
@@ -69,7 +68,6 @@ const ItemMediaViewer = ({ item, canvasIndex }: ItemProps) => {
       <>
         <UniversalViewer
           manifestId={item.manifestURL}
-          canvasIndex={canvasIndex || 0}
           captureUuidToIdx={captureUuidToIdx}
           config={uvConfig}
           onChangeCanvas={(manifest, canvas) => {

--- a/app/src/components/items/viewer/viewer.tsx
+++ b/app/src/components/items/viewer/viewer.tsx
@@ -70,13 +70,6 @@ const ItemMediaViewer = ({ item }: ItemProps) => {
           manifestId={item.manifestURL}
           captureUuidToIdx={captureUuidToIdx}
           config={uvConfig}
-          onChangeCanvas={(manifest, canvas) => {
-            // why is this not printing in the console
-            console.log("canvas index changed", manifest, canvas);
-          }}
-          onChangeManifest={(manifest) => {
-            console.log("manfest changed", manifest);
-          }}
         />
       </>
     );

--- a/app/src/components/pages/itemPage/itemPage.tsx
+++ b/app/src/components/pages/itemPage/itemPage.tsx
@@ -4,7 +4,7 @@ import Item from "../../items/item";
 
 import { ItemModel } from "@/src/models/item";
 
-export function ItemPage({ uuid, itemDetail, canvasIndex, citationsData }) {
+export function ItemPage({ uuid, itemDetail, citationsData }) {
   const item = new ItemModel(uuid, itemDetail, citationsData);
-  return <Item item={item} canvasIndex={canvasIndex} />;
+  return <Item item={item} />;
 }

--- a/app/src/context/CanvasProvider.tsx
+++ b/app/src/context/CanvasProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { createContext, useContext, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import React, { createContext, useContext, useCallback } from "react";
 
 interface CanvasContextType {
   currentCanvasIndex: number;
@@ -11,12 +11,28 @@ interface CanvasContextType {
 const CanvasContext = createContext<CanvasContextType | undefined>(undefined);
 
 export const CanvasProvider = ({ children }: { children: React.ReactNode }) => {
+  const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const paramIndex = parseInt(searchParams.get("canvasIndex") || "0", 10);
+  // 1. Read directly from URL
+  const currentCanvasIndex = parseInt(
+    searchParams.get("canvasIndex") || "0",
+    10
+  );
 
-  const [currentCanvasIndex, setCurrentCanvasIndex] =
-    useState<number>(paramIndex);
+  // 2. Update by changing the URL
+  const setCurrentCanvasIndex = useCallback(
+    (index: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("canvasIndex", index.toString());
+
+      // This updates the URL without a full page reload
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [searchParams, pathname, router]
+  );
+
   return (
     <CanvasContext.Provider
       value={{ currentCanvasIndex, setCurrentCanvasIndex }}


### PR DESCRIPTION
## Ticket:

- NOREF 

## This PR does the following:

Some followup cleanup as I've learned a bit more about nextJS / context

The state was a bit hard to follow between the data provided by the
canvas context and the props passed down explicitly. Additionally, it
seems that we can use nextJS native hooks to get / set the canvas index,
allowing us to remove some of the use of window APIs.

Disclosure - the updates to useCanvasContext were generated using
gemini. Everything else is artisanal. Also, note the use of `scroll:
false` in `router.push`. That was a manual update to prevent the focus
from being disrupted when paging to the next canvas.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
