### PR TITLE
DR-4087 Add cta_click GA events for various buttons on the Item and Collection pages

### DIFF
--- a/app/src/components/collectionMetadata/collectionMetadata.tsx
+++ b/app/src/components/collectionMetadata/collectionMetadata.tsx
@@ -1,4 +1,5 @@
 import { capitalize } from "@/src/utils/utils";
+import { trackCTA } from "@/src/utils/ga4Utils";
 import {
   Flex,
   Heading,
@@ -253,9 +254,11 @@ const CollectionMetadata = ({ data }: { data: CollectionMetadataProps }) => {
               <Button
                 variant="secondary"
                 id="finding-aid-btn"
-                onClick={() =>
-                  window.open(`https://archives.nypl.org/${mssID}`, "_blank")
-                }
+                onClick={() => {
+                  const url = `https://archives.nypl.org/${mssID}`;
+                  trackCTA("Finding aid", url, "Collection Page Finding Aid");
+                  window.open(url, "_blank");
+                }}
               >
                 Finding aid
               </Button>
@@ -264,12 +267,15 @@ const CollectionMetadata = ({ data }: { data: CollectionMetadataProps }) => {
               <Button
                 variant="secondary"
                 id="catalog-btn"
-                onClick={() =>
-                  window.open(
-                    `https://www.nypl.org/research/research-catalog/bib/${bNumbers[0]}`,
-                    "_blank"
-                  )
-                }
+                onClick={() => {
+                  const url = `https://www.nypl.org/research/research-catalog/bib/${bNumbers[0]}`;
+                  trackCTA(
+                    "Catalog record",
+                    url,
+                    "Collection Page Catalog Record"
+                  );
+                  window.open(url, "_blank");
+                }}
               >
                 Catalog record
               </Button>

--- a/app/src/components/items/overview/external/overview.tsx
+++ b/app/src/components/items/overview/external/overview.tsx
@@ -1,4 +1,5 @@
 import { Box, Heading, Link, Text } from "@nypl/design-system-react-components";
+import { trackCTA } from "@/src/utils/ga4Utils";
 
 const ExternalLinksOverview = ({ catalogLink, archivesLink }) => {
   return (
@@ -19,6 +20,9 @@ const ExternalLinksOverview = ({ catalogLink, archivesLink }) => {
             aria-label={`view finding aid`}
             variant="buttonSecondary"
             marginRight="xs"
+            onClick={() =>
+              trackCTA("Finding Aid", archivesLink, "Item Page Finding Aid")
+            }
           >
             Finding Aid
           </Link>
@@ -31,6 +35,13 @@ const ExternalLinksOverview = ({ catalogLink, archivesLink }) => {
             target="_blank"
             aria-label={`view in catalog`}
             variant="buttonSecondary"
+            onClick={() =>
+              trackCTA(
+                "Research Catalog",
+                catalogLink,
+                "Item Page Research Catalog"
+              )
+            }
           >
             Research Catalog
           </Link>

--- a/app/src/components/items/overview/print/overview.tsx
+++ b/app/src/components/items/overview/print/overview.tsx
@@ -18,6 +18,7 @@ import parse from "html-react-parser";
 import { headerBreakpoints } from "@/src/utils/breakpoints";
 import React, { forwardRef } from "react";
 import { useCanvasContext } from "../../../../context/CanvasProvider";
+import { trackCTA } from "@/src/utils/ga4Utils";
 
 const PrintOverview = ({ buyable, imageIDs }) => {
   const { currentCanvasIndex } = useCanvasContext();
@@ -46,6 +47,10 @@ const PrintOverview = ({ buyable, imageIDs }) => {
               target="_blank"
               aria-label={`order print`}
               variant="buttonSecondary"
+              onClick={() => {
+                const url = `https://archivea.studio/?id=${imageID}`;
+                trackCTA("Order Print", url, "Item Page Order Print");
+              }}
             >
               Order Print
             </Link>


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-4087](https://newyorkpubliclibrary.atlassian.net/browse/DR-4087)

## This PR does the following:

This PR adds a `cta_click` GA event to the following buttons:

* Collection Page
    * Finding Aid
    * Catalog Record
* Item Page
    * Finding Aid
    * Research Catalog
    * Order Print

## Open questions

One thing worth noting is that, since the "Order Print" button actually takes you to a different domain, there already is a GA event that gets fired when it is pressed (`outbound_links`). Since we're now adding a second GA event for this button, GA will group these two events and place the data in the request payload, not query params (which is what all the others do). I highly doubt this will cause any issues, but I just wanted to mention it.

## How has this been tested? How should a reviewer test this?

I ran my local digital-collections instance with these change and confirmed in the network tab that each of these CTAs now makes a GA call with the correct parameters.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4087]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ