### PR TITLE
NOREF: Delay loading of uv library

### DIFF
--- a/app/src/components/items/uv/universalViewer.tsx
+++ b/app/src/components/items/uv/universalViewer.tsx
@@ -17,20 +17,23 @@ export type UniversalViewerProps = {
 // pulled most of this code from: https://codesandbox.io/p/sandbox/uv-nextjs-example-239ff5?file=%2Fcomponents%2FUniversalViewer.tsx%3A39%2C1-49%2C8
 const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
   ({ manifestId, captureUuidToIdx, config }) => {
-    // Try to parse a capture uuid from the url hash for OG-style capture links
-    // These links come with a hash like '#/?uuid=xxxx', so to convert to params,
-    // we strip off the first 3 chars
-    const hash = window.location.hash.slice(3);
-    const captureUuid = new URLSearchParams(hash).get("uuid");
     const { currentCanvasIndex, setCurrentCanvasIndex } = useCanvasContext();
     const canvasIndex = currentCanvasIndex;
+    useEffect(() => {
+      // Try to parse a capture uuid from the url hash for OG-style capture links
+      // These links come with a hash like '#/?uuid=xxxx', so to convert to params,
+      // we strip off the first 3 chars
+      const hash = window.location.hash.slice(3);
+      const captureUuid = new URLSearchParams(hash).get("uuid");
 
-    if (captureUuid) {
-      const captureIdx = captureUuidToIdx[captureUuid];
-      if (captureIdx) {
-        setCurrentCanvasIndex(captureIdx);
+      if (captureUuid) {
+        const captureIdx = captureUuidToIdx[captureUuid];
+        if (captureIdx) {
+          setCurrentCanvasIndex(captureIdx);
+        }
       }
-    }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    });
 
     const handleOnClick = (e) => {
       if (e.target.className === "openseadragon-canvas") {

--- a/app/src/components/items/uv/universalViewer.tsx
+++ b/app/src/components/items/uv/universalViewer.tsx
@@ -1,18 +1,19 @@
 "use client";
-import {
-  useUniversalViewer,
-  useEvent,
-} from "../../../hooks/useUniversalViewer";
+import { useUniversalViewer } from "../../../hooks/useUniversalViewer";
 import React, { useEffect, useMemo, useRef } from "react";
-import { IIIFEvents as BaseEvents, IIIFURLAdapter } from "universalviewer";
-import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useCanvasContext } from "../../../context/CanvasProvider";
+import dynamic from "next/dynamic";
 
 export type UniversalViewerProps = {
   config?: any;
   manifestId: string;
   captureUuidToIdx: { [uuid: string]: number };
 };
+
+const UniversalViewerClientLogic = dynamic(
+  () => import("./universalViewerClientLogic"),
+  { ssr: false }
+);
 
 // pulled most of this code from: https://codesandbox.io/p/sandbox/uv-nextjs-example-239ff5?file=%2Fcomponents%2FUniversalViewer.tsx%3A39%2C1-49%2C8
 const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
@@ -62,44 +63,34 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
     );
 
     const uv = useUniversalViewer(ref, options);
+    function pruneDownloadButtons() {
+      const host =
+        document.querySelector(".uv-iiif-extension-host") || document;
+      const nodes = host.querySelectorAll<HTMLElement>(
+        "li.option.single > button, li.option.single button, li.option.single > a, li.option.single a"
+      );
+      nodes.forEach((el) => {
+        const text = (el.textContent || "").trim().toLowerCase();
+        const isWholeImage = text.startsWith("whole image");
 
-    useEffect(() => {
-      if (uv) {
-        uv._assignedContentHandler?.publish(
-          BaseEvents.CANVAS_INDEX_CHANGE,
-          canvasIndex
-        );
-      }
-    }, [canvasIndex, uv]);
+        if (isWholeImage) {
+          const li = el.closest("li");
+          if (li instanceof HTMLElement) {
+            li.style.display = "none";
+          } else {
+            (el as HTMLElement).style.display = "none";
+          }
+          // Uncomment to verify what got hidden:
+          // console.log("[UV prune] hid", text, el);
+        }
+      });
+    }
 
     useEffect(() => {
       let mo: MutationObserver | undefined;
 
       if (uv) {
         // Hide specific default download options by button/anchor text. Right now, just "Whole imiage".
-        function pruneDownloadButtons() {
-          const host =
-            document.querySelector(".uv-iiif-extension-host") || document;
-          const nodes = host.querySelectorAll<HTMLElement>(
-            "li.option.single > button, li.option.single button, li.option.single > a, li.option.single a"
-          );
-          nodes.forEach((el) => {
-            const text = (el.textContent || "").trim().toLowerCase();
-            const isWholeImage = text.startsWith("whole image");
-
-            if (isWholeImage) {
-              const li = el.closest("li");
-              if (li instanceof HTMLElement) {
-                li.style.display = "none";
-              } else {
-                (el as HTMLElement).style.display = "none";
-              }
-              // Uncomment to verify what got hidden:
-              // console.log("[UV prune] hid", text, el);
-            }
-          });
-        }
-
         // override config using an inline json object
         uv.on("configure", function ({ config, cb }) {
           console.log("config on uv.on(configure) is : ", config);
@@ -241,14 +232,6 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
       };
     }, [canvasIndex, uv]);
 
-    useEvent(uv, BaseEvents.CANVAS_INDEX_CHANGE, (i) => {
-      setCurrentCanvasIndex(i);
-    });
-
-    useEvent(uv, BaseEvents.DOWNLOAD, (i) => {
-      console.log("blah i ", i);
-    });
-
     return (
       <>
         <div
@@ -256,6 +239,14 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
           onClick={(e) => handleOnClick(e)}
           style={{ height: 500 }}
           ref={ref}
+        />
+        <UniversalViewerClientLogic
+          uv={uv}
+          canvasIndex={canvasIndex}
+          onCanvasChange={(canvasIndex) => {
+            setCurrentCanvasIndex(canvasIndex);
+            pruneDownloadButtons();
+          }}
         />
       </>
     );

--- a/app/src/components/items/uv/universalViewerClientLogic.tsx
+++ b/app/src/components/items/uv/universalViewerClientLogic.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useEvent } from "../../../hooks/useUniversalViewer";
+import { useEffect } from "react";
+import { IIIFEvents as BaseEvents } from "universalviewer";
+
+export type UniversalViewerClientLogicProps = {
+  uv: any;
+  canvasIndex: number;
+  onCanvasChange: (canvasIndex: number) => void;
+};
+
+const UniversalViewerClientLogic = ({
+  uv,
+  canvasIndex,
+  onCanvasChange,
+}: UniversalViewerClientLogicProps) => {
+  useEffect(() => {
+    if (uv) {
+      uv._assignedContentHandler?.publish(
+        BaseEvents.CANVAS_INDEX_CHANGE,
+        canvasIndex
+      );
+    }
+  }, [canvasIndex, uv]);
+
+  useEvent(uv, BaseEvents.CANVAS_INDEX_CHANGE, (i) => {
+    onCanvasChange(i);
+  });
+
+  return null;
+};
+
+UniversalViewerClientLogic.displayName = "UniversalViewerClientLogic";
+
+export default UniversalViewerClientLogic;

--- a/app/src/components/items/uv/universalViewerClientLogic.tsx
+++ b/app/src/components/items/uv/universalViewerClientLogic.tsx
@@ -1,10 +1,10 @@
 "use client";
 import { useEvent } from "../../../hooks/useUniversalViewer";
 import { useEffect } from "react";
-import { IIIFEvents as BaseEvents } from "universalviewer";
+import { IIIFEvents as BaseEvents, Viewer } from "universalviewer";
 
 export type UniversalViewerClientLogicProps = {
-  uv: any;
+  uv?: Viewer;
   canvasIndex: number;
   onCanvasChange: (canvasIndex: number) => void;
 };

--- a/app/src/hooks/useUniversalViewer.ts
+++ b/app/src/hooks/useUniversalViewer.ts
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useEffect, useState } from "react";
-import { init, Viewer } from "universalviewer";
+import type { Viewer } from "universalviewer";
 
 export function useEvent(
   // from code came from https://codesandbox.io/p/sandbox/uv-nextjs-example-239ff5?file=%2Flib%2Fuse-universalviewer.ts%3A9%2C26
@@ -19,8 +19,12 @@ export function useUniversalViewer(
   options: any
 ) {
   const [uv, setUv] = useState<Viewer>();
-
+  const windowIsLoaded = typeof window !== "undefined";
   useEffect(() => {
+    if (!windowIsLoaded) {
+      return undefined;
+    }
+    const { init } = require("universalviewer");
     if (ref.current) {
       const currentUv = init(ref.current, options);
       setUv(currentUv);
@@ -29,7 +33,7 @@ export function useUniversalViewer(
         currentUv.dispose();
       };
     }
-  }, [ref]);
+  }, [ref, windowIsLoaded]);
 
   return uv;
 }


### PR DESCRIPTION
## Ticket:

NOREF

## This PR does the following:

Seeing 500s on item pages (though the page is loading fine). It appears the uv library runs `window` code on import, so we need to delay the import of the library until we're in the browser. I do this in a couple different ways, the most notable of which is explained in the 3rd commit of this PR.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.
