### PR TITLE
Add dependency to useEffect to eliminate duplicate GA events, change field derivation logic

### DIFF
--- a/app/items/[uuid]/page.tsx
+++ b/app/items/[uuid]/page.tsx
@@ -112,8 +112,8 @@ export default async function ItemViewer({ params, searchParams }: ItemProps) {
       activePage="item"
       breadcrumbs={breadcrumbData}
       ga4Data={{
-        division: breadcrumbData[1]?.text,
-        collection: breadcrumbData[2]?.text,
+        division: item.breadcrumbData?.division?.text,
+        collection: item.breadcrumbData?.collection?.text,
         subcollection: item.subcollectionName ?? undefined,
         contentType: item.contentType,
         resourceType: extractAllAnchorsFromHTML(item.typeOfResource)

--- a/app/src/components/pageLayout/pageLayout.tsx
+++ b/app/src/components/pageLayout/pageLayout.tsx
@@ -43,7 +43,7 @@ const PageLayout = ({
     if (ga4Data) {
       trackGa4PageView(ga4Data);
     }
-  });
+  }, [ga4Data]);
 
   const { responsivePadding } = useResponsiveSpacing();
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-4096](https://newyorkpubliclibrary.atlassian.net/browse/DR-4096)

## This PR does the following:

- Change field derivation logic to eliminate possibility that we're sending collection data in the division field
- Added useEffect dependency to eliminate duplicate GA events

## Open questions

I wasn't directly able to reproduce the issue described in the ticket. But it technically possible that if the item metadata doesn't have locations, then setting the GA field based on the indexed breadcrumbs can give an offset error. Which is why I think it's best to use the underlying breadcrumb data, not the formatted data. @avertrees let me know if that's ok, since this would be reversing this change you made a year ago https://github.com/NYPL/digital-collections/commit/75133c8497608b747c54c24b889aaad190cd8860#diff-175214ef204206efad8ca2de3a1c72d5686e11f269839037c4772d726e8d546dL89-R91

## How has this been tested? How should a reviewer test this?

Tested locally. Apparently we're firing duplicate page view events on pages where users can change search params:

https://github.com/user-attachments/assets/a648a257-44e3-4721-99dd-0b7935c78465

This issue should go away now.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4096]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ