### PR TITLE
Pipe ga4 data through context for download event - DR-3595

### DIFF
--- a/app/src/components/items/uv/universalViewer.tsx
+++ b/app/src/components/items/uv/universalViewer.tsx
@@ -7,6 +7,7 @@ import uvConfig from "./uvConfig.json";
 import React, { useEffect, useMemo, useRef } from "react";
 import { useCanvasContext } from "../../../context/CanvasProvider";
 import { sendDownloadEvent } from "@/src/utils/ga4Utils";
+import { useAnalyticsDataContext } from "@/src/context/AnalyticsDataProvider";
 
 export type UniversalViewerProps = {
   config?: any;
@@ -92,13 +93,27 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
       setCurrentCanvasIndex(i);
     });
 
+    const analyticsData = useAnalyticsDataContext();
+
     useEvent(uv, IIIFEvents.DOWNLOAD, ({ label }) => {
       const fileInfo = parseUVDownloadFilename(label);
       if (fileInfo) {
-        sendDownloadEvent(fileInfo.name, fileInfo.extension);
+        sendDownloadEvent(
+          fileInfo.name,
+          fileInfo.extension,
+          analyticsData.division,
+          analyticsData.collection,
+          analyticsData.subCollection
+        );
       } else {
         console.log(`Could not parse file info from label ${label}`);
-        sendDownloadEvent(label);
+        sendDownloadEvent(
+          label,
+          undefined,
+          analyticsData.division,
+          analyticsData.collection,
+          analyticsData.subCollection
+        );
       }
     });
 

--- a/app/src/components/items/uv/universalViewer.tsx
+++ b/app/src/components/items/uv/universalViewer.tsx
@@ -97,24 +97,15 @@ const UniversalViewer: React.FC<UniversalViewerProps> = React.memo(
 
     useEvent(uv, IIIFEvents.DOWNLOAD, ({ label }) => {
       const fileInfo = parseUVDownloadFilename(label);
-      if (fileInfo) {
-        sendDownloadEvent(
-          fileInfo.name,
-          fileInfo.extension,
-          analyticsData.division,
-          analyticsData.collection,
-          analyticsData.subCollection
-        );
-      } else {
+      const ga4Data = {
+        fileName: fileInfo ? fileInfo.name : label,
+        extension: fileInfo?.extension ?? undefined,
+        ...analyticsData,
+      };
+      if (!fileInfo) {
         console.log(`Could not parse file info from label ${label}`);
-        sendDownloadEvent(
-          label,
-          undefined,
-          analyticsData.division,
-          analyticsData.collection,
-          analyticsData.subCollection
-        );
       }
+      sendDownloadEvent(ga4Data);
     });
 
     const parseUVDownloadFilename = (fileLabel: string) => {

--- a/app/src/components/pageLayout/pageLayout.tsx
+++ b/app/src/components/pageLayout/pageLayout.tsx
@@ -41,13 +41,7 @@ const PageLayout = ({
   // Track page view events to Google Analytics
   useEffect(() => {
     if (ga4Data) {
-      trackGa4PageView(
-        ga4Data.division,
-        ga4Data.collection,
-        ga4Data.subcollection,
-        ga4Data.contentType,
-        ga4Data.resourceType
-      );
+      trackGa4PageView(ga4Data);
     }
   });
 

--- a/app/src/components/pageLayout/pageLayout.tsx
+++ b/app/src/components/pageLayout/pageLayout.tsx
@@ -16,6 +16,7 @@ import { SearchParamsType } from "@/search/index/page";
 import { SearchProvider } from "@/src/context/SearchProvider";
 import { CollectionSearchParamsType } from "@/collections/[uuid]/page";
 import { trackGa4PageView } from "@/src/utils/ga4Utils";
+import { AnalyticsDataProvider } from "@/src/context/AnalyticsDataProvider";
 
 interface PageLayoutProps {
   activePage: string;
@@ -57,37 +58,39 @@ const PageLayout = ({
       <DSProvider>
         <SearchProvider searchParams={searchParams}>
           <FeedbackProvider>
-            <SkipNavigation />
-            <Header />
-            {activePage === "home" ||
-            activePage === "about" ||
-            activePage === "notFound" ||
-            activePage === "serverError" ||
-            activePage === "search" ? (
-              children
-            ) : (
-              <>
-                <Breadcrumbs
-                  variant="digitalCollections"
-                  breadcrumbsData={breadcrumbs || []}
-                  aria-label={activePage}
-                />
-                {/* TODO: Move to TemplateAppContainer once spacing is more flexible.  --> */}
-                <Box
-                  id="mainContent"
-                  sx={{
-                    margin: "auto",
-                    maxWidth: "1280px",
-                    paddingLeft: responsivePadding,
-                    paddingRight: responsivePadding,
-                    paddingTop: "64px",
-                    paddingBottom: "64px",
-                  }}
-                >
-                  {children as JSX.Element}
-                </Box>
-              </>
-            )}
+            <AnalyticsDataProvider data={ga4Data ?? {}}>
+              <SkipNavigation />
+              <Header />
+              {activePage === "home" ||
+              activePage === "about" ||
+              activePage === "notFound" ||
+              activePage === "serverError" ||
+              activePage === "search" ? (
+                children
+              ) : (
+                <>
+                  <Breadcrumbs
+                    variant="digitalCollections"
+                    breadcrumbsData={breadcrumbs || []}
+                    aria-label={activePage}
+                  />
+                  {/* TODO: Move to TemplateAppContainer once spacing is more flexible.  --> */}
+                  <Box
+                    id="mainContent"
+                    sx={{
+                      margin: "auto",
+                      maxWidth: "1280px",
+                      paddingLeft: responsivePadding,
+                      paddingRight: responsivePadding,
+                      paddingTop: "64px",
+                      paddingBottom: "64px",
+                    }}
+                  >
+                    {children as JSX.Element}
+                  </Box>
+                </>
+              )}
+            </AnalyticsDataProvider>
           </FeedbackProvider>
         </SearchProvider>
       </DSProvider>

--- a/app/src/context/AnalyticsDataProvider.tsx
+++ b/app/src/context/AnalyticsDataProvider.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import React, { createContext, useContext, useCallback } from "react";
+
+interface AnalyticsDataContextType {
+  division?: string;
+  collection?: string;
+  subCollection?: string;
+}
+
+const AnalyticsDataContext = createContext<
+  AnalyticsDataContextType | undefined
+>(undefined);
+
+export const AnalyticsDataProvider = ({
+  data,
+  children,
+}: {
+  data: AnalyticsDataContextType;
+  children: React.ReactNode;
+}) => {
+  return (
+    <AnalyticsDataContext.Provider value={data}>
+      {children}
+    </AnalyticsDataContext.Provider>
+  );
+};
+
+export const useAnalyticsDataContext = (): AnalyticsDataContextType => {
+  const context = useContext(AnalyticsDataContext);
+  if (!context) {
+    throw new Error(
+      "useAnalyticsDataContext must be used within a AnalyticsDataProvider"
+    );
+  }
+  return context;
+};

--- a/app/src/utils/ga4Utils.ts
+++ b/app/src/utils/ga4Utils.ts
@@ -1,38 +1,54 @@
 const GA_NOT_SET = "Not set";
 
-export const trackGa4PageView = (
-  division?: string,
-  collection?: string,
-  subCollection?: string,
-  contentType?: string,
-  resourceType?: string
-) => {
+interface GA4BaseData {
+  division?: string;
+  collection?: string;
+  subCollection?: string;
+}
+
+interface PageViewData extends GA4BaseData {
+  contentType?: string;
+  resourceType?: string;
+}
+
+export const trackGa4PageView = ({
+  division = GA_NOT_SET,
+  collection = GA_NOT_SET,
+  subCollection = GA_NOT_SET,
+  contentType = GA_NOT_SET,
+  resourceType = GA_NOT_SET,
+}: PageViewData) => {
   const dataLayer = window["dataLayer"] || [];
   dataLayer.push({
     event: "page_view",
-    division_center: division ? division : GA_NOT_SET,
-    collection: collection ? collection : GA_NOT_SET,
-    subcollection: subCollection ? subCollection : GA_NOT_SET,
-    dc_content_type: contentType ?? GA_NOT_SET,
-    dc_resource_type: resourceType ?? GA_NOT_SET,
+    division_center: division,
+    collection: collection,
+    subcollection: subCollection,
+    dc_content_type: contentType,
+    dc_resource_type: resourceType,
   });
 };
 
-export const sendDownloadEvent = (
-  fileName: string,
-  extension?: string,
-  division?: string,
-  collection?: string,
-  subcollection?: string
-) => {
+interface DownloadData extends GA4BaseData {
+  fileName: string;
+  extension?: string;
+}
+
+export const sendDownloadEvent = ({
+  fileName,
+  extension = GA_NOT_SET,
+  division = GA_NOT_SET,
+  collection = GA_NOT_SET,
+  subCollection = GA_NOT_SET,
+}: DownloadData) => {
   const dataLayer = window["dataLayer"] || [];
   dataLayer.push({
     event: "file_download",
     file_name: fileName,
-    file_extension: extension ?? GA_NOT_SET,
-    division_center: division ? division : GA_NOT_SET,
-    collection: collection ? collection : GA_NOT_SET,
-    subcollection: subcollection ? subcollection : GA_NOT_SET,
+    file_extension: extension,
+    division_center: division,
+    collection: collection,
+    subcollection: subCollection,
   });
 };
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3595](https://newyorkpubliclibrary.atlassian.net/browse/DR-3595)

## This PR does the following:

Something I've wanted to do for a while and ran into the right opportunity. File download analytics events should have division, collection and subcollection set. Instead of passing all this data down through props, just inject it into a new context in the base layout, and use the data to send the event.

While this is only currently used in one place, we have other analytics needs that will require this data, and this will make it easier to pipe this top level data down.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Hit a random item and download it, verify the download event in the console now includes division, collection and subcollection:
<img width="1641" height="576" alt="Screenshot 2026-05-06 at 11 36 07 AM" src="https://github.com/user-attachments/assets/65129224-d992-41bf-b95a-375b5dc30af7" />

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3595]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ