### PR TITLE
Show 'Download' and 'Share' label text in UV 

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -26,6 +26,16 @@ mark {
     z-index: 10000 !important;
 }
 
+.uv-iiif-extension-host .download .sr-only {
+ /*uv css sets this to 'absolute', overriding with 'static' shows the 'download' label */
+  position: static !important;
+}
+
+.uv-iiif-extension-host .share .sr-only {
+ /*uv css sets this to 'absolute', overriding with 'static' shows the 'share' label */
+  position: static !important;
+}
+
 .plyr__video-wrapper{
   height: 500px !important;
 }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3951](https://newyorkpubliclibrary.atlassian.net/browse/DR-3951)

## This PR does the following:

Pinged the UniversalViewer slack and was suggested this fix - the UV has
hidden spans with 'sr-only' CSS for screen readers - we can set the
position to 'static' to make the text visible

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?
load up an item on vercel:

<img width="928" height="369" alt="Screenshot 2026-04-13 at 1 57 15 PM" src="https://github.com/user-attachments/assets/185af9d3-528e-4223-821e-3a648c4665db" />

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3951]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ