### PR TITLE
Dr 4130 - Fix download overlay tests

### DIFF
--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -90,11 +90,10 @@ export default class ItemMediaPage {
   // Downloads
 
   // Opens and verifies download overlay modal
-
   async openDownloadMenu(): Promise<void> {
     await this.downloadButton.waitFor({ state: "visible" });
 
-    // Retry click up to 3 times if the browser temporarily swallows the DOM click event
+    // Retry click up to 5 times if the browser temporarily swallows the DOM click event
     for (let attempt = 1; attempt <= 5; attempt++) {
       await this.downloadButton.click({ force: true });
 
@@ -107,9 +106,7 @@ export default class ItemMediaPage {
         });
         await expect(this.downloadOptionSmall).toBeEnabled();
         return;
-      } catch (error) {
-        console.warn(`Retrying download menu trigger: attempt ${attempt}/5`);
-      }
+      } catch (error) {}
     }
 
     throw new Error("Failed to open the download menu after 5 attempts.");

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -91,7 +91,6 @@ export default class ItemMediaPage {
 
   // Opens and verifies download overlay modal
 
-  // NEW Option 1.0
   async openDownloadMenu(): Promise<void> {
     await this.downloadButton.waitFor({ state: "visible" });
 
@@ -115,41 +114,6 @@ export default class ItemMediaPage {
 
     throw new Error("Failed to open the download menu after 5 attempts.");
   }
-
-  // NEW Option 2.0
-  //   async openDownloadMenu(): Promise<void> {
-  //     await this.downloadButton.waitFor({ state: "visible" });
-
-  //     await expect(async () => {
-  //       await this.downloadButton.click({ force: true });
-  //       await expect(this.downloadOptionSmall).toBeVisible();
-  //     }).toPass({ timeout: 5000, intervals: [750] });
-
-  //     await expect(this.downloadOptionSmall).toBeEnabled();
-  // }
-
-  // NEW Option 2.0 - with logging
-  // async openDownloadMenu(): Promise<void> {
-  //   await this.downloadButton.waitFor({ state: "visible" });
-
-  //   const capturedErrors: Error[] = []; // Diagnostics bucket
-
-  //   await expect(async () => {
-  //     try {
-  //       await this.downloadButton.click({ force: true });
-  //       await expect(this.downloadOptionSmall).toBeVisible();
-  //     } catch (error) {
-  //       // 1. Capture the exact error (TypeError, Network crash, or Locator timeout)
-  //       capturedErrors.push(error as Error);
-  //       console.warn(`[DEBUG LOG] Attempt failed with: ${(error as Error).message}`);
-
-  //       // 2. Crucial: Re-throw it so toPass() knows to keep retrying
-  //       throw error;
-  //     }
-  //   }).toPass({ timeout: 20000, intervals: [750] });
-
-  //   await expect(this.downloadOptionSmall).toBeEnabled();
-  // }
 
   // Dismisses  download overlay and verifies it is removed from the view.
   async closeDownloadMenu(): Promise<void> {

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -91,12 +91,27 @@ export default class ItemMediaPage {
 
   // Opens and verifies download overlay modal
   async openDownloadMenu(): Promise<void> {
-    await this.downloadButton.click({ force: true });
+    await this.downloadButton.waitFor({ state: "visible" });
 
-    // Wait for the popup to be visible
-    await this.downloadOptionSmall.waitFor({ state: "visible" });
+    // Retry click up to 5 times if the browser swallows the DOM click event
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      await this.downloadButton.click({ force: true });
 
-    await expect(this.downloadOptionSmall).toBeEnabled();
+      try {
+        // Leave a short 750ms pause per click.
+        // If download options show up, the try block succeeds.
+        await this.downloadOptionSmall.waitFor({
+          state: "visible",
+          timeout: 750,
+        });
+        await expect(this.downloadOptionSmall).toBeEnabled();
+        return;
+      } catch (error) {
+        console.warn(`Retrying download menu trigger: attempt ${attempt}/5`);
+      }
+    }
+
+    throw new Error("Failed to open the download menu after 5 attempts.");
   }
 
   // Dismisses  download overlay and verifies it is removed from the view.

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -87,50 +87,17 @@ export default class ItemMediaPage {
     }
   }
 
-  // Downloads
-
-  // Opens and verifies download overlay modal
-  async openDownloadMenu(): Promise<void> {
-    await this.downloadButton.click({ force: true });
-
-    // Wait for the popup to be visible
-    await this.downloadOptionSmall.waitFor({ state: "visible" });
-
-    await expect(this.downloadOptionSmall).toBeEnabled();
-  }
-
-  // Dismisses  download overlay and verifies it is removed from the view.
-  async closeDownloadMenu(): Promise<void> {
-    await this.closeOverlayButton.click();
-    await expect(this.downloadOverlay).not.toBeVisible();
-  }
-
-  // NEW VERSION:
+  // OLD VERSION
   // // Downloads
 
   // // Opens and verifies download overlay modal
   // async openDownloadMenu(): Promise<void> {
-  //   await this.downloadButton.waitFor({ state: "visible" });
+  //   await this.downloadButton.click({ force: true });
 
-  //   // Retry click up to 5 times if the browser swallows the DOM click event
-  //   for (let attempt = 1; attempt <= 5; attempt++) {
-  //     await this.downloadButton.click({ force: true });
+  //   // Wait for the popup to be visible
+  //   await this.downloadOptionSmall.waitFor({ state: "visible" });
 
-  //     try {
-  //       // Leave a short 750ms pause per click.
-  //       // If download options show up, the try block succeeds.
-  //       await this.downloadOptionSmall.waitFor({
-  //         state: "visible",
-  //         timeout: 750,
-  //       });
-  //       await expect(this.downloadOptionSmall).toBeEnabled();
-  //       return;
-  //     } catch (error) {
-  //       console.warn(`Retrying download menu trigger: attempt ${attempt}/5`);
-  //     }
-  //   }
-
-  //   throw new Error("Failed to open the download menu after 5 attempts.");
+  //   await expect(this.downloadOptionSmall).toBeEnabled();
   // }
 
   // // Dismisses  download overlay and verifies it is removed from the view.
@@ -138,6 +105,39 @@ export default class ItemMediaPage {
   //   await this.closeOverlayButton.click();
   //   await expect(this.downloadOverlay).not.toBeVisible();
   // }
+
+  // Downloads
+
+  // Opens and verifies download overlay modal
+  async openDownloadMenu(): Promise<void> {
+    await this.downloadButton.waitFor({ state: "visible" });
+
+    // Retry click up to 5 times if the browser swallows the DOM click event
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      await this.downloadButton.click({ force: true });
+
+      try {
+        // Leave a short 750ms pause per click.
+        // If download options show up, the try block succeeds.
+        await this.downloadOptionSmall.waitFor({
+          state: "visible",
+          timeout: 750,
+        });
+        await expect(this.downloadOptionSmall).toBeEnabled();
+        return;
+      } catch (error) {
+        console.warn(`Retrying download menu trigger: attempt ${attempt}/5`);
+      }
+    }
+
+    throw new Error("Failed to open the download menu after 5 attempts.");
+  }
+
+  // Dismisses  download overlay and verifies it is removed from the view.
+  async closeDownloadMenu(): Promise<void> {
+    await this.closeOverlayButton.click();
+    await expect(this.downloadOverlay).not.toBeVisible();
+  }
 
   // Purchase Print
 

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -94,7 +94,7 @@ export default class ItemMediaPage {
     await this.downloadButton.waitFor({ state: "visible" });
 
     // Retry click up to 3 times if the browser temporarily swallows the DOM click event
-    for (let attempt = 1; attempt <= 3; attempt++) {
+    for (let attempt = 1; attempt <= 5; attempt++) {
       await this.downloadButton.click({ force: true });
 
       try {

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -87,25 +87,6 @@ export default class ItemMediaPage {
     }
   }
 
-  // OLD VERSION
-  // // Downloads
-
-  // // Opens and verifies download overlay modal
-  // async openDownloadMenu(): Promise<void> {
-  //   await this.downloadButton.click({ force: true });
-
-  //   // Wait for the popup to be visible
-  //   await this.downloadOptionSmall.waitFor({ state: "visible" });
-
-  //   await expect(this.downloadOptionSmall).toBeEnabled();
-  // }
-
-  // // Dismisses  download overlay and verifies it is removed from the view.
-  // async closeDownloadMenu(): Promise<void> {
-  //   await this.closeOverlayButton.click();
-  //   await expect(this.downloadOverlay).not.toBeVisible();
-  // }
-
   // Downloads
 
   // Opens and verifies download overlay modal

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -93,8 +93,8 @@ export default class ItemMediaPage {
   async openDownloadMenu(): Promise<void> {
     await this.downloadButton.waitFor({ state: "visible" });
 
-    // Retry click up to 5 times if the browser swallows the DOM click event
-    for (let attempt = 1; attempt <= 5; attempt++) {
+    // Retry click up to 3 times if the browser temporarily swallows the DOM click event
+    for (let attempt = 1; attempt <= 3; attempt++) {
       await this.downloadButton.click({ force: true });
 
       try {

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -90,6 +90,8 @@ export default class ItemMediaPage {
   // Downloads
 
   // Opens and verifies download overlay modal
+
+  // NEW Option 1.0
   async openDownloadMenu(): Promise<void> {
     await this.downloadButton.waitFor({ state: "visible" });
 
@@ -113,6 +115,41 @@ export default class ItemMediaPage {
 
     throw new Error("Failed to open the download menu after 5 attempts.");
   }
+
+  // NEW Option 2.0
+  //   async openDownloadMenu(): Promise<void> {
+  //     await this.downloadButton.waitFor({ state: "visible" });
+
+  //     await expect(async () => {
+  //       await this.downloadButton.click({ force: true });
+  //       await expect(this.downloadOptionSmall).toBeVisible();
+  //     }).toPass({ timeout: 5000, intervals: [750] });
+
+  //     await expect(this.downloadOptionSmall).toBeEnabled();
+  // }
+
+  // NEW Option 2.0 - with logging
+  // async openDownloadMenu(): Promise<void> {
+  //   await this.downloadButton.waitFor({ state: "visible" });
+
+  //   const capturedErrors: Error[] = []; // Diagnostics bucket
+
+  //   await expect(async () => {
+  //     try {
+  //       await this.downloadButton.click({ force: true });
+  //       await expect(this.downloadOptionSmall).toBeVisible();
+  //     } catch (error) {
+  //       // 1. Capture the exact error (TypeError, Network crash, or Locator timeout)
+  //       capturedErrors.push(error as Error);
+  //       console.warn(`[DEBUG LOG] Attempt failed with: ${(error as Error).message}`);
+
+  //       // 2. Crucial: Re-throw it so toPass() knows to keep retrying
+  //       throw error;
+  //     }
+  //   }).toPass({ timeout: 20000, intervals: [750] });
+
+  //   await expect(this.downloadOptionSmall).toBeEnabled();
+  // }
 
   // Dismisses  download overlay and verifies it is removed from the view.
   async closeDownloadMenu(): Promise<void> {

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -91,7 +91,7 @@ export default class ItemMediaPage {
 
   // Opens and verifies download overlay modal
   async openDownloadMenu(): Promise<void> {
-    await this.downloadButton.click();
+    await this.downloadButton.click({ force: true });
 
     // Wait for the popup to be visible
     await this.downloadOptionSmall.waitFor({ state: "visible" });

--- a/playwright/pages/item-media.page.ts
+++ b/playwright/pages/item-media.page.ts
@@ -91,27 +91,12 @@ export default class ItemMediaPage {
 
   // Opens and verifies download overlay modal
   async openDownloadMenu(): Promise<void> {
-    await this.downloadButton.waitFor({ state: "visible" });
+    await this.downloadButton.click({ force: true });
 
-    // Retry click up to 5 times if the browser swallows the DOM click event
-    for (let attempt = 1; attempt <= 5; attempt++) {
-      await this.downloadButton.click({ force: true });
+    // Wait for the popup to be visible
+    await this.downloadOptionSmall.waitFor({ state: "visible" });
 
-      try {
-        // Leave a short 750ms pause per click.
-        // If download options show up, the try block succeeds.
-        await this.downloadOptionSmall.waitFor({
-          state: "visible",
-          timeout: 750,
-        });
-        await expect(this.downloadOptionSmall).toBeEnabled();
-        return;
-      } catch (error) {
-        console.warn(`Retrying download menu trigger: attempt ${attempt}/5`);
-      }
-    }
-
-    throw new Error("Failed to open the download menu after 5 attempts.");
+    await expect(this.downloadOptionSmall).toBeEnabled();
   }
 
   // Dismisses  download overlay and verifies it is removed from the view.
@@ -119,6 +104,40 @@ export default class ItemMediaPage {
     await this.closeOverlayButton.click();
     await expect(this.downloadOverlay).not.toBeVisible();
   }
+
+  // NEW VERSION:
+  // // Downloads
+
+  // // Opens and verifies download overlay modal
+  // async openDownloadMenu(): Promise<void> {
+  //   await this.downloadButton.waitFor({ state: "visible" });
+
+  //   // Retry click up to 5 times if the browser swallows the DOM click event
+  //   for (let attempt = 1; attempt <= 5; attempt++) {
+  //     await this.downloadButton.click({ force: true });
+
+  //     try {
+  //       // Leave a short 750ms pause per click.
+  //       // If download options show up, the try block succeeds.
+  //       await this.downloadOptionSmall.waitFor({
+  //         state: "visible",
+  //         timeout: 750,
+  //       });
+  //       await expect(this.downloadOptionSmall).toBeEnabled();
+  //       return;
+  //     } catch (error) {
+  //       console.warn(`Retrying download menu trigger: attempt ${attempt}/5`);
+  //     }
+  //   }
+
+  //   throw new Error("Failed to open the download menu after 5 attempts.");
+  // }
+
+  // // Dismisses  download overlay and verifies it is removed from the view.
+  // async closeDownloadMenu(): Promise<void> {
+  //   await this.closeOverlayButton.click();
+  //   await expect(this.downloadOverlay).not.toBeVisible();
+  // }
 
   // Purchase Print
 

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -40,9 +40,6 @@ test.describe("Verify Video Viewer Controls", () => {
   });
 });
 
-// FIXME: dl modal is not showing correct links within playwright even though they can be observed
-// manually on localhost.
-
 test.describe("Verify Download Actions", () => {
   test.beforeEach(async ({ page }) => {
     itemMediaPage = new ItemMediaPage(page, "IMAGE");

--- a/playwright/tests/item-media.spec.ts
+++ b/playwright/tests/item-media.spec.ts
@@ -43,7 +43,7 @@ test.describe("Verify Video Viewer Controls", () => {
 // FIXME: dl modal is not showing correct links within playwright even though they can be observed
 // manually on localhost.
 
-test.describe.fixme("Verify Download Actions", () => {
+test.describe("Verify Download Actions", () => {
   test.beforeEach(async ({ page }) => {
     itemMediaPage = new ItemMediaPage(page, "IMAGE");
     await itemMediaPage.loadPage(ItemMediaPage.IMAGE_UUID);


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-4130](https://newyorkpubliclibrary.atlassian.net/browse/DR-4130)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

The download overlay button tests have been problematic for awhile.  This test-block has at times required 2 tries to succeed, which, though tolerable for CI purposes, wasn't ideal.   Recently they started failing even more often.  They shouldn't need a IIIF success, in terms of the image actually _displaying_ to pass.  The test itself is just a check that the overlay opens, has the correct download choices for a sample item, and can be closed.

These code changes remove the IIIF dependency, and "force" the test to click the dl-button that it "sees" in the DOM, via `.click({ force: true })`, before the UV gets a chance to throw a blanket on the whole image viewport due to qa-iiif slowness, blocking, etc.  Since we don't need the IIIF server to be able to click the download button, we use a try-catch to have playwright try the click a few times quickly (with a 750ms wait in between).   

These two changes seem to be working well for any race conditions where playwright may be over-eager to get on with things too quickly, before the DOM "settles."

I tried it without the catch/try, and got a 25% failure rate in 4 runs of the test-suite.  When tried with the catch/try, I got a 100% success rate for 6 runs of the test suite.



## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

`npm run build --workers=2`

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4130]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ