### PR TITLE
DR-3758/enable dev sheet

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,9 @@ jobs:
       COLLECTIONS_API_URL: ${{ secrets.QA_COLLECTIONS_API_URL }}
       COLLECTIONS_API_AUTH_TOKEN: ${{ secrets.QA_COLLECTIONS_API_AUTH_TOKEN }}
       NEW_RELIC_ENABLED: false
+      SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
+      GOOGLE_SHEETS_CLIENT_EMAIL: ${{ secrets.GOOGLE_SHEETS_CLIENT_EMAIL }}
+      GOOGLE_SHEETS_PRIVATE_KEY: ${{ secrets.GOOGLE_SHEETS_PRIVATE_KEY }}
 
     steps:
       - uses: actions/checkout@v6

--- a/playwright/pages/feedback-form.page.ts
+++ b/playwright/pages/feedback-form.page.ts
@@ -1,5 +1,9 @@
 import { expect, Locator, Page } from "@playwright/test";
 import { DCHomepage } from "./homepage.page";
+import {
+  SheetsTeardownUtil,
+  SheetRowData,
+} from "../utils/feedbackSetupTeardown";
 
 export default class FeedbackModal extends DCHomepage {
   readonly feedbackPage: Page;
@@ -61,5 +65,41 @@ export default class FeedbackModal extends DCHomepage {
 
     await this.feedbackSubmitButton.click();
     await expect(this.successBanner).toBeVisible();
+  }
+  //Poll Google sheet for a newly created row and verifies 7 columns.
+  async verifySheetRowData(
+    sheetsUtil: SheetsTeardownUtil,
+    commentSignature: string,
+    expectedType: "comment" | "bug" | "correction",
+    expectedPageUrl: string
+  ): Promise<void> {
+    let rowData: SheetRowData | null = null;
+
+    // 1. Poll until Google Sheets receives the row
+    await expect
+      .poll(
+        async () => {
+          rowData = await sheetsUtil.getRowBySignature(commentSignature);
+          return rowData;
+        },
+        {
+          message: `Timed out waiting for feedback row signature: "${commentSignature}"`,
+          timeout: 15000,
+          intervals: [1000, 2000],
+        }
+      )
+      .not.toBeNull();
+
+    // Explicitly tell Typescript that expect.poll ensured rowData is populated
+    const row = rowData!; // Or: rowData as SheetRowData
+
+    expect(row.type).toBe(expectedType);
+    expect(row.feedback).toBe(commentSignature);
+    expect(row.timestamp).toBeTruthy();
+    expect(row.page).toContain(expectedPageUrl);
+    expect(row.ip).toBeTruthy();
+    // expect(row.platform).toBeTruthy();
+    expect(row.browser).toBeTruthy();
+    expect(row.version).toBeTruthy();
   }
 }

--- a/playwright/pages/feedback-form.page.ts
+++ b/playwright/pages/feedback-form.page.ts
@@ -91,14 +91,13 @@ export default class FeedbackModal extends DCHomepage {
       .not.toBeNull();
 
     // Explicitly tell Typescript that expect.poll ensured rowData is populated
-    const row = rowData!; // Or: rowData as SheetRowData
+    const row = rowData!;
 
     expect(row.type).toBe(expectedType);
     expect(row.feedback).toBe(commentSignature);
     expect(row.timestamp).toBeTruthy();
     expect(row.page).toContain(expectedPageUrl);
     expect(row.ip).toBeTruthy();
-    // expect(row.platform).toBeTruthy();
     expect(row.browser).toBeTruthy();
     expect(row.version).toBeTruthy();
   }

--- a/playwright/tests/feedback-form.spec.ts
+++ b/playwright/tests/feedback-form.spec.ts
@@ -41,6 +41,8 @@ test.describe("Feedback UX & Integration Tests", () => {
   });
 
   test.describe("Verify Feedback data", () => {
+    // Run sequentially to preserve sheet state
+    test.describe.configure({ mode: "serial" });
     let sheetsUtil: SheetsTeardownUtil;
     let liveTestComment: string;
     const createdSignatures: string[] = [];

--- a/playwright/tests/feedback-form.spec.ts
+++ b/playwright/tests/feedback-form.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from "../base";
 import { AboutPage } from "../pages/about.page";
 import FeedbackModal from "../pages/feedback-form.page";
+import { SheetsTeardownUtil } from "../utils/feedbackSetupTeardown";
 
-test.describe("Verify Feedback Controls", () => {
+test.describe("Feedback UX & Integration Tests", () => {
   let feedbackModal: FeedbackModal;
 
   test.beforeEach(async ({ page }) => {
@@ -12,28 +13,97 @@ test.describe("Verify Feedback Controls", () => {
     await feedbackModal.open();
   });
 
-  test("should dynamically update the character counter", async () => {
-    await feedbackModal.verifyCharacterCounterUpdates();
-  });
+  test.describe("Verify UX Feedback Controls", () => {
+    test("should dynamically update the character counter", async () => {
+      await feedbackModal.verifyCharacterCounterUpdates();
+    });
 
-  test("should successfully submit a bug report", async () => {
-    await feedbackModal.setupNetworkMock();
-    await feedbackModal.verifySuccessfulSubmission(
-      feedbackModal.feedbackBugRadioButton
-    );
-  });
+    test("should successfully submit a bug report", async () => {
+      await feedbackModal.setupNetworkMock();
+      await feedbackModal.verifySuccessfulSubmission(
+        feedbackModal.feedbackBugRadioButton
+      );
+    });
 
-  test("should successfully submit a comment", async () => {
-    await feedbackModal.setupNetworkMock();
-    await feedbackModal.verifySuccessfulSubmission(
-      feedbackModal.feedbackCommentRadioButton
-    );
-  });
+    test("should successfully submit a comment", async () => {
+      await feedbackModal.setupNetworkMock();
+      await feedbackModal.verifySuccessfulSubmission(
+        feedbackModal.feedbackCommentRadioButton
+      );
+    });
 
-  test("should successfully submit a correction", async () => {
-    await feedbackModal.setupNetworkMock();
-    await feedbackModal.verifySuccessfulSubmission(
-      feedbackModal.feedbackCorrectionRadioButton
-    );
+    test("should successfully submit a correction", async () => {
+      await feedbackModal.setupNetworkMock();
+      await feedbackModal.verifySuccessfulSubmission(
+        feedbackModal.feedbackCorrectionRadioButton
+      );
+    });
+  });
+  test.describe.skip("Verify Feedback data", () => {
+    let sheetsUtil: SheetsTeardownUtil;
+    let liveTestComment: string;
+    const createdSignatures: string[] = [];
+
+    test.beforeAll(async () => {
+      sheetsUtil = new SheetsTeardownUtil();
+      // Guardrail check executes once before running live integration tests on sheet
+      await sheetsUtil.assertIsDevSpreadsheet();
+    });
+
+    test.afterAll(async () => {
+      // Clean up any rows generated across integration test runs
+      if (createdSignatures.length > 0) {
+        await sheetsUtil.deleteTestRows(createdSignatures);
+      }
+    });
+
+    test.beforeEach(async () => {
+      const timestamp = new Date().toISOString();
+      liveTestComment = `TEST - QA Integration Test - ${timestamp}`;
+      createdSignatures.push(liveTestComment);
+    });
+
+    // Integration tests run against DEV sheet
+    test("should successfully submit a comment", async () => {
+      await feedbackModal.verifySuccessfulSubmission(
+        feedbackModal.feedbackCommentRadioButton,
+        liveTestComment
+      );
+
+      await feedbackModal.verifySheetRowData(
+        sheetsUtil,
+        liveTestComment,
+        "comment",
+        AboutPage.aboutUrl
+      );
+    });
+
+    test("should successfully submit a bug report", async () => {
+      await feedbackModal.verifySuccessfulSubmission(
+        feedbackModal.feedbackBugRadioButton,
+        liveTestComment
+      );
+
+      await feedbackModal.verifySheetRowData(
+        sheetsUtil,
+        liveTestComment,
+        "bug",
+        AboutPage.aboutUrl
+      );
+    });
+
+    test("should successfully submit a correction", async () => {
+      await feedbackModal.verifySuccessfulSubmission(
+        feedbackModal.feedbackCorrectionRadioButton,
+        liveTestComment
+      );
+
+      await feedbackModal.verifySheetRowData(
+        sheetsUtil,
+        liveTestComment,
+        "correction",
+        AboutPage.aboutUrl
+      );
+    });
   });
 });

--- a/playwright/tests/feedback-form.spec.ts
+++ b/playwright/tests/feedback-form.spec.ts
@@ -39,7 +39,8 @@ test.describe("Feedback UX & Integration Tests", () => {
       );
     });
   });
-  test.describe.skip("Verify Feedback data", () => {
+
+  test.describe("Verify Feedback data", () => {
     let sheetsUtil: SheetsTeardownUtil;
     let liveTestComment: string;
     const createdSignatures: string[] = [];
@@ -55,6 +56,7 @@ test.describe("Feedback UX & Integration Tests", () => {
       if (createdSignatures.length > 0) {
         await sheetsUtil.deleteTestRows(createdSignatures);
       }
+      await sheetsUtil.logFinalRowCount();
     });
 
     test.beforeEach(async () => {

--- a/playwright/utils/feedbackSetupTeardown.ts
+++ b/playwright/utils/feedbackSetupTeardown.ts
@@ -110,7 +110,7 @@ export class SheetsTeardownUtil {
       return null;
     }
 
-    const [type, feedback, timestamp, page, ip, platform, browser, version] =
+    const [type, feedback, timestamp, page, ip, _platform, browser, version] =
       matchedRow;
 
     return {

--- a/playwright/utils/feedbackSetupTeardown.ts
+++ b/playwright/utils/feedbackSetupTeardown.ts
@@ -15,17 +15,16 @@ const MAX_ALLOWED_DEV_ROWS = 50;
 
 export class SheetsTeardownUtil {
   private spreadsheetId: string;
+  private sheets: ReturnType<typeof google.sheets>;
 
   constructor() {
-    this.spreadsheetId = process.env.SPREADSHEET_ID || "";
+    this.spreadsheetId = process.env.SPREADSHEET_ID!;
     if (!this.spreadsheetId) {
       throw new Error(
         "SAFETY ERROR: SPREADSHEET_ID environment variable is missing."
       );
     }
-  }
 
-  private getSheetsClient() {
     const auth = new google.auth.GoogleAuth({
       credentials: {
         client_email: process.env.GOOGLE_SHEETS_CLIENT_EMAIL,
@@ -37,13 +36,11 @@ export class SheetsTeardownUtil {
       scopes: ["https://www.googleapis.com/auth/spreadsheets"],
     });
 
-    return google.sheets({ version: "v4", auth });
+    this.sheets = google.sheets({ version: "v4", auth });
   }
 
   private async getActiveSheetData(rangeColumn: string = "A:Z") {
-    const sheets = this.getSheetsClient();
-
-    const meta = await sheets.spreadsheets.get({
+    const meta = await this.sheets.spreadsheets.get({
       spreadsheetId: this.spreadsheetId,
     });
 
@@ -54,7 +51,7 @@ export class SheetsTeardownUtil {
       throw new Error("ERROR: Could not find any tabs in this spreadsheet.");
     }
 
-    const data = await sheets.spreadsheets.values.get({
+    const data = await this.sheets.spreadsheets.values.get({
       spreadsheetId: this.spreadsheetId,
       range: `'${activeSheet.title}'!${rangeColumn}`,
     });
@@ -170,9 +167,7 @@ export class SheetsTeardownUtil {
 
     console.log(`\nExecuting batch deletion request (bottom-to-top)...`);
 
-    const sheets = this.getSheetsClient();
-
-    await sheets.spreadsheets.batchUpdate({
+    await this.sheets.spreadsheets.batchUpdate({
       spreadsheetId: this.spreadsheetId,
       requestBody: {
         requests: rowIndices.map((idx) => ({

--- a/playwright/utils/feedbackSetupTeardown.ts
+++ b/playwright/utils/feedbackSetupTeardown.ts
@@ -1,0 +1,195 @@
+import { google } from "googleapis";
+
+export interface SheetRowData {
+  type: string;
+  feedback: string;
+  timestamp: string;
+  page: string;
+  ip: string;
+  browser: string;
+  version: string;
+}
+
+const EXPECTED_DEV_TITLE = "AUTOMATED-DEV-FEEDBACK-SHEET-DONT-TOUCH";
+const MAX_ALLOWED_DEV_ROWS = 50;
+
+export class SheetsTeardownUtil {
+  private spreadsheetId: string;
+
+  constructor() {
+    this.spreadsheetId = process.env.SPREADSHEET_ID || "";
+    if (!this.spreadsheetId) {
+      throw new Error(
+        "SAFETY ERROR: SPREADSHEET_ID environment variable is missing."
+      );
+    }
+  }
+
+  private getSheetsClient() {
+    const auth = new google.auth.GoogleAuth({
+      credentials: {
+        client_email: process.env.GOOGLE_SHEETS_CLIENT_EMAIL,
+        private_key: process.env.GOOGLE_SHEETS_PRIVATE_KEY?.replace(
+          /\\n/g,
+          "\n"
+        ),
+      },
+      scopes: ["https://www.googleapis.com/auth/spreadsheets"],
+    });
+
+    return google.sheets({ version: "v4", auth });
+  }
+
+  private async getActiveSheetData(rangeColumn: string = "A:Z") {
+    const sheets = this.getSheetsClient();
+
+    const meta = await sheets.spreadsheets.get({
+      spreadsheetId: this.spreadsheetId,
+    });
+
+    const fileTitle = meta.data.properties?.title || "Unknown File Name";
+    const activeSheet = meta.data.sheets?.[0]?.properties;
+
+    if (!activeSheet?.title) {
+      throw new Error("ERROR: Could not find any tabs in this spreadsheet.");
+    }
+
+    const data = await sheets.spreadsheets.values.get({
+      spreadsheetId: this.spreadsheetId,
+      range: `'${activeSheet.title}'!${rangeColumn}`,
+    });
+
+    return {
+      fileTitle,
+      tabName: activeSheet.title,
+      numericSheetId: activeSheet.sheetId ?? 0,
+      rows: data.data.values || [],
+    };
+  }
+
+  public async assertIsDevSpreadsheet(): Promise<void> {
+    const { fileTitle, tabName, rows } = await this.getActiveSheetData("A:A");
+    console.log(`[GUARDRAIL] Confirmed DEV sheet ("${fileTitle}")`);
+    console.log(
+      `[Spreadsheet ID] ${
+        this.spreadsheetId
+          ? `${this.spreadsheetId.slice(0, 4)}*****${this.spreadsheetId.slice(
+              -4
+            )}`
+          : "N/A"
+      }`
+    );
+    console.log(
+      `[Current Rows] ${rows.length} / ${MAX_ALLOWED_DEV_ROWS} max rows allowed`
+    );
+
+    if (fileTitle !== EXPECTED_DEV_TITLE) {
+      throw new Error(
+        `GUARDRAIL FAILURE: Sheet title is "${fileTitle}", expected "${EXPECTED_DEV_TITLE}". Aborting!`
+      );
+    }
+
+    if (rows.length > MAX_ALLOWED_DEV_ROWS) {
+      throw new Error(
+        `GUARDRAIL FAILURE: Sheet has ${rows.length} rows (Limit: ${MAX_ALLOWED_DEV_ROWS}). Aborting!`
+      );
+    }
+  }
+
+  // Fetch and map 7 target columns for a row matching the signature.
+  public async getRowBySignature(
+    commentSignature: string
+  ): Promise<SheetRowData | null> {
+    const { rows } = await this.getActiveSheetData("A:H");
+
+    const matchedRow = rows.find((row) =>
+      String(row[1] || "").includes(commentSignature)
+    );
+
+    if (!matchedRow) {
+      return null;
+    }
+
+    const [type, feedback, timestamp, page, ip, platform, browser, version] =
+      matchedRow;
+
+    return {
+      type,
+      feedback,
+      timestamp,
+      page,
+      ip,
+      browser,
+      version,
+    };
+  }
+
+  public async deleteTestRows(commentSignatures: string[]): Promise<void> {
+    if (!commentSignatures.length) {
+      console.log("WARNING: Teardown skipped - No search signatures provided.");
+      return;
+    }
+
+    const { tabName, numericSheetId, rows } =
+      await this.getActiveSheetData("A:Z");
+
+    console.log(`Scanned ${rows.length} total rows in "${tabName}"...`);
+
+    const matchedRowsInfo: { index: number; text: string }[] = [];
+
+    rows.forEach((row, idx) => {
+      const feedbackText = String(row[1] || "");
+      const isMatch = commentSignatures.some((sig) =>
+        feedbackText.includes(sig)
+      );
+
+      if (isMatch) {
+        matchedRowsInfo.push({ index: idx, text: feedbackText });
+      }
+    });
+
+    if (matchedRowsInfo.length === 0) {
+      console.log(`[INFO] No matching rows found for deletion.`);
+      return;
+    }
+
+    console.log(
+      `\n[FOUND] ${matchedRowsInfo.length} MATCHING ROW(S) TO DELETE:`
+    );
+    matchedRowsInfo.forEach((item) => {
+      console.log(
+        `  - Sheet Row ${item.index + 1} (Zero-index ${item.index}): "${
+          item.text
+        }"`
+      );
+    });
+
+    const rowIndices = matchedRowsInfo
+      .map((m) => m.index)
+      .sort((a, b) => b - a);
+
+    console.log(`\nExecuting batch deletion request (bottom-to-top)...`);
+
+    const sheets = this.getSheetsClient();
+
+    await sheets.spreadsheets.batchUpdate({
+      spreadsheetId: this.spreadsheetId,
+      requestBody: {
+        requests: rowIndices.map((idx) => ({
+          deleteDimension: {
+            range: {
+              sheetId: numericSheetId,
+              dimension: "ROWS",
+              startIndex: idx,
+              endIndex: idx + 1,
+            },
+          },
+        })),
+      },
+    });
+
+    console.log(
+      `[TEARDOWN] Deleted ${rowIndices.length} row(s) from tab "${tabName}".`
+    );
+  }
+}

--- a/playwright/utils/feedbackSetupTeardown.ts
+++ b/playwright/utils/feedbackSetupTeardown.ts
@@ -66,7 +66,10 @@ export class SheetsTeardownUtil {
 
   public async assertIsDevSpreadsheet(): Promise<void> {
     const { fileTitle, tabName, rows } = await this.getActiveSheetData("A:A");
-    console.log(`[GUARDRAIL] Confirmed DEV sheet ("${fileTitle}")`);
+    const maskedTitle = fileTitle
+      ? `${fileTitle.slice(0, 4)}*****${fileTitle.slice(-4)}`
+      : "UNKNOWN";
+    console.log(`[GUARDRAIL] Sheet found is: ("${maskedTitle}")`);
     console.log(
       `[Spreadsheet ID] ${
         this.spreadsheetId
@@ -82,7 +85,7 @@ export class SheetsTeardownUtil {
 
     if (fileTitle !== EXPECTED_DEV_TITLE) {
       throw new Error(
-        `GUARDRAIL FAILURE: Sheet title is "${fileTitle}", expected "${EXPECTED_DEV_TITLE}". Aborting!`
+        `GUARDRAIL FAILURE: Sheet title is "${maskedTitle}", expected "${EXPECTED_DEV_TITLE}". Aborting!`
       );
     }
 
@@ -186,5 +189,10 @@ export class SheetsTeardownUtil {
     console.log(
       `[TEARDOWN] Deleted ${rowIndices.length} row(s) from tab "${tabName}".`
     );
+  }
+
+  public async logFinalRowCount(): Promise<void> {
+    const { rows } = await this.getActiveSheetData("A:A");
+    console.log(`[TEARDOWN] Final row count: ${rows.length}`);
   }
 }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [DR-3758](https://newyorkpubliclibrary.atlassian.net/browse/DR-3758)

## This PR does the following:

<!-- What has been updated or added in this PR? -->

This updates the work from previous DRAFT in closed [PR #597](https://github.com/NYPL/digital-collections/pull/597) 

If tests are run locally and you "unskip" the specific integration tests, while adding the correct sheet ID value to your own `.env.local` file, you can run the full set of tests against the DEV sheet.   You'll need to also have the correct google-account and key values in your env file.


## Open questions

If we add the google-account and key info to gha secrets, we can start running the tests unskipped on CI.  Since the Sheet ID (and name) are  different, this isolates the DEV sheet from the one used for PROD.  And the PROD values will still get propagated when the application is running on prod.

<!-- Any questions you want to ask the reviewer? -->


## How has this been tested? How should a reviewer test this?

`npm run build` 

followed by cmd below after the build is finished
`npx playwright test playwright/tests/feedback-form.spec.ts --project=chromium --workers=2`

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
- [ ] I have updated the CHANGELOG.md.


[DR-3758]: https://newyorkpubliclibrary.atlassian.net/browse/DR-3758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ