### PR TITLE
DR-4168 - Get all browsers to run on local host again

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,9 +12,6 @@ import path from "path";
  * See https://playwright.dev/docs/test-configuration.
  */
 
-const runSpecificProject = process.argv.some(
-  (arg) => arg.includes("--project") || arg === "-p"
-);
 const headlessOptimization = process.env.OPT === "true";
 
 export const HEADLESS_OPTIMIZATION_FLAGS =
@@ -71,51 +68,57 @@ export default defineConfig({
   },
 
   /* Configure projects for major browsers */
-  projects:
-    process.env.CI || !runSpecificProject
-      ? [
-          {
-            name: "chromium",
-            use: {
-              ...devices["Desktop Chrome"],
-            },
+  projects: process.env.CI
+    ? [
+        // --- CI WORKFLOW: ONLY RUN CHROMIUM BY DEFAULT ---
+        {
+          name: "chromium",
+          use: {
+            ...devices["Desktop Chrome"],
           },
-        ]
-      : [
-          {
-            name: "chromium",
-            use: { ...devices["Desktop Firefox"] },
+        },
+      ]
+    : [
+        // --- LOCAL DEV WORKFLOW: ALLOW ALL BROWSERS ---
+        {
+          name: "chromium",
+          use: {
+            ...devices["Desktop Chrome"],
           },
-          {
-            name: "firefox",
-            use: { ...devices["Desktop Firefox"] },
+        },
+        {
+          name: "firefox",
+          use: {
+            ...devices["Desktop Firefox"],
           },
+        },
+        {
+          name: "webkit",
+          use: {
+            ...devices["Desktop Safari"],
+          },
+        },
 
-          {
-            name: "webkit",
-            use: { ...devices["Desktop Safari"] },
-          },
+        /* Test against mobile viewports. */
+        // {
+        //   name: 'Mobile Chrome',
+        //   use: { ...devices['Pixel 5'] },
+        // },
+        // {
+        //   name: 'Mobile Safari',
+        //   use: { ...devices['iPhone 12'] },
+        // },
 
-          /* Test against mobile viewports. */
-          // {
-          //   name: 'Mobile Chrome',
-          //   use: { ...devices['Pixel 5'] },
-          // },
-          // {
-          //   name: 'Mobile Safari',
-          //   use: { ...devices['iPhone 12'] },
-          // },
-
-          /* Test against branded browsers. */
-          // {
-          //   name: 'Microsoft Edge',
-          //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-          // },
-          // {
-          //   name: 'Google Chrome',
-          //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-          // },
-        ],
+        /* Test against branded browsers. */
+        // {
+        //   name: 'Microsoft Edge',
+        //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+        // },
+        // {
+        //   name: 'Google Chrome',
+        //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+        // },
+      ],
 
   /* Run your local dev server before starting the tests */
   webServer: {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-4169](https://newyorkpubliclibrary.atlassian.net/browse/DR-4168)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

Removes a customization called "runSpecificProject,"  whose implementation has outlived its usefulness.  The original intent was to allow devs to type a simple "npx playwright test" and have it magically just run on chrome.  

But to support multi-browsers  simultaneously running on localhost, we need plain-vanilla "--project" defaults back.

I've removed the variable assignment, and the projects array now just filters on whether we are on CI (run only chromium, please), or on localhost (do whatever you want, but you must type in at least one browser `--project=<browser>` flag).  

If you do run it without typing in a `--project` flag, playwright will use its own default, which is to run ALL the browsers uncommented in your `projects[]` array.  So remember to include at least one, if you don't want to spawn a 300 test run across 3 browsers on localhost!


## Open questions
If you really, really want to run your own playwright suite against a "default" browser with the shortest possible command?  Answer: write an alias for it, or you could also experiment with your local .env.local setup to achieve some version of this.

<!-- Any questions you want to ask the reviewer? -->

## How has this been tested? How should a reviewer test this?

<!--- Please describe in detail how you tested your changes. -->

Ran `npx playwright test --project=chromium`

Also ran  `npx playwright test --project=webkit --project=firefox`

And various combinations of one, two or three browsers.

NOTE: `npx playwright test` on localhost will now default to the native playwright implementation, which is to run against all listed browsers in the playwright.config.ts file's `projects[]` array. 


## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-4169]: https://newyorkpubliclibrary.atlassian.net/browse/DR-4169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ