### PR TITLE
DR-4168 - Fix typo where Firefox is on Chromium's browser assignment

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -84,7 +84,7 @@ export default defineConfig({
       : [
           {
             name: "chromium",
-            use: { ...devices["Desktop Firefox"] },
+            use: { ...devices["Desktop Chrome"] },
           },
           {
             name: "firefox",


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-4168](https://newyorkpubliclibrary.atlassian.net/browse/DR-4168)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

This PR fixes a silent configuration typo affecting Chromium emulation.

Changes:

Firefox Profile Typo

Corrected a configuration error where the chromium single project block was accidentally assigned the Desktop Firefox device emulation profile. It now will correctly load Desktop Chrome on localhost if selected (by default it was already correctly loading chromium on localhost but if separate, per-browser project tags were used it might have failed due to that typo).

## Open questions

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

ran `npx playwright test --workers=2` on localhost

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4168]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ