### PR TITLE
Add cta_click to Nav bar links

### DIFF
--- a/app/src/components/logo/logo.tsx
+++ b/app/src/components/logo/logo.tsx
@@ -1,5 +1,6 @@
 import { Logo, Link } from "@nypl/design-system-react-components";
 import React from "react";
+import { trackCTA } from "@/src/utils/ga4Utils";
 
 interface DCLogoProps {
   isMobile?: boolean;
@@ -11,6 +12,7 @@ const DCLogo = ({ isMobile = false }: DCLogoProps) => {
       isUnderlined={false}
       aria-label={"Digital Collections Homepage"}
       href={`/`}
+      onClick={() => trackCTA("Logo", "/", "Digital Collections - Logo")}
       sx={{ fontSize: "0px" }}
     >
       {isMobile ? (

--- a/app/src/components/navMenu/navMenu.tsx
+++ b/app/src/components/navMenu/navMenu.tsx
@@ -1,6 +1,7 @@
 import { dcNavLinks } from "../../data/dcNavLinks";
 import { Link, List } from "@nypl/design-system-react-components";
 import React from "react";
+import { trackCTA } from "@/src/utils/ga4Utils";
 
 interface NavMenuProps {
   render: number;
@@ -13,6 +14,11 @@ const NavMenu = ({ render }: NavMenuProps) => {
       href={href}
       aria-label={text}
       key={text}
+      onClick={
+        href !== "/shuffle" // exclude shuffle page from tracking because it is tracked in the shufflePage component
+          ? () => trackCTA(text, href, "Digital Collections - " + text)
+          : undefined
+      }
       sx={{
         marginBottom: "0px",
         fontWeight: "medium",

--- a/app/src/components/publicDomainFilter/publicDomainFilter.tsx
+++ b/app/src/components/publicDomainFilter/publicDomainFilter.tsx
@@ -6,15 +6,28 @@ import {
   Text,
 } from "@nypl/design-system-react-components";
 import { PublicDomainFilterProps } from "../../types/props/PublicDomainFilterProps";
+import { trackCTA } from "@/src/utils/ga4Utils";
 
 const PublicDomainFilter = ({ onCheckChange }: PublicDomainFilterProps) => {
   const [isChecked, setIsChecked] = useState(false);
   const checkboxRef = useRef<HTMLInputElement>(null);
 
+  const publicDomainCTALink = "/about#public_domain";
+
   const text = (
     <>
       Search only public domain.{" "}
-      <Link hasVisitedState={false} href="/about#public_domain">
+      <Link
+        hasVisitedState={false}
+        href={publicDomainCTALink}
+        onClick={() =>
+          trackCTA(
+            "What is public domain?",
+            publicDomainCTALink,
+            "Digital Collections - What is public domain?"
+          )
+        }
+      >
         What is public domain?
       </Link>
     </>


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-4086](https://newyorkpubliclibrary.atlassian.net/browse/DR-4086)

## This PR does the following:

- Add `cta_click` GA event tracking to clicks on the Logo, Nav bar buttons (`Divisions`, `Collections`, and `About`), and `What is public domain?` buttons.

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4086]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ