### PR TITLE
Import uv css in uv component NOREF

### DIFF
--- a/app/src/components/items/uv/universalViewer.tsx
+++ b/app/src/components/items/uv/universalViewer.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useMemo, useRef } from "react";
 import { IIIFEvents as BaseEvents, IIIFURLAdapter } from "universalviewer";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useCanvasContext } from "../../../context/CanvasProvider";
+import "universalviewer/dist/esm/index.css";
 
 export type UniversalViewerProps = {
   config?: any;

--- a/app/src/components/items/viewer/viewer.tsx
+++ b/app/src/components/items/viewer/viewer.tsx
@@ -3,7 +3,6 @@
 import { ItemModel } from "../../../models/item";
 import React from "react";
 import UniversalViewer from "../uv/universalViewer";
-import "universalviewer/dist/esm/index.css";
 import { PlyrPlayer } from "../plyr/dynamic";
 
 interface ItemProps {


### PR DESCRIPTION
## Ticket:

NOREF

## This PR does the following:

Noticed this error popping up all the time when loading an item:

Critical dependency: require function is used in a way in which dependencies cannot be statically extracted

The import trace pointed to this css import. Moving it to the uv component seems to fix it.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
