### PR TITLE
Add results_count field to view_search_results GA event

### DIFF
--- a/app/src/components/pages/collectionPage/collectionPage.tsx
+++ b/app/src/components/pages/collectionPage/collectionPage.tsx
@@ -123,7 +123,7 @@ const CollectionPage = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchResults]);
 
-  useSearchAnalytics(collectionSearchManager);
+  useSearchAnalytics(collectionSearchManager, searchResults.numResults);
 
   return (
     <Box id="collectionsPageContent">

--- a/app/src/components/pages/collectionsPage/collectionsPage.tsx
+++ b/app/src/components/pages/collectionsPage/collectionsPage.tsx
@@ -93,7 +93,7 @@ export function CollectionsPage({ data, collectionsSearchParams }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collections]);
 
-  useSearchAnalytics(collectionsSearchManager);
+  useSearchAnalytics(collectionsSearchManager, data.numResults);
 
   return (
     <>

--- a/app/src/components/pages/searchPage/searchPage.tsx
+++ b/app/src/components/pages/searchPage/searchPage.tsx
@@ -92,7 +92,7 @@ const SearchPage = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchResults, searchManager.viewMode]);
 
-  useSearchAnalytics(searchManager);
+  useSearchAnalytics(searchManager, searchResults.numResults);
   useSubcollectionRedirect();
 
   return (

--- a/app/src/hooks/useSearchAnalytics.ts
+++ b/app/src/hooks/useSearchAnalytics.ts
@@ -2,7 +2,10 @@ import { useEffect } from "react";
 import { SearchManager } from "../utils/searchManager/searchManager";
 import { trackSearchResults } from "../utils/ga4Utils";
 
-const useSearchAnalytics = (searchManager: SearchManager) => {
+const useSearchAnalytics = (
+  searchManager: SearchManager,
+  numResults?: number
+) => {
   const filters = searchManager.filters;
   const filterNames = filters.map((f) => f.filter) ?? undefined;
   const keywords = searchManager.keywords ?? undefined;
@@ -14,6 +17,7 @@ const useSearchAnalytics = (searchManager: SearchManager) => {
     filterNames: filterNames,
     searchType: searchType,
     keywords: keywords,
+    numResults: numResults,
   });
 
   useEffect(() => {
@@ -21,7 +25,8 @@ const useSearchAnalytics = (searchManager: SearchManager) => {
       searchManager.viewMode,
       filterNames,
       searchType,
-      keywords
+      keywords,
+      numResults
     );
   }, [changeHash]);
 };

--- a/app/src/utils/ga4Utils.ts
+++ b/app/src/utils/ga4Utils.ts
@@ -88,7 +88,8 @@ export const trackSearchResults = (
   searchResultsLayout: "grid" | "list",
   filterNames: string[],
   searchType?: string,
-  searchTerm?: string
+  searchTerm?: string,
+  numResults?: number
 ) => {
   const dataLayer = window["dataLayer"] || [];
   const layout = upperGridViewLayoutParam(searchResultsLayout);
@@ -102,6 +103,9 @@ export const trackSearchResults = (
   }
   if (filterNames.length > 0) {
     data["filter_name"] = filterNames.join("|");
+  }
+  if (numResults !== undefined) {
+    data["results_count"] = numResults;
   }
   dataLayer.push(data);
 };

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -8,7 +8,7 @@ export default class ItemMapOverlayPage {
   readonly mapCanvas: Locator;
   readonly zoomInButton: Locator;
   readonly zoomOutButton: Locator;
-  static readonly MAP1_UUID = "417fe160-c603-012f-4183-58d385a7bc34";
+  static readonly MAP1_UUID = "0c564b50-c5ab-012f-6cbb-58d385a7bc34";
 
   static itemMapUrl: string = "/items/" + this.MAP1_UUID;
 

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -88,8 +88,8 @@ export default class ItemMapOverlayPage {
         },
         {
           message: "zoom-in button never reached max zoom (aria-disabled=true)",
-          timeout: 20_000,
-          intervals: [500, 1000, 1500], // backoff between polls
+          timeout: 30_000,
+          intervals: [500],
         }
       )
       .toBe(true);

--- a/playwright/pages/item-map-overlay.page.ts
+++ b/playwright/pages/item-map-overlay.page.ts
@@ -8,7 +8,7 @@ export default class ItemMapOverlayPage {
   readonly mapCanvas: Locator;
   readonly zoomInButton: Locator;
   readonly zoomOutButton: Locator;
-  static readonly MAP1_UUID = "0c564b50-c5ab-012f-6cbb-58d385a7bc34";
+  static readonly MAP1_UUID = "330ad600-c5f8-012f-e5e0-58d385a7bc34";
 
   static itemMapUrl: string = "/items/" + this.MAP1_UUID;
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-4071](https://newyorkpubliclibrary.atlassian.net/browse/DR-4071)

## This PR does the following:

- Start passing in `results_count` argument to `view_search_results` GA event from main search, collection search, and collections search

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

Inspected data layer on my local instance

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4071]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ