### PR TITLE
Use consistent spelling of subcollection to prevent analytics field from accidentally getting not set

### DIFF
--- a/app/src/context/AnalyticsDataProvider.tsx
+++ b/app/src/context/AnalyticsDataProvider.tsx
@@ -5,7 +5,7 @@ import React, { createContext, useContext, useCallback } from "react";
 interface AnalyticsDataContextType {
   division?: string;
   collection?: string;
-  subCollection?: string;
+  subcollection?: string;
 }
 
 const AnalyticsDataContext = createContext<

--- a/app/src/utils/ga4Utils.ts
+++ b/app/src/utils/ga4Utils.ts
@@ -3,7 +3,7 @@ const GA_NOT_SET = "Not set";
 interface GA4BaseData {
   division?: string;
   collection?: string;
-  subCollection?: string;
+  subcollection?: string;
 }
 
 interface PageViewData extends GA4BaseData {
@@ -14,7 +14,7 @@ interface PageViewData extends GA4BaseData {
 export const trackGa4PageView = ({
   division = GA_NOT_SET,
   collection = GA_NOT_SET,
-  subCollection = GA_NOT_SET,
+  subcollection = GA_NOT_SET,
   contentType = GA_NOT_SET,
   resourceType = GA_NOT_SET,
 }: PageViewData) => {
@@ -23,7 +23,7 @@ export const trackGa4PageView = ({
     event: "page_view",
     division_center: division,
     collection: collection,
-    subcollection: subCollection,
+    subcollection: subcollection,
     dc_content_type: contentType,
     dc_resource_type: resourceType,
   });
@@ -39,7 +39,7 @@ export const sendDownloadEvent = ({
   extension = GA_NOT_SET,
   division = GA_NOT_SET,
   collection = GA_NOT_SET,
-  subCollection = GA_NOT_SET,
+  subcollection = GA_NOT_SET,
 }: DownloadData) => {
   const dataLayer = window["dataLayer"] || [];
   dataLayer.push({
@@ -48,7 +48,7 @@ export const sendDownloadEvent = ({
     file_extension: extension,
     division_center: division,
     collection: collection,
-    subcollection: subCollection,
+    subcollection: subcollection,
   });
 };
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-4161](https://newyorkpubliclibrary.atlassian.net/browse/DR-4161)

## This PR does the following:

- Fix spelling discrepancy between `subcollection` and `subCollection`, which was causing our page view analytics to mistakenly get set to `NOT_SET`

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Made the change on my local and inspected the `dataLayer`

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4161]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ