### PR TITLE
DR 4107 - Maps overlay tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,13 +4,42 @@ import { defineConfig, devices } from "@playwright/test";
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// import dotenv from 'dotenv';
-// import path from 'path';
+import dotenv from "dotenv";
+import path from "path";
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+const parsedEnv =
+  dotenv.config({ path: path.resolve(__dirname, ".env.local") }).parsed || {};
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
+
+const headlessOptimization = process.env.OPT === "true";
+
+export const HEADLESS_OPTIMIZATION_FLAGS =
+  process.platform === "darwin"
+    ? [
+        // --- LOCAL MAC SILICON ACCELERATION ---
+        "--disable-background-timer-throttling",
+        "--disable-backgrounding-occluded-windows",
+        "--disable-renderer-backgrounding",
+        "--disable-dev-shm-usage",
+        "--no-sandbox",
+        "--enable-gpu",
+        "--use-gl=angle",
+        "--use-angle=metal",
+      ]
+    : [
+        // --- LINUX, ETC CI ACCELERATION ---
+        "--disable-background-timer-throttling",
+        "--disable-backgrounding-occluded-windows",
+        "--disable-renderer-backgrounding",
+        "--disable-dev-shm-usage",
+        "--no-sandbox",
+        // Linux CI handles headless canvas rendering via software wrappers (gl=egl or swiftshader)
+        //'--use-gl=egl'
+      ];
 
 export default defineConfig({
   testDir: "./playwright",
@@ -35,6 +64,10 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
+    /* set optional flags to optimize headless chromedriver visual interactions*/
+    launchOptions: {
+      args: headlessOptimization ? HEADLESS_OPTIMIZATION_FLAGS : [],
+    },
   },
 
   /* Configure projects for major browsers */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,11 +6,8 @@ import { defineConfig, devices } from "@playwright/test";
  */
 import dotenv from "dotenv";
 import path from "path";
+
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
-
-const parsedEnv =
-  dotenv.config({ path: path.resolve(__dirname, ".env.local") }).parsed || {};
-
 /**
  * See https://playwright.dev/docs/test-configuration.
  */

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -63,6 +63,17 @@ export default class ItemMapOverlayPage {
     await expect(this.mapToggleButton).toHaveText(/close map/i);
   }
 
+  async waitForMapReady(): Promise<void> {
+    const canvasContainer = this.page.locator(".maplibregl-canvas-container");
+
+    await expect(
+      canvasContainer,
+      "Map failed to reach 'interactive' state"
+    ).toHaveClass(/maplibregl-interactive/, {
+      timeout: 10_000,
+    });
+  }
+
   // Zoom in functions
   async verifyZoomIn(): Promise<void> {
     await this.mapViewerContainer.scrollIntoViewIfNeeded();

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -68,24 +68,26 @@ export default class ItemMapOverlayPage {
     await this.mapViewerContainer.scrollIntoViewIfNeeded();
     await expect(this.zoomInButton).toBeVisible();
 
-    // click the zoom-in button until we reach a non-active state
-    const MAX_ZOOM_ATTEMPTS = 12;
-
-    for (let i = 0; i < MAX_ZOOM_ATTEMPTS; i++) {
-      const isDisabled = await this.zoomInButton.getAttribute("aria-disabled");
-
-      if (isDisabled === "true") {
-        break;
-      }
-
-      // wait for apx a sec and try again
-      await this.zoomInButton.click({ force: true });
-      await this.page.waitForTimeout(1500);
-    }
-    // verify we broke out of loop due to a match and not to max attemps reached
-    await expect(this.zoomInButton).toHaveAttribute("aria-disabled", "true", {
-      timeout: 1000,
-    });
+    // Keep clicking zoom-in until MapLibre reports max zoom (aria-disabled="true").
+    // expect.poll re-runs the callback until it passes or the timeout elapses,
+    // so there's no fixed sleep or manual attempt counter needed
+    await expect
+      .poll(
+        async () => {
+          const disabled =
+            (await this.zoomInButton.getAttribute("aria-disabled")) === "true";
+          if (!disabled) {
+            await this.zoomInButton.click({ force: true });
+          }
+          return disabled;
+        },
+        {
+          message: "zoom-in button never reached max zoom (aria-disabled=true)",
+          timeout: 20_000,
+          intervals: [500, 1000, 1500], // backoff between polls
+        }
+      )
+      .toBe(true);
   }
 
   // Zoom out functions

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -42,7 +42,6 @@ export default class ItemMapOverlayPage {
 
   // New view-on-map button can be clicked
   async verifyMapIsClosedState(): Promise<void> {
-    await expect(this.page).not.toHaveURL(/\?viewAs=map/);
     await expect(this.mapToggleButton).toBeVisible();
     await expect(this.mapToggleButton).toHaveText(/view on map/i);
     // await expect(this.mapViewerContainer).not.toBeVisible();
@@ -50,7 +49,6 @@ export default class ItemMapOverlayPage {
 
   // Close map button appears when map is opened
   async verifyMapIsOpenState(): Promise<void> {
-    await expect(this.page).toHaveURL(/\?viewAs=map/);
     await expect(this.mapToggleButton).toBeVisible();
     await expect(this.mapToggleButton).toHaveText(/close map/i);
     // await expect(this.mapViewerContainer).toBeVisible();

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -1,0 +1,64 @@
+import { expect, Locator, Page } from "@playwright/test";
+
+export class ItemMapOverlayPage {
+  readonly page: Page;
+
+  static readonly MAP1_UUID = "8b2b3160-c5d5-012f-d95c-58d385a7bc34";
+  static readonly MAP2_UUID = "25a47180-c55f-012f-3759-58d385a7bc34";
+
+  readonly mapToggleButton: Locator;
+  readonly mapViewerContainer: Locator;
+  readonly zoomInButton: Locator;
+  readonly zoomOutButton: Locator;
+
+  static getItemURL(uuid: string): string {
+    return `/items/${uuid}`;
+  }
+
+  constructor(page: Page) {
+    this.page = page;
+
+    const dataSourceHeading = this.page.getByRole("heading", {
+      name: /data source/i,
+    });
+    // find button in parent (data source) that contains "map"
+    this.mapToggleButton = dataSourceHeading
+      .locator("..")
+      .getByRole("button", { name: /map/i });
+
+    // this.mapViewerContainer = this.page.getByRole("region", { name: /map interactive/i });
+    // this.zoomInButton = this.mapViewerContainer.getByRole("button", { name: /zoom in/i });
+    // this.zoomOutButton = this.mapViewerContainer.getByRole("button", { name: /zoom out/i });
+  }
+
+  async visitItem(uuid: string): Promise<void> {
+    await this.page.goto(ItemMapOverlayPage.getItemURL(uuid));
+  }
+
+  async toggleMapView(): Promise<void> {
+    await this.mapToggleButton.waitFor({ state: "visible" });
+    await this.mapToggleButton.click();
+  }
+
+  // New view-on-map button can be clicked
+  async verifyMapIsClosedState(): Promise<void> {
+    await expect(this.page).not.toHaveURL(/\?viewAs=map/);
+    await expect(this.mapToggleButton).toBeVisible();
+    await expect(this.mapToggleButton).toHaveText(/view on map/i);
+    // await expect(this.mapViewerContainer).not.toBeVisible();
+  }
+
+  // Close map button appears when map is opened
+  async verifyMapIsOpenState(): Promise<void> {
+    await expect(this.page).toHaveURL(/\?viewAs=map/);
+    await expect(this.mapToggleButton).toBeVisible();
+    await expect(this.mapToggleButton).toHaveText(/close map/i);
+    // await expect(this.mapViewerContainer).toBeVisible();
+  }
+
+  // verify map controls
+  async verifyMapControlsAvailable(): Promise<void> {
+    // await expect(this.zoomInButton).toBeVisible();
+    // await expect(this.zoomOutButton).toBeVisible();
+  }
+}

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -3,17 +3,16 @@ import { expect, Locator, Page } from "@playwright/test";
 export default class ItemMapOverlayPage {
   readonly page: Page;
 
-  static readonly MAP1_UUID = "417fe160-c603-012f-4183-58d385a7bc34";
-  static readonly MAP2_UUID = "blablablablablablablablablablablabla";
-
   readonly mapToggleButton: Locator;
   readonly mapViewerContainer: Locator;
+  readonly mapCanvas: Locator;
   readonly zoomInButton: Locator;
   readonly zoomOutButton: Locator;
+  readonly compassButton: Locator;
+  readonly compassIcon: Locator;
+  static readonly MAP1_UUID = "417fe160-c603-012f-4183-58d385a7bc34";
 
-  static getItemURL(uuid: string): string {
-    return `/items/${uuid}`;
-  }
+  static itemMapUrl: string = "/items/" + this.MAP1_UUID;
 
   constructor(page: Page) {
     this.page = page;
@@ -21,18 +20,30 @@ export default class ItemMapOverlayPage {
     const dataSourceHeading = this.page.getByRole("heading", {
       name: /data source/i,
     });
-    // find button in parent (data source) that contains "map"
+
+    // find button in parent (data source block) that contains "map"
     this.mapToggleButton = dataSourceHeading
       .locator("..")
       .getByRole("button", { name: /map/i });
 
-    // this.mapViewerContainer = this.page.getByRole("region", { name: /map interactive/i });
-    // this.zoomInButton = this.mapViewerContainer.getByRole("button", { name: /zoom in/i });
-    // this.zoomOutButton = this.mapViewerContainer.getByRole("button", { name: /zoom out/i });
+    // map overlay UX locators
+    this.mapViewerContainer = this.page.locator(".maplibregl-map");
+    this.mapCanvas = this.page.locator(".maplibregl-canvas");
+    this.zoomInButton = this.mapViewerContainer.getByRole("button", {
+      name: "Zoom in",
+    });
+    this.zoomOutButton = this.mapViewerContainer.getByRole("button", {
+      name: "Zoom out",
+    });
+    this.compassButton = this.mapViewerContainer.getByRole("button", {
+      name: /drag to rotate map/i,
+    });
+    this.compassIcon = this.compassButton.locator(".maplibregl-ctrl-icon");
   }
 
-  async visitItem(uuid: string): Promise<void> {
-    await this.page.goto(ItemMapOverlayPage.getItemURL(uuid));
+  async loadPage(gotoPage: string): Promise<void> {
+    // await this.page.setViewportSize({ width: 1280, height: 4000 });
+    await this.page.goto(gotoPage);
   }
 
   async toggleMapView(): Promise<void> {
@@ -40,23 +51,53 @@ export default class ItemMapOverlayPage {
     await this.mapToggleButton.click();
   }
 
-  // New view-on-map button can be clicked
+  // View-on-map button can be clicked
   async verifyMapIsClosedState(): Promise<void> {
     await expect(this.mapToggleButton).toBeVisible();
     await expect(this.mapToggleButton).toHaveText(/view on map/i);
-    // await expect(this.mapViewerContainer).not.toBeVisible();
   }
 
-  // Close map button appears when map is opened
+  // Close-map button appears when map is in open state
   async verifyMapIsOpenState(): Promise<void> {
     await expect(this.mapToggleButton).toBeVisible();
     await expect(this.mapToggleButton).toHaveText(/close map/i);
-    // await expect(this.mapViewerContainer).toBeVisible();
   }
 
-  // verify map controls
-  async verifyMapControlsAvailable(): Promise<void> {
-    // await expect(this.zoomInButton).toBeVisible();
-    // await expect(this.zoomOutButton).toBeVisible();
+  // Zoom in functions
+  async verifyZoomIn(): Promise<void> {
+    await this.mapViewerContainer.scrollIntoViewIfNeeded();
+    await expect(this.zoomInButton).toBeVisible();
+
+    // click the zoom-in button until we reach a non-active state
+    const MAX_ZOOM_ATTEMPTS = 12;
+
+    for (let i = 0; i < MAX_ZOOM_ATTEMPTS; i++) {
+      const isDisabled = await this.zoomInButton.getAttribute("aria-disabled");
+
+      if (isDisabled === "true") {
+        break;
+      }
+
+      // wait for apx a sec and try again
+      await this.zoomInButton.click({ force: true });
+      await this.page.waitForTimeout(1500);
+    }
+    // verify we broke out of loop due to a match and not to max attemps reached
+    await expect(this.zoomInButton).toHaveAttribute("aria-disabled", "true", {
+      timeout: 1000,
+    });
+  }
+
+  // Zoom out functions
+  async verifyZoomOut(): Promise<void> {
+    // Since test is running serially, we only need to confirm that while the maps layer
+    // is fully zoomed in, a single "zoom out" click will change the "zoom-in" button back to active again
+
+    await expect(this.zoomOutButton).toBeVisible();
+
+    await expect(this.zoomInButton).toHaveAttribute("aria-disabled", "true");
+    await this.zoomOutButton.click({ force: true });
+    // the zoom-in button should now be active
+    await expect(this.zoomInButton).toHaveAttribute("aria-disabled", "false");
   }
 }

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -37,7 +37,6 @@ export default class ItemMapOverlayPage {
   }
 
   async loadPage(gotoPage: string): Promise<void> {
-    // await this.page.setViewportSize({ width: 1280, height: 4000 });
     await this.page.goto(gotoPage);
   }
 

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -58,7 +58,7 @@ export default class ItemMapOverlayPage {
   }
 
   // Close-map button appears when map is in open state
-  async verifyMapIsOpenState(): Promise<void> {
+  async verifyButtonIsInOpenState(): Promise<void> {
     await expect(this.mapToggleButton).toBeVisible();
     await expect(this.mapToggleButton).toHaveText(/close map/i);
   }

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -1,10 +1,10 @@
 import { expect, Locator, Page } from "@playwright/test";
 
-export class ItemMapOverlayPage {
+export default class ItemMapOverlayPage {
   readonly page: Page;
 
-  static readonly MAP1_UUID = "8b2b3160-c5d5-012f-d95c-58d385a7bc34";
-  static readonly MAP2_UUID = "25a47180-c55f-012f-3759-58d385a7bc34";
+  static readonly MAP1_UUID = "417fe160-c603-012f-4183-58d385a7bc34";
+  static readonly MAP2_UUID = "blablablablablablablablablablablabla";
 
   readonly mapToggleButton: Locator;
   readonly mapViewerContainer: Locator;

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -8,8 +8,6 @@ export default class ItemMapOverlayPage {
   readonly mapCanvas: Locator;
   readonly zoomInButton: Locator;
   readonly zoomOutButton: Locator;
-  readonly compassButton: Locator;
-  readonly compassIcon: Locator;
   static readonly MAP1_UUID = "417fe160-c603-012f-4183-58d385a7bc34";
 
   static itemMapUrl: string = "/items/" + this.MAP1_UUID;
@@ -36,10 +34,6 @@ export default class ItemMapOverlayPage {
     this.zoomOutButton = this.mapViewerContainer.getByRole("button", {
       name: "Zoom out",
     });
-    this.compassButton = this.mapViewerContainer.getByRole("button", {
-      name: /drag to rotate map/i,
-    });
-    this.compassIcon = this.compassButton.locator(".maplibregl-ctrl-icon");
   }
 
   async loadPage(gotoPage: string): Promise<void> {

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -21,9 +21,10 @@ export default class ItemMapOverlayPage {
       name: /data source/i,
     });
 
-    // find button in parent (data source block) that contains "map"
-    this.mapToggleButton = dataSourceHeading
-      .locator("..")
+    this.mapToggleButton = this.page
+      .locator("*")
+      .filter({ has: dataSourceHeading })
+      .last()
       .getByRole("button", { name: /map/i });
 
     // map overlay UX locators

--- a/playwright/tests/item-map-overlay.spec.ts
+++ b/playwright/tests/item-map-overlay.spec.ts
@@ -43,9 +43,8 @@ test.describe.serial("Dynamic Maps Display", () => {
       test("button text should say 'close map'", async ({}, testInfo) => {
         await itemMapOverlay.toggleMapView();
         await itemMapOverlay.verifyMapIsOpenState();
-
-        // give map time to render/refresh
-        await new Promise((resolve) => setTimeout(resolve, 5000));
+        // wait for map overlay to be stable to proceed
+        await itemMapOverlay.waitForMapReady();
       });
 
       test("AllMaps overlay should now be displayed", async ({}, testInfo) => {

--- a/playwright/tests/item-map-overlay.spec.ts
+++ b/playwright/tests/item-map-overlay.spec.ts
@@ -42,13 +42,12 @@ test.describe.serial("Dynamic Maps Display", () => {
     test.describe("After button is clicked", () => {
       test("button text should say 'close map'", async () => {
         await itemMapOverlay.toggleMapView();
-        await itemMapOverlay.verifyMapIsOpenState();
-        // wait for map overlay to be stable to proceed
-        await itemMapOverlay.waitForMapReady();
+        await itemMapOverlay.verifyButtonIsInOpenState();
       });
 
-      test("AllMaps overlay should now be displayed", async () => {
-        await itemMapOverlay.verifyMapIsOpenState();
+      test("AllMaps overlay should be displayed", async () => {
+        // wait for map overlay to be stable to proceed
+        await itemMapOverlay.waitForMapReady();
       });
 
       test.describe("Map interaction functions should be available", () => {

--- a/playwright/tests/item-map-overlay.spec.ts
+++ b/playwright/tests/item-map-overlay.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "../base";
+import ItemMapOverlayPage from "../pages/item-map-overlay.page";
+
+test.describe("Dynamic Maps Should Display Overlay", () => {
+  let itemMapOverlay: ItemMapOverlayPage;
+
+  test.beforeEach(async ({ page }) => {
+    itemMapOverlay = new ItemMapOverlayPage(page);
+    await itemMapOverlay.visitItem(ItemMapOverlayPage.MAP1_UUID);
+  });
+
+  test.describe("Sample Map 1", () => {
+    test("Should display a view on map button", async () => {
+      await itemMapOverlay.verifyMapIsClosedState();
+    });
+
+    test("When view on map is clicked, button should allow closing overlay", async () => {
+      await itemMapOverlay.toggleMapView();
+      await itemMapOverlay.verifyMapIsOpenState();
+    });
+
+    test("Overlay should be displayed", async () => {
+      await itemMapOverlay.toggleMapView();
+      await itemMapOverlay.verifyMapControlsAvailable();
+    });
+  });
+});

--- a/playwright/tests/item-map-overlay.spec.ts
+++ b/playwright/tests/item-map-overlay.spec.ts
@@ -1,27 +1,73 @@
 import { test, expect } from "../base";
 import ItemMapOverlayPage from "../pages/item-map-overlay.page";
+import { applyRouteFilters } from "../utils/routeFilters";
+import { HEADLESS_OPTIMIZATION_FLAGS } from "../../playwright.config";
 
-test.describe("Dynamic Maps Should Display Overlay", () => {
-  let itemMapOverlay: ItemMapOverlayPage;
+test.use({
+  launchOptions: {
+    args: HEADLESS_OPTIMIZATION_FLAGS,
+  },
+});
 
-  test.beforeEach(async ({ page }) => {
+let itemMapOverlay: ItemMapOverlayPage;
+
+test.describe.serial("Dynamic Maps Display", () => {
+  // Runs ONCE to create the shared, filtered page context.
+
+  /**
+  JUSTIFICATION FOR .serial USAGE:
+  
+  These tests intentionally use .serial to maintain browser state across multiple test steps. This deviates from Playwright's recommendation for isolated tests for the following reasons:
+  
+  1. Performance: Avoids separate page loads for re-use of modal
+  2. Resource efficiency: Uses single worker instead of parallel workers
+  3. User journey testing: Simulates realistic workflow of opening modal once and applying multiple filters in sequence
+  4. State accumulation: Each filter builds on previous selections
+  */
+
+  test.beforeAll(async ({ browser }) => {
+    const browserContext = await browser.newContext();
+    const page = await browserContext.newPage();
+
+    await applyRouteFilters(page);
     itemMapOverlay = new ItemMapOverlayPage(page);
-    await itemMapOverlay.visitItem(ItemMapOverlayPage.MAP1_UUID);
+    await itemMapOverlay.loadPage(ItemMapOverlayPage.itemMapUrl);
   });
 
   test.describe("Sample Map 1", () => {
-    test("Should display a view on map button", async () => {
+    test("Item should display a clickable map button", async () => {
       await itemMapOverlay.verifyMapIsClosedState();
     });
 
-    test("When view on map is clicked, button should allow closing overlay", async () => {
-      await itemMapOverlay.toggleMapView();
-      await itemMapOverlay.verifyMapIsOpenState();
+    test.describe("After button is clicked", () => {
+      test("button text should say 'close map'", async ({}, testInfo) => {
+        await itemMapOverlay.toggleMapView();
+        await itemMapOverlay.verifyMapIsOpenState();
+
+        // give map time to render/refresh
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      });
+
+      test("AllMaps overlay should now be displayed", async ({}, testInfo) => {
+        await itemMapOverlay.verifyMapIsOpenState();
+      });
+
+      test.describe("Map interaction functions should be available", () => {
+        test("Click Zoom In", async () => {
+          await itemMapOverlay.verifyZoomIn();
+        });
+
+        test("Click Zoom Out", async () => {
+          await itemMapOverlay.verifyZoomOut();
+        });
+      });
     });
 
-    test("Overlay should be displayed", async () => {
-      await itemMapOverlay.toggleMapView();
-      await itemMapOverlay.verifyMapControlsAvailable();
+    test.describe("After map is closed", () => {
+      test("button text should say 'view map'", async ({}, testInfo) => {
+        await itemMapOverlay.toggleMapView();
+        await itemMapOverlay.verifyMapIsClosedState();
+      });
     });
   });
 });

--- a/playwright/tests/item-map-overlay.spec.ts
+++ b/playwright/tests/item-map-overlay.spec.ts
@@ -40,14 +40,14 @@ test.describe.serial("Dynamic Maps Display", () => {
     });
 
     test.describe("After button is clicked", () => {
-      test("button text should say 'close map'", async ({}, testInfo) => {
+      test("button text should say 'close map'", async () => {
         await itemMapOverlay.toggleMapView();
         await itemMapOverlay.verifyMapIsOpenState();
         // wait for map overlay to be stable to proceed
         await itemMapOverlay.waitForMapReady();
       });
 
-      test("AllMaps overlay should now be displayed", async ({}, testInfo) => {
+      test("AllMaps overlay should now be displayed", async () => {
         await itemMapOverlay.verifyMapIsOpenState();
       });
 
@@ -63,7 +63,7 @@ test.describe.serial("Dynamic Maps Display", () => {
     });
 
     test.describe("After map is closed", () => {
-      test("button text should say 'view map'", async ({}, testInfo) => {
+      test("button text should say 'view map'", async () => {
         await itemMapOverlay.toggleMapView();
         await itemMapOverlay.verifyMapIsClosedState();
       });


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-4107](https://newyorkpubliclibrary.atlassian.net/browse/DR-4107)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

These playwright tests check if a map-button exists (it will, since we are passing it a known sample record), and if you click it will it then say "close map."

Also tests whether the AllMaps overlay is produced, and clicks the zoom-in button on that map UI until it has fully zoomed it. We can tell if we are fully zoomed in because the "active" zoom-in toggle no longer accepts clicks and is greyed out.  We test the zoom-out button by simply clicking it once while fully zoomed in to verify that the "zoom-in" button again becomes active.


## Open questions

<!-- Any questions you want to ask the reviewer? -->

The biggest hurdle was getting this to run headless, since it's testing WEBGL-type actions for the AllMaps plugin.   Consulted Gemini re. chromedriver workarounds for Mac M-chips that would allow the visible interactions to load and be stable in a headless browser session.   The tests can now be run on either CI or an Apple Silicon environment via a platform-aware set of flags that were added to the playwright.config file called `HEADLESS_OPTIMIZATION_FLAGS`.  Currently, only this one SPEC is calling that import.  

The main purpose of most of the flags was to disable background resource throttling and additionally force the hardware layer to behave sanely, especially on Mac M-chips.   Google and Apple M-chips don't seem to get along when it comes to chromedriver:  what a surprise!

## How has this been tested? How should a reviewer test this?

locally run `npx playwright test --workers=2`

<!--- Please describe in detail how you tested your changes. -->

Ran test suite locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4107]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ