### PR TITLE
DR-4168 - remove extra browsers from CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm install
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium --with-deps
 
       - name: Run build
         run: npm run build

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,6 +34,7 @@ jobs:
         run: npm run build
 
       - name: Run Playwright tests
+        # Explicitly enforce Chromium
         run: npm run playwright -- --project=chromium
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Run Playwright tests
-        run: npm run playwright
+        run: npm run playwright -- --project=chromium
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && failure() }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,9 @@ import path from "path";
  * See https://playwright.dev/docs/test-configuration.
  */
 
+const runSpecificProject = process.argv.some(
+  (arg) => arg.includes("--project") || arg === "-p"
+);
 const headlessOptimization = process.env.OPT === "true";
 
 export const HEADLESS_OPTIMIZATION_FLAGS =
@@ -68,44 +71,51 @@ export default defineConfig({
   },
 
   /* Configure projects for major browsers */
-  projects: [
-    {
-      name: "chromium",
-      use: {
-        ...devices["Desktop Chrome"],
-      },
-    },
+  projects:
+    process.env.CI || !runSpecificProject
+      ? [
+          {
+            name: "chromium",
+            use: {
+              ...devices["Desktop Chrome"],
+            },
+          },
+        ]
+      : [
+          {
+            name: "chromium",
+            use: { ...devices["Desktop Firefox"] },
+          },
+          {
+            name: "firefox",
+            use: { ...devices["Desktop Firefox"] },
+          },
 
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
+          {
+            name: "webkit",
+            use: { ...devices["Desktop Safari"] },
+          },
 
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
+          /* Test against mobile viewports. */
+          // {
+          //   name: 'Mobile Chrome',
+          //   use: { ...devices['Pixel 5'] },
+          // },
+          // {
+          //   name: 'Mobile Safari',
+          //   use: { ...devices['iPhone 12'] },
+          // },
 
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
-  ],
+          /* Test against branded browsers. */
+          // {
+          //   name: 'Microsoft Edge',
+          //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+          // },
+          // {
+          //   name: 'Google Chrome',
+          //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+          // },
+        ],
 
   /* Run your local dev server before starting the tests */
   webServer: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -76,15 +76,15 @@ export default defineConfig({
       },
     },
 
-    // {
-    //   name: "firefox",
-    //   use: { ...devices["Desktop Firefox"] },
-    // },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
 
-    // {
-    //   name: "webkit",
-    //   use: { ...devices["Desktop Safari"] },
-    // },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
 
     /* Test against mobile viewports. */
     // {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-4168](https://newyorkpubliclibrary.atlassian.net/browse/DR-4168)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

We download and install 3 different browsers every time the test suite runs on CI.  The current suite only uses Chromium.   Removing the other 2 (safari and firefox) could easily save a minute or more off of our test runs.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

I also added a var to the playwright.config file that assigns `chromium` to the "project" if no browser arg appears in a `--project=<browser>` flag.  This way, on localhost one can run the suite against a default chromium without having to declare a specific browser.  But they can also choose firefox, safari, or even all of them by just adding the appropriate "project" flags (e.g. `--project=webkit`, etc.).

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4168]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ